### PR TITLE
feat: pre-flight validation for referenced schemas

### DIFF
--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -316,6 +316,29 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
     Ok(graph)
 }
 
+/// Fetch the names of all non-system schemas in the target database.
+///
+/// Used for pre-flight validation — the operator checks that every schema
+/// referenced by a policy exists before rendering GRANT statements that would
+/// otherwise fail mid-transaction with `schema "X" does not exist`.
+///
+/// Returns a [`BTreeSet`] for efficient membership lookup. Excludes
+/// `pg_catalog`, `pg_toast`, other `pg_*` schemas, and `information_schema`.
+pub async fn fetch_existing_schemas(
+    pool: &PgPool,
+) -> Result<std::collections::BTreeSet<String>, InspectError> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        r#"
+        SELECT nspname::text FROM pg_namespace
+        WHERE nspname NOT LIKE 'pg_%'
+          AND nspname <> 'information_schema'
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|r| r.0).collect())
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -123,6 +123,13 @@ pub enum ReconcileError {
     #[error("invalid spec: {0}")]
     InvalidSpec(String),
 
+    #[error(
+        "policy references objects that do not exist in target database: {0}. Either create \
+         the missing objects, remove them from the policy, or verify the policy is pointing at \
+         the intended database."
+    )]
+    MissingDatabaseObjects(String),
+
     #[error("{0}")]
     ConflictingPolicy(String),
 
