### PR TITLE
feat: add printer columns to PostgresPolicy CRD

### DIFF
--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -25,6 +25,26 @@
             "type": "string"
           },
           {
+            "jsonPath": ".spec.mode",
+            "name": "Mode",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".status.conditions[?(@.type==\"Drifted\")].status",
+            "name": "Drift",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".status.change_summary.total",
+            "name": "Changes",
+            "type": "integer"
+          },
+          {
+            "jsonPath": ".status.last_reconcile_time",
+            "name": "Last Reconcile",
+            "type": "date"
+          },
+          {
             "jsonPath": ".metadata.creationTimestamp",
             "name": "Age",
             "type": "date"

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -40,7 +40,7 @@
             "type": "integer"
           },
           {
-            "jsonPath": ".status.last_reconcile_time",
+            "jsonPath": ".status.last_successful_reconcile_time",
             "name": "Last Reconcile",
             "type": "date"
           },

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -30,6 +30,12 @@
             "type": "string"
           },
           {
+            "jsonPath": ".spec.reconciliation_mode",
+            "name": "Recon",
+            "priority": 1,
+            "type": "string"
+          },
+          {
             "jsonPath": ".status.conditions[?(@.type==\"Drifted\")].status",
             "name": "Drift",
             "type": "string"

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -33,7 +33,7 @@ use pgroles_core::manifest::{
     printcolumn = r#"{"name":"Mode","type":"string","jsonPath":".spec.mode"}"#,
     printcolumn = r#"{"name":"Drift","type":"string","jsonPath":".status.conditions[?(@.type==\"Drifted\")].status"}"#,
     printcolumn = r#"{"name":"Changes","type":"integer","jsonPath":".status.change_summary.total"}"#,
-    printcolumn = r#"{"name":"Last Reconcile","type":"date","jsonPath":".status.last_reconcile_time"}"#,
+    printcolumn = r#"{"name":"Last Reconcile","type":"date","jsonPath":".status.last_successful_reconcile_time"}"#,
     printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
 )]
 pub struct PostgresPolicySpec {

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -31,6 +31,7 @@ use pgroles_core::manifest::{
     shortname = "pgr",
     printcolumn = r#"{"name":"Ready","type":"string","jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
     printcolumn = r#"{"name":"Mode","type":"string","jsonPath":".spec.mode"}"#,
+    printcolumn = r#"{"name":"Recon","type":"string","jsonPath":".spec.reconciliation_mode","priority":1}"#,
     printcolumn = r#"{"name":"Drift","type":"string","jsonPath":".status.conditions[?(@.type==\"Drifted\")].status"}"#,
     printcolumn = r#"{"name":"Changes","type":"integer","jsonPath":".status.change_summary.total"}"#,
     printcolumn = r#"{"name":"Last Reconcile","type":"date","jsonPath":".status.last_successful_reconcile_time"}"#,

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -30,6 +30,10 @@ use pgroles_core::manifest::{
     status = "PostgresPolicyStatus",
     shortname = "pgr",
     printcolumn = r#"{"name":"Ready","type":"string","jsonPath":".status.conditions[?(@.type==\"Ready\")].status"}"#,
+    printcolumn = r#"{"name":"Mode","type":"string","jsonPath":".spec.mode"}"#,
+    printcolumn = r#"{"name":"Drift","type":"string","jsonPath":".status.conditions[?(@.type==\"Drifted\")].status"}"#,
+    printcolumn = r#"{"name":"Changes","type":"integer","jsonPath":".status.change_summary.total"}"#,
+    printcolumn = r#"{"name":"Last Reconcile","type":"date","jsonPath":".status.last_reconcile_time"}"#,
     printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
 )]
 pub struct PostgresPolicySpec {

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -30,6 +30,12 @@
             "type": "string"
           },
           {
+            "jsonPath": ".spec.reconciliation_mode",
+            "name": "Recon",
+            "priority": 1,
+            "type": "string"
+          },
+          {
             "jsonPath": ".status.conditions[?(@.type==\"Drifted\")].status",
             "name": "Drift",
             "type": "string"

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -25,6 +25,26 @@
             "type": "string"
           },
           {
+            "jsonPath": ".spec.mode",
+            "name": "Mode",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".status.conditions[?(@.type==\"Drifted\")].status",
+            "name": "Drift",
+            "type": "string"
+          },
+          {
+            "jsonPath": ".status.change_summary.total",
+            "name": "Changes",
+            "type": "integer"
+          },
+          {
+            "jsonPath": ".status.last_successful_reconcile_time",
+            "name": "Last Reconcile",
+            "type": "date"
+          },
+          {
             "jsonPath": ".metadata.creationTimestamp",
             "name": "Age",
             "type": "date"


### PR DESCRIPTION
Adds `additionalPrinterColumns` so `kubectl get postgrespolicies` shows useful status at a glance:

```
NAME             READY   MODE   DRIFT   CHANGES   LAST RECONCILE   AGE
staging-policy   True    plan   True    13178     10m              3d
```

New columns: **Mode** (plan/apply), **Drift** (True/False), **Changes** (total planned), **Last Reconcile** (timestamp).

Previously only showed Name, Ready, and Age.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five new columns to policy list/table views: Mode, Recon (priority 1), Drift, Changes, and Last Reconcile — making mode, reconciliation mode, drift status, total changes, and last successful reconcile time visible in list views (including kubectl table output) for faster at-a-glance monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->