### PR TITLE
Add supply chain integrity measures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   SQLX_OFFLINE: "true"
@@ -31,6 +34,12 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny@0.19.0 --locked
+
+      - name: Check dependencies
+        run: cargo deny check
 
       - name: CRD drift check
         run: |
@@ -111,6 +120,7 @@ jobs:
         run: |
           [ -f /usr/local/bin/kind ] || {
             curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+            echo "b89aada5a39d620da3fcd16435b7f28d858927dd53f92cbac77686b0588b600d  /usr/local/bin/kind" | sha256sum -c -
             chmod +x /usr/local/bin/kind
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  attestations: write
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -59,6 +60,7 @@ jobs:
       - uses: docker/setup-buildx-action@v4
 
       - name: Build and push
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -68,6 +70,27 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
+
+      - name: Sign image with cosign
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true
 
   docker-cli:
     name: Docker — CLI
@@ -110,6 +133,7 @@ jobs:
       - uses: docker/setup-buildx-action@v4
 
       - name: Build and push
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -119,6 +143,27 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
+
+      - name: Sign image with cosign
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true
 
   # ---------------------------------------------------------------------------
   # Cross-compile CLI binaries for GitHub Releases
@@ -183,7 +228,7 @@ jobs:
 
       - name: Install cross (Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5 --locked
 
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-musl'

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,27 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "OpenSSL",
+    "Zlib",
+]
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Shared build base
 # ---------------------------------------------------------------------------
-FROM rust:1.89-alpine@sha256:4b800f2e72e04be908e5f634c504c741bd943b763d1d8ad7b096cc340e1b5b46 AS base
+FROM rust:1.94-alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS base
 
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static pkgconf
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- **Dependency auditing**: Added `cargo-deny` with `deny.toml` config — checks for known vulnerabilities (advisories), license compliance, and blocks unknown registries/git sources
- **Pinned Rust toolchain**: Added `rust-toolchain.toml` pinning to 1.94.0 for reproducible builds; bumped Docker build image to match (`rust:1.94-alpine`, digest-pinned)
- **Container image signing**: Both operator and CLI images are now signed with cosign (keyless via GitHub OIDC) on release
- **Build provenance**: Added `actions/attest@v4` to generate SLSA provenance attestations, pushed to the container registry
- **Pinned build tools**: `cross-rs` pinned to `v0.2.5 --locked`; `kind` binary download verified with SHA256 checksum
- **Least privilege CI**: Added `permissions: contents: read` to CI workflow

## Verification

After a release, consumers can verify images:

```bash
# Cosign signature
cosign verify \
  --certificate-identity-regexp="github.com/hardbyte/pgroles" \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
  ghcr.io/hardbyte/pgroles-operator:<tag>

# GitHub attestation
gh attestation verify oci://ghcr.io/hardbyte/pgroles-operator:<tag> --owner hardbyte
```

## Test plan

- [x] `cargo build --workspace` passes on Rust 1.94.0
- [x] `cargo clippy` clean
- [x] `cargo deny check` passes (advisories ok, bans ok, licenses ok, sources ok)
- [x] CI passes on this PR
- [ ] Cosign signing and attestation verified on next tag release