### PR TITLE
fix: enable TLS for PostgreSQL connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "hmac",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-inspect"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pgroles-core",
  "sqlx",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-operator"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2667,6 +2667,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2676,6 +2677,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3453,6 +3455,24 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1"
 tokio = { version = "1", features = ["full"] }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls"] }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Brian Thorne <brian@thorne.link>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ k8s-openapi = { version = "0.27", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Internal crates
-pgroles-core = { path = "crates/pgroles-core", version = "0.4.0" }
-pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.4.0" }
+pgroles-core = { path = "crates/pgroles-core", version = "0.4.1" }
+pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.4.1" }
 
 [profile.release]
 strip = "symbols"

--- a/charts/pgroles-operator/Chart.yaml
+++ b/charts/pgroles-operator/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Define roles, memberships, grants, and default privileges in YAML
   and let the operator converge your database to the desired state.
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"
 icon: https://raw.githubusercontent.com/hardbyte/pgroles/main/docs/public/logo.svg
 sources:
   - https://github.com/hardbyte/pgroles

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ allow = [
     "Unicode-DFS-2016",
     "OpenSSL",
     "Zlib",
+    "CDLA-Permissive-2.0",
 ]
 
 [licenses.private]


### PR DESCRIPTION
## Summary

- Add `tls-rustls` to the sqlx workspace dependency
- Bump version to 0.4.1 (app + chart)

Without TLS support, connections to PostgreSQL servers that require SSL (e.g. Cloud SQL, Zalando operator instances) fail with `pg_hba.conf rejects connection... no encryption`.

The Dockerfile already installs `openssl-dev` and `openssl-libs-static` — only the Cargo feature was missing.

## Test plan

- Built and tested locally against a Zalando Postgres Operator instance via Tailscale with `sslmode=require`
- `cargo clippy` and `cargo test` pass