### PR TITLE
Rewrite README for clarity and first impressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Then `pgroles apply` to execute it.
 
 ```bash
 # Already have a database with roles? Generate a manifest from it:
-pgroles generate --database-url postgres://...
+pgroles generate --database-url postgres://... > pgroles.yaml
 
 # See what SQL pgroles would run:
 pgroles diff -f pgroles.yaml --database-url postgres://...


### PR DESCRIPTION
## Summary

- Lead with the YAML manifest and SQL diff output — the "aha moment" — instead of a wall of 10 commands
- Cut from 274 lines to 117 by moving reference material to the docs site
- Quick start reduced to 3 commands: `generate`, `diff`, `apply`
- Install section condensed to one line per method
- Features presented as scannable bullets

Content moved to docs (not deleted, just no longer in the README):
- Retirements and convergent model details
- Operational boundaries
- CI/CD integration examples
- Compatibility matrix
- Local testing instructions
- Component architecture

## Test plan

- [ ] Review rendered README on GitHub for readability
- [ ] Verify docs site links resolve correctly