@@ -339,6 +346,7 @@ fn retry_class_for_reconcile_error(error: &ReconcileError) -> RetryClass {
         ReconcileError::ManifestExpansion(_)
         | ReconcileError::InvalidInterval(_, _)
         | ReconcileError::InvalidSpec(_)
+        | ReconcileError::MissingDatabaseObjects(_)
         | ReconcileError::ConflictingPolicy(_)
         | ReconcileError::UnsafeRoleDrops(_)
         | ReconcileError::EmptyPasswordSecret { .. }
@@ -430,6 +438,59 @@ fn next_transient_failure_count(resource: &PostgresPolicy) -> u32 {
 fn slow_retry_delay(resource: &PostgresPolicy) -> Duration {
     parse_interval(&resource.spec.interval)
         .unwrap_or_else(|_| Duration::from_secs(DEFAULT_REQUEUE_SECS))
+}
+
+/// Collect every schema name referenced by an expanded manifest.
+///
+/// Covers schema-type grants (where the schema is in `object.name`), grants on
+/// objects within a schema (where the schema is in `object.schema`), and
+/// default privileges (which always carry a schema).
+fn referenced_schema_names(
+    expanded: &pgroles_core::manifest::ExpandedManifest,
+) -> std::collections::BTreeSet<String> {
+    let mut names = std::collections::BTreeSet::new();
+    for grant in &expanded.grants {
+        if grant.object.object_type == pgroles_core::manifest::ObjectType::Schema
+            && let Some(name) = &grant.object.name
+        {
+            names.insert(name.clone());
+        }
+        if let Some(schema) = &grant.object.schema {
+            names.insert(schema.clone());
+        }
+    }
+    for dp in &expanded.default_privileges {
+        names.insert(dp.schema.clone());
+    }
+    names
+}
+
+/// Pre-flight check: ensure every schema referenced by the policy exists in
+/// the target database. Returns [`ReconcileError::MissingDatabaseObjects`]
+/// listing the missing schemas if any are absent.
+async fn validate_referenced_schemas_exist(
+    pool: &sqlx::PgPool,
+    expanded: &pgroles_core::manifest::ExpandedManifest,
+) -> Result<(), ReconcileError> {
+    let referenced = referenced_schema_names(expanded);
+    if referenced.is_empty() {
+        return Ok(());
+    }
+    let existing = pgroles_inspect::fetch_existing_schemas(pool).await?;
+    let missing: Vec<String> = referenced
+        .into_iter()
+        .filter(|name| !existing.contains(name))
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        let formatted = missing
+            .iter()
+            .map(|name| format!("schema \"{name}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(ReconcileError::MissingDatabaseObjects(formatted))
+    }
 }
 
 /// Apply reconciliation — the main "ensure desired state" logic.
@@ -740,6 +801,12 @@ async fn apply_under_lock(
                     .map(|retirement| retirement.role.clone()),
             );
     let current = pgroles_inspect::inspect(pool, &inspect_config).await?;
+
+    // 6b. Pre-flight: validate that every schema referenced by the policy
+    // exists in the target database. This turns a mid-transaction
+    // `schema "X" does not exist` failure into a clear spec/environment
+    // mismatch error before we issue any DDL.
+    validate_referenced_schemas_exist(pool, expanded).await?;
 
     // 7. Compute diff, filter by reconciliation mode, then inject password
     // changes resolved from Kubernetes Secrets.
@@ -1976,6 +2043,7 @@ impl ReconcileError {
             },
             ReconcileError::UnsafeRoleDrops(_) => "UnsafeRoleDrops",
             ReconcileError::EmptyPasswordSecret { .. } => "InvalidSpec",
+            ReconcileError::MissingDatabaseObjects(_) => "MissingDatabaseObject",
             ReconcileError::PasswordGeneration(_) => "SecretFetchFailed",
             ReconcileError::Kube(_) => "KubernetesApiError",
             ReconcileError::NoNamespace => "InvalidResource",
@@ -2558,6 +2626,164 @@ mod tests {
     }
 
     #[test]
+    fn error_reason_missing_database_objects() {
+        let err = ReconcileError::MissingDatabaseObjects("schema \"etl\"".into());
+        assert_eq!(err.reason(), "MissingDatabaseObject");
+    }
+
+    #[test]
+    fn error_display_missing_database_objects_lists_schemas() {
+        let err = ReconcileError::MissingDatabaseObjects("schema \"etl\", schema \"jobs\"".into());
+        let msg = err.to_string();
+        assert!(msg.contains("schema \"etl\""));
+        assert!(msg.contains("schema \"jobs\""));
+        assert!(
+            msg.contains("pointing at the intended database"),
+            "message should include remediation hint"
+        );
+    }
+
+    #[test]
+    fn referenced_schema_names_from_schema_grants() {
+        use pgroles_core::manifest::{
+            ExpandedManifest, Grant, ObjectTarget, ObjectType, Privilege,
+        };
+        let expanded = ExpandedManifest {
+            roles: Vec::new(),
+            grants: vec![Grant {
+                role: "app".into(),
+                privileges: vec![Privilege::Usage],
+                object: ObjectTarget {
+                    object_type: ObjectType::Schema,
+                    schema: None,
+                    name: Some("etl".into()),
+                },
+            }],
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+        };
+        let names = referenced_schema_names(&expanded);
+        assert!(names.contains("etl"));
+    }
+
+    #[test]
+    fn referenced_schema_names_from_table_grants() {
+        use pgroles_core::manifest::{
+            ExpandedManifest, Grant, ObjectTarget, ObjectType, Privilege,
+        };
+        let expanded = ExpandedManifest {
+            roles: Vec::new(),
+            grants: vec![Grant {
+                role: "app".into(),
+                privileges: vec![Privilege::Select],
+                object: ObjectTarget {
+                    object_type: ObjectType::Table,
+                    schema: Some("analytics".into()),
+                    name: Some("*".into()),
+                },
+            }],
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+        };
+        let names = referenced_schema_names(&expanded);
+        assert!(names.contains("analytics"));
+    }
+
+    #[test]
+    fn referenced_schema_names_from_default_privileges() {
+        use pgroles_core::manifest::{
+            DefaultPrivilege, DefaultPrivilegeGrant, ExpandedManifest, ObjectType, Privilege,
+        };
+        let expanded = ExpandedManifest {
+            roles: Vec::new(),
+            grants: Vec::new(),
+            default_privileges: vec![DefaultPrivilege {
+                owner: Some("app_owner".into()),
+                schema: "reporting".into(),
+                grant: vec![DefaultPrivilegeGrant {
+                    role: Some("app".into()),
+                    privileges: vec![Privilege::Select],
+                    on_type: ObjectType::Table,
+                }],
+            }],
+            memberships: Vec::new(),
+        };
+        let names = referenced_schema_names(&expanded);
+        assert!(names.contains("reporting"));
+    }
+
+    #[test]
+    fn referenced_schema_names_deduplicates_across_sources() {
+        use pgroles_core::manifest::{
+            DefaultPrivilege, DefaultPrivilegeGrant, ExpandedManifest, Grant, ObjectTarget,
+            ObjectType, Privilege,
+        };
+        let expanded = ExpandedManifest {
+            roles: Vec::new(),
+            grants: vec![
+                Grant {
+                    role: "app".into(),
+                    privileges: vec![Privilege::Usage],
+                    object: ObjectTarget {
+                        object_type: ObjectType::Schema,
+                        schema: None,
+                        name: Some("shared".into()),
+                    },
+                },
+                Grant {
+                    role: "app".into(),
+                    privileges: vec![Privilege::Select],
+                    object: ObjectTarget {
+                        object_type: ObjectType::Table,
+                        schema: Some("shared".into()),
+                        name: Some("*".into()),
+                    },
+                },
+            ],
+            default_privileges: vec![DefaultPrivilege {
+                owner: Some("app_owner".into()),
+                schema: "shared".into(),
+                grant: vec![DefaultPrivilegeGrant {
+                    role: Some("app".into()),
+                    privileges: vec![Privilege::Select],
+                    on_type: ObjectType::Table,
+                }],
+            }],
+            memberships: Vec::new(),
+        };
+        let names = referenced_schema_names(&expanded);
+        // BTreeSet deduplicates so a schema referenced three ways appears once.
+        assert_eq!(names.len(), 1);
+        assert!(names.contains("shared"));
+    }
+
+    #[test]
+    fn referenced_schema_names_skips_database_and_roleless_grants() {
+        use pgroles_core::manifest::{
+            ExpandedManifest, Grant, ObjectTarget, ObjectType, Privilege,
+        };
+        let expanded = ExpandedManifest {
+            roles: Vec::new(),
+            grants: vec![Grant {
+                role: "app".into(),
+                privileges: vec![Privilege::Connect],
+                object: ObjectTarget {
+                    object_type: ObjectType::Database,
+                    schema: None,
+                    name: Some("mydb".into()),
+                },
+            }],
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+        };
+        let names = referenced_schema_names(&expanded);
+        assert!(
+            names.is_empty(),
+            "database-level grants should not contribute schema names"
+        );
+    }
+
+    #[test]
     fn error_reason_conflicting_policy() {
         let err = ReconcileError::ConflictingPolicy("overlaps with other".into());
         assert_eq!(err.reason(), "ConflictingPolicy");
@@ -2710,6 +2936,14 @@ mod tests {
         let error = finalizer::Error::ApplyFailed(ReconcileError::InvalidInterval(
             "oops".into(),
             "bad interval".into(),
+        ));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
+    }
+
+    #[test]
+    fn retry_classifies_missing_database_objects_as_slow() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::MissingDatabaseObjects(
+            "schema \"etl\"".into(),
         ));
         assert_eq!(retry_class(&error), RetryClass::Slow);
     }

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -468,11 +468,26 @@ fn referenced_schema_names(
 /// Pre-flight check: ensure every schema referenced by the policy exists in
 /// the target database. Returns [`ReconcileError::MissingDatabaseObjects`]
 /// listing the missing schemas if any are absent.
+/// Returns true for PostgreSQL system schemas that always exist but are
+/// excluded from [`pgroles_inspect::fetch_existing_schemas`].
+fn is_system_schema(name: &str) -> bool {
+    name.starts_with("pg_") || name == "information_schema"
+}
+
+/// Pre-flight check: ensure every schema referenced by the policy exists in
+/// the target database. Returns [`ReconcileError::MissingDatabaseObjects`]
+/// listing the missing schemas if any are absent.
+///
+/// System schemas (`pg_*`, `information_schema`) are excluded from the check
+/// since they always exist but are filtered out of the inspect query.
 async fn validate_referenced_schemas_exist(
     pool: &sqlx::PgPool,
     expanded: &pgroles_core::manifest::ExpandedManifest,
 ) -> Result<(), ReconcileError> {
-    let referenced = referenced_schema_names(expanded);
+    let referenced: std::collections::BTreeSet<String> = referenced_schema_names(expanded)
+        .into_iter()
+        .filter(|name| !is_system_schema(name))
+        .collect();
     if referenced.is_empty() {
         return Ok(());
     }
@@ -2781,6 +2796,17 @@ mod tests {
             names.is_empty(),
             "database-level grants should not contribute schema names"
         );
+    }
+
+    #[test]
+    fn is_system_schema_identifies_pg_and_information_schema() {
+        assert!(is_system_schema("pg_catalog"));
+        assert!(is_system_schema("pg_toast"));
+        assert!(is_system_schema("pg_temp_1"));
+        assert!(is_system_schema("information_schema"));
+        assert!(!is_system_schema("public"));
+        assert!(!is_system_schema("etl"));
+        assert!(!is_system_schema("analytics"));
     }
 
     #[test]

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -315,16 +315,14 @@ This is the expected state when the database credential is valid but under-privi
 
 ### Missing database object
 
-If the policy references a schema, table, function, or other database object that does not exist in the target database, the operator sets a non-ready state instead of hot-looping. This catches common misconfigurations like a policy declaring a schema that hasn't been created, or being pointed at the wrong database.
-
-Current behavior:
+Before issuing any DDL, the operator validates that every schema referenced by the policy exists in the target database. If one is missing, the apply is aborted up front and the policy settles into a non-ready state with a clear message.
 
 - `Ready=False`
 - reason `MissingDatabaseObject`
-- `last_error` contains the PostgreSQL error message, for example `schema "etl" does not exist`
+- `last_error` lists the missing objects, e.g. `policy references objects that do not exist in target database: schema "etl". Either create the missing objects, remove them from the policy, or verify the policy is pointing at the intended database.`
 - the policy retries on its normal reconcile interval rather than exponential transient backoff
 
-Covered PostgreSQL error codes: `3F000` (invalid_schema_name), `42P01` (undefined_table), `42883` (undefined_function), `42704` (undefined_object). Either create the missing object, remove the reference from the policy, or verify the policy is pointing at the intended database.
+This catches common misconfigurations like a policy that declares a schema which hasn't been created, or a policy pointed at the wrong database. As a fallback, the same reason is also produced when a SQL-level error with PostgreSQL codes `3F000` (invalid_schema_name), `42P01` (undefined_table), `42883` (undefined_function), or `42704` (undefined_object) slips past the pre-flight validator.
 
 ### Interval
 


### PR DESCRIPTION
## Summary

Closes #78.

When a `PostgresPolicy` references a schema that doesn't exist in the target database, the operator now fails fast with a clear structured error **before** issuing any DDL, instead of letting the SQL round-trip surface a cryptic \`SQL execution error: schema "etl" does not exist\`.

## What changed

- New `pgroles_inspect::fetch_existing_schemas()` queries non-system schemas from `pg_namespace`
- New `referenced_schema_names()` helper collects every schema referenced by schema-type grants, object grants with a schema prefix, and default privileges
- Pre-flight `validate_referenced_schemas_exist()` runs between inspect and diff, returning `ReconcileError::MissingDatabaseObjects` (mapped to `RetryClass::Slow` + `MissingDatabaseObject` reason) if any are missing
- Error message includes remediation guidance: create the object, remove from policy, or check the DB target
- Docs section covers the new failure mode and notes consistency with the SQL-level catch from #76

## Relationship to #79 (#76)

Orthogonal. #76 classifies the SQL-level error as non-transient once it happens. This PR catches the same condition earlier, before any DDL is issued, producing the same `MissingDatabaseObject` status reason. Either PR stands alone; together they give fast-path and fallback coverage.

## Test plan

- [x] Unit tests for `referenced_schema_names()` across schema grants, table grants, default privileges, deduplication, and database-level grants
- [x] Unit tests for retry class and reason mapping
- [x] Error display includes remediation hint
- [x] `cargo fmt` / `cargo clippy -D warnings` / `cargo test --workspace` — all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-flight validation now checks that all schemas referenced by a policy exist and fails fast with a standardized reason "MissingDatabaseObject", listing missing schemas and remediation guidance.

* **Bug Fixes**
  * Policy application aborts earlier to avoid issuing DDL when referenced schemas are absent; resources transition to Ready=False.

* **Documentation**
  * Updated docs describing the failure mode, error message changes, and retry behavior.

* **Tests**
  * Added unit tests covering schema checks, error mapping, and retry classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->