### PR TITLE
Add password management support to PostgreSQL role CRD

### DIFF
--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -475,6 +475,39 @@
                         "name": {
                           "type": "string"
                         },
+                        "password": {
+                          "description": "Password source for this role. References a Kubernetes Secret key.",
+                          "nullable": true,
+                          "properties": {
+                            "secretKey": {
+                              "description": "Key within the Secret. Defaults to the role name.",
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "Reference to the Kubernetes Secret containing the password.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the Secret.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object"
+                        },
+                        "password_valid_until": {
+                          "description": "Password expiration timestamp (ISO 8601, e.g. \"2025-12-31T00:00:00Z\").",
+                          "nullable": true,
+                          "type": "string"
+                        },
                         "replication": {
                           "nullable": true,
                           "type": "boolean"
@@ -568,6 +601,10 @@
                         "format": "int32",
                         "type": "integer"
                       },
+                      "passwords_set": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
                       "roles_altered": {
                         "format": "int32",
                         "type": "integer"
@@ -596,6 +633,7 @@
                       "grants_revoked",
                       "members_added",
                       "members_removed",
+                      "passwords_set",
                       "roles_altered",
                       "roles_created",
                       "roles_dropped",


### PR DESCRIPTION
## Summary
This PR extends the PostgreSQL role Custom Resource Definition (CRD) to support password management, including password source configuration and password expiration tracking.

## Key Changes
- **Password source configuration**: Added a new `password` field that allows specifying passwords via Kubernetes Secrets
  - `secretRef`: Reference to the Kubernetes Secret containing the password (required)
  - `secretKey`: Optional key within the Secret (defaults to the role name if not specified)
- **Password expiration**: Added `password_valid_until` field to set password expiration timestamps in ISO 8601 format
- **Status tracking**: Added `passwords_set` counter to the role status to track the number of passwords that have been set

## Implementation Details
- The `password` field is nullable and structured as an object with required `secretRef` property
- The `secretKey` is optional and provides flexibility in Secret key naming
- The `password_valid_until` field accepts ISO 8601 formatted strings (e.g., "2025-12-31T00:00:00Z")
- The `passwords_set` status field is an int32 counter, consistent with other status counters like `roles_created` and `grants_revoked`

https://claude.ai/code/session_01MB3uGcRWTpUP9HMJHYdShe