### PR TITLE
fix: dedup recently-failed plans by sqlHash to prevent accumulation

### DIFF
--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -241,6 +241,11 @@
                     },
                     "type": "array"
                   },
+                  "failedAt": {
+                    "description": "Timestamp when the plan entered Failed phase (for dedup window).",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "lastError": {
                     "description": "Error message if apply failed.",
                     "nullable": true,

--- a/crates/pgroles-operator/Cargo.toml
+++ b/crates/pgroles-operator/Cargo.toml
@@ -36,6 +36,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 rand = "0.9"
+jiff = "0.2"
 base64 = "0.22"
 sha2 = "0.10"
 

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -597,6 +597,9 @@ pub struct PostgresPolicyPlanStatus {
     /// Timestamp when the plan entered Applying phase (for stuck detection).
     #[serde(default)]
     pub applying_since: Option<String>,
+    /// Timestamp when the plan entered Failed phase (for dedup window).
+    #[serde(default)]
+    pub failed_at: Option<String>,
 }
 
 /// Reference to a ConfigMap containing SQL for a plan.

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -54,6 +54,11 @@ const SQL_CONFIGMAP_KEY: &str = "plan.sql";
 /// Default maximum number of historical plans to retain per policy.
 const DEFAULT_MAX_PLANS: usize = 10;
 
+/// How recently a Failed plan must have been created (in seconds) for the
+/// dedup check to consider it a match. Plans older than this are ignored so
+/// that retries after the user fixes the environment are not blocked.
+const FAILED_PLAN_DEDUP_WINDOW_SECS: i64 = 120;
+
 // ---------------------------------------------------------------------------
 // Plan approval check
 // ---------------------------------------------------------------------------
@@ -156,6 +161,35 @@ pub async fn create_or_update_plan(
                 "existing pending plan has identical SQL hash, skipping creation"
             );
             return Ok(PlanCreationResult::Deduplicated(plan_name));
+        }
+    }
+
+    // 5b. Check for recently-failed plan with the same hash. If a plan with
+    // this exact SQL already failed within the dedup window, creating another
+    // identical one is pointless — it would produce the same error. The window
+    // ensures we don't block retries after the user fixes the environment.
+    let now_ts = chrono_now_epoch_secs();
+    for plan in &existing_plans {
+        if let Some(ref status) = plan.status
+            && status.phase == PlanPhase::Failed
+            && status.sql_hash.as_deref() == Some(&sql_hash)
+        {
+            let created_ts = plan
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|t| t.0.as_second())
+                .unwrap_or(0);
+            if now_ts - created_ts < FAILED_PLAN_DEDUP_WINDOW_SECS {
+                let plan_name = plan.name_any();
+                info!(
+                    plan = %plan_name,
+                    policy = %policy_name,
+                    age_secs = now_ts - created_ts,
+                    "recently-failed plan has identical SQL hash, skipping creation"
+                );
+                return Ok(PlanCreationResult::Deduplicated(plan_name));
+            }
         }
     }
 
@@ -596,6 +630,14 @@ fn sanitize_label_value(value: &str) -> String {
         .take(63)
         .collect();
     sanitized
+}
+
+/// Current time as Unix epoch seconds (for dedup window checks).
+fn chrono_now_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
 }
 
 /// Build an OwnerReference pointing from a plan to its parent policy.
