### PR TITLE
test(operator): cover same-db churn recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,18 @@ jobs:
           wait_for_ready_true second-disjoint-policy
           kubectl exec postgres-0 -- psql -U postgres -tAc "SELECT rolname FROM pg_roles WHERE rolname = 'reporting'" | grep -qx "reporting"
 
+          kubectl create secret generic postgres-credentials \
+            --from-literal=DATABASE_URL='postgres://postgres:devpassword@postgres.default.svc.cluster.local:15432/postgres' \
+            --dry-run=client -o yaml | kubectl apply -f -
+          wait_for_ready_reason disjoint-policy DatabaseConnectionFailed
+          wait_for_ready_reason second-disjoint-policy DatabaseConnectionFailed
+
+          kubectl create secret generic postgres-credentials \
+            --from-literal=DATABASE_URL='postgres://postgres:devpassword@postgres.default.svc.cluster.local:5432/postgres' \
+            --dry-run=client -o yaml | kubectl apply -f -
+          wait_for_ready_true disjoint-policy
+          wait_for_ready_true second-disjoint-policy
+
           kubectl apply -f k8s/samples/conflicting-policy.yaml
           wait_for_ready_reason conflicting-policy ConflictingPolicy
 

--- a/docs/src/pages/docs/operator-architecture.md
+++ b/docs/src/pages/docs/operator-architecture.md
@@ -143,6 +143,7 @@ CI covers:
 
 - happy-path reconciliation in kind
 - same-database disjoint policies
+- same-database disjoint policies recovering through shared-secret churn
 - same-database conflicting policies
 - invalid specs
 - missing secrets

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -108,6 +108,7 @@ The operator is intended to become a production controller, but that still requi
 - CI covers:
   - multiple policies targeting the same database with conflicting ownership
   - multiple non-overlapping policies targeting the same database
+  - shared-secret churn across multiple policies targeting the same database
   - invalid specs
   - missing secrets
   - insufficient database privileges


### PR DESCRIPTION
## Summary
- add an E2E scenario that churns a shared database secret used by multiple policies on the same database
- verify both same-database disjoint policies settle to `DatabaseConnectionFailed` and then recover to `Ready=True`
- update operator docs to record this CI coverage

## Roadmap
- advances #7
- contributes to #11
