### PR TITLE
fix: CLI accepts Kubernetes CR manifest files

### DIFF
--- a/crates/pgroles-cli/src/lib.rs
+++ b/crates/pgroles-cli/src/lib.rs
@@ -42,6 +42,17 @@ pub fn parse_and_expand(yaml: &str) -> Result<ExpandedManifest> {
 /// Returns the expanded manifest and the desired RoleGraph.
 pub fn validate_manifest(yaml: &str) -> Result<ValidatedManifest> {
     let policy_manifest = parse(yaml)?;
+
+    if policy_manifest.roles.is_empty()
+        && policy_manifest.schemas.is_empty()
+        && policy_manifest.grants.is_empty()
+        && policy_manifest.memberships.is_empty()
+    {
+        tracing::warn!(
+            "manifest defines no roles, schemas, grants, or memberships — is the file correct?"
+        );
+    }
+
     let expanded =
         manifest::expand_manifest(&policy_manifest).map_err(|err| anyhow::anyhow!("{err}"))?;
 

--- a/crates/pgroles-cli/src/lib.rs
+++ b/crates/pgroles-cli/src/lib.rs
@@ -294,12 +294,19 @@ pub fn format_validation_result(validated: &ValidatedManifest) -> String {
 pub fn format_role_graph_summary(graph: &RoleGraph) -> String {
     let mut output = String::new();
     output.push_str(&format!("Roles: {}\n", graph.roles.len()));
+    for (name, state) in &graph.roles {
+        let login_marker = if state.login { "LOGIN" } else { "NOLOGIN" };
+        output.push_str(&format!("  {name} ({login_marker})\n"));
+    }
     output.push_str(&format!("Grants: {}\n", graph.grants.len()));
     output.push_str(&format!(
         "Default privileges: {}\n",
         graph.default_privileges.len()
     ));
     output.push_str(&format!("Memberships: {}\n", graph.memberships.len()));
+    for edge in &graph.memberships {
+        output.push_str(&format!("  {} -> {}\n", edge.member, edge.role));
+    }
     output
 }
 
@@ -609,6 +616,7 @@ schemas:
         let validated = validate_manifest(MINIMAL_MANIFEST).unwrap();
         let summary = format_role_graph_summary(&validated.desired);
         assert!(summary.contains("Roles: 1"), "got: {summary}");
+        assert!(summary.contains("analytics (LOGIN)"), "got: {summary}");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -521,6 +521,7 @@ async fn cmd_inspect(file: Option<&Path>, database_url: &str) -> Result<()> {
     };
 
     print!("{}", format_role_graph_summary(&current));
+    eprintln!("Note: grants to PUBLIC are not shown. Effective privileges may differ from what is displayed here (see https://github.com/hardbyte/pgroles/issues/57).");
 
     Ok(())
 }

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -98,11 +98,13 @@ enum Commands {
         mode: CliReconciliationMode,
     },
 
-    /// Inspect the current database state for managed roles and privileges.
+    /// Inspect the current database state for roles and privileges.
     Inspect {
-        /// Path to the policy manifest YAML file (used to scope inspection).
-        #[arg(short, long, default_value = "pgroles.yaml")]
-        file: PathBuf,
+        /// Path to policy manifest YAML. When provided, scopes output to roles
+        /// and schemas declared in the manifest. When omitted, shows all
+        /// database roles and privileges.
+        #[arg(short, long)]
+        file: Option<PathBuf>,
 
         /// PostgreSQL connection string (or set DATABASE_URL).
         #[arg(long, env = "DATABASE_URL")]
@@ -275,7 +277,7 @@ async fn run(cli: Cli) -> Result<ExitCode> {
             Ok(ExitCode::SUCCESS)
         }
         Commands::Inspect { file, database_url } => {
-            cmd_inspect(&file, &database_url).await?;
+            cmd_inspect(file.as_deref(), &database_url).await?;
             Ok(ExitCode::SUCCESS)
         }
         Commands::Generate {
@@ -496,12 +498,27 @@ async fn cmd_apply(
     Ok(())
 }
 
-async fn cmd_inspect(file: &Path, database_url: &str) -> Result<()> {
-    let yaml = read_manifest_file(file)?;
-    let validated = validate_manifest(&yaml)?;
-
+async fn cmd_inspect(file: Option<&Path>, database_url: &str) -> Result<()> {
     let pool = connect_db(database_url).await?;
-    let current = inspect_current(&pool, &validated).await?;
+
+    let current = match file {
+        Some(path) => {
+            let yaml = read_manifest_file(path)?;
+            let validated = validate_manifest(&yaml)?;
+            inspect_current(&pool, &validated).await?
+        }
+        None => {
+            info!("no manifest provided, inspecting all non-system roles");
+            pgroles_inspect::inspect_all(
+                &pool,
+                &pgroles_inspect::InspectAllConfig {
+                    exclude_system_roles: true,
+                },
+            )
+            .await
+            .context("failed to introspect database")?
+        }
+    };
 
     print!("{}", format_role_graph_summary(&current));
 

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -526,7 +526,15 @@ async fn cmd_inspect(file: Option<&Path>, database_url: &str) -> Result<()> {
     };
 
     print!("{}", format_role_graph_summary(&current));
-    eprintln!("Note: grants to PUBLIC are not shown. Effective privileges may differ from what is displayed here (see https://github.com/hardbyte/pgroles/issues/57).");
+
+    // Query and display PUBLIC grants (informational only).
+    let public_grants = pgroles_inspect::fetch_public_grants(&pool)
+        .await
+        .context("failed to query PUBLIC grants")?;
+    let public_output = pgroles_inspect::format_public_grants(&public_grants);
+    if !public_output.is_empty() {
+        print!("{public_output}");
+    }
 
     Ok(())
 }

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -102,7 +102,7 @@ enum Commands {
     Inspect {
         /// Path to policy manifest YAML. When provided, scopes output to roles
         /// and schemas declared in the manifest. When omitted, shows all
-        /// database roles and privileges.
+        /// non-system database roles and privileges.
         #[arg(short, long)]
         file: Option<PathBuf>,
 
@@ -499,14 +499,19 @@ async fn cmd_apply(
 }
 
 async fn cmd_inspect(file: Option<&Path>, database_url: &str) -> Result<()> {
-    let pool = connect_db(database_url).await?;
-
-    let current = match file {
+    // Validate manifest before connecting so YAML errors fail fast.
+    let validated = match file {
         Some(path) => {
             let yaml = read_manifest_file(path)?;
-            let validated = validate_manifest(&yaml)?;
-            inspect_current(&pool, &validated).await?
+            Some(validate_manifest(&yaml)?)
         }
+        None => None,
+    };
+
+    let pool = connect_db(database_url).await?;
+
+    let current = match validated {
+        Some(ref v) => inspect_current(&pool, v).await?,
         None => {
             info!("no manifest provided, inspecting all non-system roles");
             pgroles_inspect::inspect_all(

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -912,7 +912,8 @@ mod live_db {
             .assert()
             .success()
             .stdout(predicate::str::contains("Roles:"))
-            .stdout(predicate::str::contains("Grants:"));
+            .stdout(predicate::str::contains("Grants:"))
+            .stdout(predicate::str::contains("PUBLIC grants"));
     }
 
     #[test]
@@ -2016,6 +2017,43 @@ grants:
             DROP ROLE IF EXISTS "{extra_role}";
             "#
         ));
+    }
+
+    /// Inspect without a manifest shows PUBLIC grants for the current database.
+    /// A fresh database should have at least CONNECT and TEMPORARY granted to
+    /// PUBLIC, and USAGE on the "public" schema.
+    #[test]
+    #[ignore]
+    fn inspect_shows_public_grants() {
+        pgroles_cmd()
+            .args(["inspect", "--database-url", &database_url()])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("PUBLIC grants"))
+            .stdout(predicate::str::contains("Database:"))
+            .stdout(predicate::str::contains("CONNECT"))
+            .stdout(predicate::str::contains("TEMPORARY"))
+            .stdout(predicate::str::contains("Schema \"public\""));
+    }
+
+    /// Inspect with a manifest also shows PUBLIC grants.
+    #[test]
+    #[ignore]
+    fn inspect_with_manifest_shows_public_grants() {
+        let manifest_file = write_temp_manifest(VALID_MINIMAL);
+
+        pgroles_cmd()
+            .args([
+                "inspect",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("PUBLIC grants"))
+            .stdout(predicate::str::contains("CONNECT"));
     }
 
     /// Authoritative mode (default): drops extra roles that aren't in the manifest.

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -425,8 +425,25 @@ pub struct ExpandedManifest {
 // ---------------------------------------------------------------------------
 
 /// Parse a YAML string into a `PolicyManifest`.
+///
+/// Accepts both bare manifests and Kubernetes CustomResource wrappers.
+/// If the YAML contains an `apiVersion` and `spec` field, the `spec` is
+/// extracted and parsed as a `PolicyManifest`.
 pub fn parse_manifest(yaml: &str) -> Result<PolicyManifest, ManifestError> {
-    let manifest: PolicyManifest = serde_yaml::from_str(yaml)?;
+    // Check if this looks like a Kubernetes CR wrapper.
+    let value: serde_yaml::Value = serde_yaml::from_str(yaml)?;
+    if let serde_yaml::Value::Mapping(ref map) = value {
+        let api_version_key = serde_yaml::Value::String("apiVersion".into());
+        let spec_key = serde_yaml::Value::String("spec".into());
+        if map.contains_key(&api_version_key) && map.contains_key(&spec_key) {
+            let spec = map.get(&spec_key).ok_or_else(|| {
+                ManifestError::Yaml(serde::de::Error::custom("missing spec in CR"))
+            })?;
+            let manifest: PolicyManifest = serde_yaml::from_value(spec.clone())?;
+            return Ok(manifest);
+        }
+    }
+    let manifest: PolicyManifest = serde_yaml::from_value(value)?;
     Ok(manifest)
 }
 
@@ -1314,5 +1331,96 @@ roles:
         assert!(!is_valid_iso8601_timestamp("2025-12-31T25:00:00Z")); // hour 25
         assert!(!is_valid_iso8601_timestamp("2025-12-31T00:00:00")); // no timezone
         assert!(!is_valid_iso8601_timestamp("")); // empty
+    }
+
+    #[test]
+    fn parse_manifest_from_kubernetes_cr() {
+        let yaml = r#"
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: staging-policy
+  namespace: pgroles-system
+spec:
+  connection:
+    secretRef:
+      name: pgroles-db-credentials
+  interval: "5m"
+  mode: plan
+  roles:
+    - name: app_analytics
+      login: true
+    - name: app_billing
+      login: true
+  schemas:
+    - name: analytics
+      profiles: [editor, viewer]
+  profiles:
+    editor:
+      grants:
+        - object: { type: schema }
+          privileges: [USAGE]
+        - object: { type: table, name: "*" }
+          privileges: [SELECT, INSERT, UPDATE, DELETE]
+    viewer:
+      grants:
+        - object: { type: schema }
+          privileges: [USAGE]
+        - object: { type: table, name: "*" }
+          privileges: [SELECT]
+  memberships:
+    - role: analytics-editor
+      members:
+        - { name: app_analytics }
+    - role: analytics-viewer
+      members:
+        - { name: app_billing }
+"#;
+        let manifest = parse_manifest(yaml).unwrap();
+        assert_eq!(manifest.roles.len(), 2);
+        assert_eq!(manifest.roles[0].name, "app_analytics");
+        assert_eq!(manifest.schemas.len(), 1);
+        assert_eq!(manifest.memberships.len(), 2);
+        assert_eq!(manifest.profiles.len(), 2);
+    }
+
+    #[test]
+    fn parse_manifest_bare_and_cr_produce_same_result() {
+        let bare = r#"
+roles:
+  - name: test_role
+    login: true
+schemas:
+  - name: public
+    profiles: [viewer]
+profiles:
+  viewer:
+    grants:
+      - object: { type: schema }
+        privileges: [USAGE]
+"#;
+        let cr = r#"
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: test
+spec:
+  roles:
+    - name: test_role
+      login: true
+  schemas:
+    - name: public
+      profiles: [viewer]
+  profiles:
+    viewer:
+      grants:
+        - object: { type: schema }
+          privileges: [USAGE]
+"#;
+        let from_bare = parse_manifest(bare).unwrap();
+        let from_cr = parse_manifest(cr).unwrap();
+        assert_eq!(from_bare.roles.len(), from_cr.roles.len());
+        assert_eq!(from_bare.schemas.len(), from_cr.schemas.len());
+        assert_eq!(from_bare.profiles.len(), from_cr.profiles.len());
     }
 }

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cloud;
 mod defaults;
 mod memberships;
 mod privileges;
+mod public_grants;
 mod roles;
 mod safety;
 mod version;
@@ -25,6 +26,7 @@ pub use cloud::{CloudProvider, PrivilegeLevel, detect_privilege_level};
 pub use defaults::fetch_default_privileges;
 pub use memberships::fetch_memberships;
 pub use privileges::{fetch_database_privileges, fetch_privileges, fetch_relation_inventory};
+pub use public_grants::{PublicGrants, fetch_public_grants, format_public_grants};
 pub use roles::fetch_roles;
 pub use safety::{
     DropRoleSafetyAssessment, DropRoleSafetyIssue, DropRoleSafetyReport, inspect_drop_role_safety,

--- a/crates/pgroles-inspect/src/public_grants.rs
+++ b/crates/pgroles-inspect/src/public_grants.rs
@@ -1,0 +1,229 @@
+//! Query grants to the PUBLIC pseudo-role from PostgreSQL catalog tables.
+//!
+//! PostgreSQL grants certain default privileges to PUBLIC (e.g. CONNECT and
+//! TEMPORARY on databases, USAGE on the public schema). These grants are
+//! represented by NULL grantee entries in ACL arrays.
+//!
+//! This module provides read-only introspection of PUBLIC grants for
+//! informational display. pgroles does not manage PUBLIC grants — they are
+//! shown so users can understand the full effective privilege picture.
+
+use std::collections::BTreeSet;
+
+use sqlx::PgPool;
+
+use pgroles_core::manifest::Privilege;
+
+// ---------------------------------------------------------------------------
+// Public API types
+// ---------------------------------------------------------------------------
+
+/// Grants held by the PUBLIC pseudo-role on the current database.
+#[derive(Debug, Clone, Default)]
+pub struct PublicGrants {
+    /// Privileges granted to PUBLIC on the current database (e.g. CONNECT, TEMPORARY).
+    pub database_privileges: BTreeSet<Privilege>,
+    /// The name of the current database (for display purposes).
+    pub database_name: String,
+    /// Schema-level grants to PUBLIC: each entry is (schema_name, privileges).
+    pub schema_grants: Vec<(String, BTreeSet<Privilege>)>,
+}
+
+impl PublicGrants {
+    /// Returns true if there are no PUBLIC grants to display.
+    pub fn is_empty(&self) -> bool {
+        self.database_privileges.is_empty() && self.schema_grants.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Raw query row
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, sqlx::FromRow)]
+struct PublicAclRow {
+    privilege_type: String,
+    object_name: String,
+    obj_kind: String,
+}
+
+/// Map a PostgreSQL ACL privilege character to our `Privilege` enum.
+fn acl_char_to_privilege(character: &str) -> Option<Privilege> {
+    match character {
+        "r" | "SELECT" => Some(Privilege::Select),
+        "a" | "INSERT" => Some(Privilege::Insert),
+        "w" | "UPDATE" => Some(Privilege::Update),
+        "d" | "DELETE" => Some(Privilege::Delete),
+        "D" | "TRUNCATE" => Some(Privilege::Truncate),
+        "x" | "REFERENCES" => Some(Privilege::References),
+        "t" | "TRIGGER" => Some(Privilege::Trigger),
+        "X" | "EXECUTE" => Some(Privilege::Execute),
+        "U" | "USAGE" => Some(Privilege::Usage),
+        "C" | "CREATE" => Some(Privilege::Create),
+        "c" | "CONNECT" => Some(Privilege::Connect),
+        "T" | "TEMPORARY" => Some(Privilege::Temporary),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query functions
+// ---------------------------------------------------------------------------
+
+/// Fetch grants to PUBLIC on the current database and its schemas.
+///
+/// Queries:
+/// - `pg_database` ACLs for database-level grants (CONNECT, TEMPORARY, CREATE)
+/// - `pg_namespace` ACLs for schema-level grants (USAGE, CREATE)
+///
+/// Only returns grants where the grantee is NULL (i.e. PUBLIC).
+pub async fn fetch_public_grants(pool: &PgPool) -> Result<PublicGrants, sqlx::Error> {
+    let rows = sqlx::query_as::<_, PublicAclRow>(
+        r#"
+        -- Database-level PUBLIC grants
+        SELECT
+            acl.privilege_type,
+            db.datname AS object_name,
+            'database' AS obj_kind
+        FROM pg_database db
+        CROSS JOIN LATERAL aclexplode(
+            COALESCE(
+                db.datacl,
+                acldefault('d'::"char", db.datdba)
+            )
+        ) AS acl
+        WHERE db.datname = current_database()
+          AND acl.grantee = 0
+
+        UNION ALL
+
+        -- Schema-level PUBLIC grants
+        SELECT
+            acl.privilege_type,
+            n.nspname AS object_name,
+            'schema' AS obj_kind
+        FROM pg_namespace n
+        CROSS JOIN LATERAL aclexplode(
+            COALESCE(
+                n.nspacl,
+                acldefault('n'::"char", n.nspowner)
+            )
+        ) AS acl
+        WHERE n.nspname NOT LIKE 'pg_%'
+          AND n.nspname <> 'information_schema'
+          AND acl.grantee = 0
+        ORDER BY obj_kind, object_name
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut grants = PublicGrants::default();
+
+    for row in rows {
+        let Some(privilege) = acl_char_to_privilege(&row.privilege_type) else {
+            continue;
+        };
+
+        match row.obj_kind.as_str() {
+            "database" => {
+                grants.database_name = row.object_name.clone();
+                grants.database_privileges.insert(privilege);
+            }
+            "schema" => {
+                // Find or create the entry for this schema.
+                if let Some(entry) = grants
+                    .schema_grants
+                    .iter_mut()
+                    .find(|(name, _)| name == &row.object_name)
+                {
+                    entry.1.insert(privilege);
+                } else {
+                    let mut privs = BTreeSet::new();
+                    privs.insert(privilege);
+                    grants.schema_grants.push((row.object_name.clone(), privs));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(grants)
+}
+
+/// Format `PublicGrants` as a human-readable string for display.
+pub fn format_public_grants(grants: &PublicGrants) -> String {
+    if grants.is_empty() {
+        return String::new();
+    }
+
+    let mut output = String::new();
+    output.push_str("\nPUBLIC grants (informational, not managed by pgroles):\n");
+
+    if !grants.database_privileges.is_empty() {
+        let privs: Vec<String> = grants
+            .database_privileges
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        output.push_str(&format!("  Database: {}\n", privs.join(", ")));
+    }
+
+    for (schema_name, privileges) in &grants.schema_grants {
+        let privs: Vec<String> = privileges.iter().map(|p| p.to_string()).collect();
+        output.push_str(&format!(
+            "  Schema \"{schema_name}\": {}\n",
+            privs.join(", ")
+        ));
+    }
+
+    output
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_public_grants_formats_as_empty_string() {
+        let grants = PublicGrants::default();
+        assert!(grants.is_empty());
+        assert_eq!(format_public_grants(&grants), "");
+    }
+
+    #[test]
+    fn format_database_and_schema_grants() {
+        let grants = PublicGrants {
+            database_name: "mydb".to_string(),
+            database_privileges: [Privilege::Connect, Privilege::Temporary]
+                .into_iter()
+                .collect(),
+            schema_grants: vec![(
+                "public".to_string(),
+                [Privilege::Usage, Privilege::Create].into_iter().collect(),
+            )],
+        };
+        let output = format_public_grants(&grants);
+        assert!(output.contains("PUBLIC grants"));
+        assert!(output.contains("Database: "));
+        assert!(output.contains("CONNECT"));
+        assert!(output.contains("TEMPORARY"));
+        assert!(output.contains("Schema \"public\""));
+        assert!(output.contains("USAGE"));
+        assert!(output.contains("CREATE"));
+    }
+
+    #[test]
+    fn is_empty_with_only_database_grants() {
+        let grants = PublicGrants {
+            database_name: "mydb".to_string(),
+            database_privileges: [Privilege::Connect].into_iter().collect(),
+            schema_grants: vec![],
+        };
+        assert!(!grants.is_empty());
+    }
+}


### PR DESCRIPTION
Fixes a silent parsing bug where passing a `PostgresPolicy` CR YAML to the CLI produced an empty manifest (0 roles, 0 grants) with no error or warning.

`parse_manifest` now detects Kubernetes CR wrappers (files with `apiVersion` + `spec`) and extracts the `spec` before parsing. This means CLI commands work with the same files used by the operator:

```bash
pgroles validate -f postgrespolicy.yaml
pgroles diff -f postgrespolicy.yaml --database-url ...
```

Also adds a warning when the parsed manifest is empty, catching cases where the wrong file is passed.

### Design notes

- The CRD spec is a superset of `PolicyManifest` — operator-specific fields (`connection`, `interval`, `mode`, `suspend`) are silently ignored by the CLI, which is the right behavior since those fields don't affect the role graph.
- `PolicyManifest` intentionally does not use `deny_unknown_fields` to allow this coupling.
- All fields remain optional with serde defaults — an empty manifest is valid but now triggers a warning.

### Tests

- CR manifest parsing produces expected roles/schemas/memberships
- Bare and CR manifests produce the same result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inspect command now works without requiring a manifest file; introspects all non-system roles by default
  * Added support for Kubernetes CustomResource manifest format alongside standard YAML
  * Display PUBLIC role grants for databases and schemas
  * Show LOGIN/NOLOGIN status indicators in role summaries

* **Improvements**
  * Added runtime warning when manifest is empty or contains no actionable content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->