@@ -1068,5 +1110,17 @@ mod tests {
         let full = render_full_sql(&changes, &ctx);
 
         assert!(full.contains("super_secret") || full.contains("SCRAM-SHA-256"));
+    }
+
+    #[test]
+    fn chrono_now_epoch_secs_returns_plausible_value() {
+        let now = chrono_now_epoch_secs();
+        // Should be after 2025-01-01 and before 2100-01-01.
+        let y2025 = 1_735_689_600_i64;
+        let y2100 = 4_102_444_800_i64;
+        assert!(
+            now > y2025 && now < y2100,
+            "epoch secs {now} should be between 2025 and 2100"
+        );
     }
 }

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -168,24 +168,26 @@ pub async fn create_or_update_plan(
     // this exact SQL already failed within the dedup window, creating another
     // identical one is pointless — it would produce the same error. The window
     // ensures we don't block retries after the user fixes the environment.
+    //
+    // Uses `status.failed_at` (not `creation_timestamp`) so that plans which
+    // waited for approval before failing are measured from the failure time.
     let now_ts = chrono_now_epoch_secs();
     for plan in &existing_plans {
         if let Some(ref status) = plan.status
             && status.phase == PlanPhase::Failed
             && status.sql_hash.as_deref() == Some(&sql_hash)
         {
-            let created_ts = plan
-                .metadata
-                .creation_timestamp
-                .as_ref()
-                .map(|t| t.0.as_second())
+            let failed_ts = status
+                .failed_at
+                .as_deref()
+                .and_then(parse_rfc3339_epoch_secs)
                 .unwrap_or(0);
-            if now_ts - created_ts < FAILED_PLAN_DEDUP_WINDOW_SECS {
+            if failed_ts > 0 && now_ts - failed_ts < FAILED_PLAN_DEDUP_WINDOW_SECS {
                 let plan_name = plan.name_any();
                 info!(
                     plan = %plan_name,
                     policy = %policy_name,
-                    age_secs = now_ts - created_ts,
+                    age_secs = now_ts - failed_ts,
                     "recently-failed plan has identical SQL hash, skipping creation"
                 );
                 return Ok(PlanCreationResult::Deduplicated(plan_name));
@@ -321,6 +323,7 @@ pub async fn create_or_update_plan(
         last_error: None,
         sql_hash: Some(sql_hash),
         applying_since: None,
+        failed_at: None,
     };
 
     let status_patch = serde_json::json!({ "status": plan_status });
@@ -406,6 +409,7 @@ pub async fn execute_plan(
             let mut failed_status = plan.status.clone().unwrap_or_default();
             failed_status.phase = PlanPhase::Failed;
             failed_status.last_error = Some(error_message);
+            failed_status.failed_at = Some(crate::crd::now_rfc3339());
 
             let patch = serde_json::json!({ "status": failed_status });
             if let Err(status_err) = plans_api
@@ -640,6 +644,16 @@ fn chrono_now_epoch_secs() -> i64 {
         .as_secs() as i64
 }
 
+/// Parse an RFC 3339 timestamp string to Unix epoch seconds.
+/// Returns `None` if parsing fails.
+fn parse_rfc3339_epoch_secs(rfc3339: &str) -> Option<i64> {
+    // Use jiff (already a transitive dep via k8s-openapi) for RFC 3339 parsing.
+    rfc3339
+        .parse::<jiff::Timestamp>()
+        .ok()
+        .map(|t| t.as_second())
+}
+
 /// Build an OwnerReference pointing from a plan to its parent policy.
 fn build_owner_reference(policy: &PostgresPolicy) -> OwnerReference {
     OwnerReference {
@@ -840,6 +854,7 @@ pub async fn mark_plan_failed(
     let mut status = plan.status.clone().unwrap_or_default();
     status.phase = PlanPhase::Failed;
     status.last_error = Some(error_message.to_string());
+    status.failed_at = Some(crate::crd::now_rfc3339());
 
     let patch = serde_json::json!({ "status": status });
     plans_api

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -171,7 +171,7 @@ pub async fn create_or_update_plan(
     //
     // Uses `status.failed_at` (not `creation_timestamp`) so that plans which
     // waited for approval before failing are measured from the failure time.
-    let now_ts = chrono_now_epoch_secs();
+    let now_ts = now_epoch_secs();
     for plan in &existing_plans {
         if let Some(ref status) = plan.status
             && status.phase == PlanPhase::Failed
@@ -637,7 +637,7 @@ fn sanitize_label_value(value: &str) -> String {
 }
 
 /// Current time as Unix epoch seconds (for dedup window checks).
-fn chrono_now_epoch_secs() -> i64 {
+fn now_epoch_secs() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -1128,8 +1128,8 @@ mod tests {
     }
 
     #[test]
-    fn chrono_now_epoch_secs_returns_plausible_value() {
-        let now = chrono_now_epoch_secs();
+    fn now_epoch_secs_returns_plausible_value() {
+        let now = now_epoch_secs();
         // Should be after 2025-01-01 and before 2100-01-01.
         let y2025 = 1_735_689_600_i64;
         let y2100 = 4_102_444_800_i64;

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -241,6 +241,11 @@
                     },
                     "type": "array"
                   },
+                  "failedAt": {
+                    "description": "Timestamp when the plan entered Failed phase (for dedup window).",
+                    "nullable": true,
+                    "type": "string"
+                  },
                   "lastError": {
                     "description": "Error message if apply failed.",
                     "nullable": true,


### PR DESCRIPTION
## Summary

Closes #77.

When a plan fails and the operator retries, the existing dedup only checks `Pending` plans. Failed plans with the same `sqlHash` get recreated on every reconcile, causing unbounded accumulation. Observed in production: 468 identical Failed plans in ~20 minutes.

## What changed

Extended the dedup check in `create_or_update_plan()` to also match `Failed` plans whose `sqlHash` matches **and** whose creation timestamp is within a 120-second window. Plans older than the window are skipped so retries after the user fixes the environment are not blocked.

## Design considerations

The dedup window (120s) is intentionally short:
- **During fast retries** (before backoff kicks in): prevents creating 30 plans/minute
- **After the user fixes the issue**: the old Failed plan ages past the window, and the next reconcile creates a fresh plan that succeeds
- **With #76 in place**: schema errors use slow retry (5-min interval), so the window is rarely even reached

This is one of three complementary fixes for the plan accumulation problem:
- #76 reclassifies the error as non-transient (reduces retry rate)
- #78 catches missing schemas before any plan is created (prevents the error entirely)
- This PR prevents accumulation when the other two don't apply (genuinely transient errors with fast retry)

## Test plan

- [x] `cargo fmt` / `cargo clippy -D warnings` / `cargo test --workspace` — all green
- [x] Unit test for `chrono_now_epoch_secs()` producing plausible values
- [ ] E2E validation: deploy to kind cluster with a failing policy, verify plan count stays bounded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan deduplication to prevent duplicate plan creation when previous attempts failed within a deduplication window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->