### PR TITLE
fix: make MemberSpec.inherit and .admin optional to avoid ArgoCD diffs

### DIFF
--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -269,14 +269,16 @@
                       "properties": {
                         "members": {
                           "items": {
-                            "description": "A single member of a role.",
+                            "description": "A single member of a role.\n\nBoth `inherit` and `admin` are optional. When omitted, they default to\n`inherit: true` and `admin: false` at resolution time (in `RoleGraph`\nconstruction). Keeping them optional in the CRD avoids Kubernetes\ninjecting default values into the stored resource, which causes\nperpetual diffs in GitOps tools like ArgoCD.",
                             "properties": {
                               "admin": {
-                                "default": false,
+                                "description": "Whether the member can administer the role. Defaults to `false`.",
+                                "nullable": true,
                                 "type": "boolean"
                               },
                               "inherit": {
-                                "default": true,
+                                "description": "Whether the member inherits the role's privileges. Defaults to `true`.",
+                                "nullable": true,
                                 "type": "boolean"
                               },
                               "name": {

--- a/crates/pgroles-core/src/export.rs
+++ b/crates/pgroles-core/src/export.rs
@@ -119,8 +119,8 @@ pub fn role_graph_to_manifest(graph: &RoleGraph) -> PolicyManifest {
             .or_default()
             .push(MemberSpec {
                 name: edge.member.clone(),
-                inherit: edge.inherit,
-                admin: edge.admin,
+                inherit: if edge.inherit { None } else { Some(false) },
+                admin: if edge.admin { Some(true) } else { None },
             });
     }
     let memberships: Vec<Membership> = membership_map

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -372,19 +372,35 @@ pub struct Membership {
 }
 
 /// A single member of a role.
+///
+/// Both `inherit` and `admin` are optional. When omitted, they default to
+/// `inherit: true` and `admin: false` at resolution time (in `RoleGraph`
+/// construction). Keeping them optional in the CRD avoids Kubernetes
+/// injecting default values into the stored resource, which causes
+/// perpetual diffs in GitOps tools like ArgoCD.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MemberSpec {
     pub name: String,
 
-    #[serde(default = "default_true")]
-    pub inherit: bool,
+    /// Whether the member inherits the role's privileges. Defaults to `true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inherit: Option<bool>,
 
-    #[serde(default)]
-    pub admin: bool,
+    /// Whether the member can administer the role. Defaults to `false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admin: Option<bool>,
 }
 
-fn default_true() -> bool {
-    true
+impl MemberSpec {
+    /// Resolve `inherit` with its default (true).
+    pub fn inherit(&self) -> bool {
+        self.inherit.unwrap_or(true)
+    }
+
+    /// Resolve `admin` with its default (false).
+    pub fn admin(&self) -> bool {
+        self.admin.unwrap_or(false)
+    }
 }
 
 /// Declarative workflow for retiring an existing role.
@@ -1077,8 +1093,8 @@ memberships:
         assert_eq!(manifest.memberships.len(), 1);
         assert_eq!(manifest.memberships[0].members.len(), 2);
         assert_eq!(manifest.memberships[0].members[0].name, "alice@example.com");
-        assert!(manifest.memberships[0].members[0].inherit);
-        assert!(manifest.memberships[0].members[1].admin);
+        assert_eq!(manifest.memberships[0].members[0].inherit, Some(true));
+        assert_eq!(manifest.memberships[0].members[1].admin, Some(true));
     }
 
     #[test]
@@ -1090,9 +1106,12 @@ memberships:
       - name: user1
 "#;
         let manifest = parse_manifest(yaml).unwrap();
-        // inherit defaults to true, admin defaults to false
-        assert!(manifest.memberships[0].members[0].inherit);
-        assert!(!manifest.memberships[0].members[0].admin);
+        // When omitted, both fields are None (defaults applied at resolution time).
+        assert_eq!(manifest.memberships[0].members[0].inherit, None);
+        assert_eq!(manifest.memberships[0].members[0].admin, None);
+        // Accessor methods still return the expected defaults.
+        assert!(manifest.memberships[0].members[0].inherit());
+        assert!(!manifest.memberships[0].members[0].admin());
     }
 
     #[test]

--- a/crates/pgroles-core/src/model.rs
+++ b/crates/pgroles-core/src/model.rs
@@ -275,8 +275,8 @@ impl RoleGraph {
                 graph.memberships.insert(MembershipEdge {
                     role: membership.role.clone(),
                     member: member_spec.name.clone(),
-                    inherit: member_spec.inherit,
-                    admin: member_spec.admin,
+                    inherit: member_spec.inherit(),
+                    admin: member_spec.admin(),
                 });
             }
         }

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -205,8 +205,8 @@ memberships:
 
 | Field | Default | Description |
 |---|---|---|
-| `inherit` | `true` | Member inherits the role's privileges |
-| `admin` | `false` | Member can administer the role (grant it to others) |
+| `inherit` | `true` | Member inherits the role's privileges (optional, omit for default) |
+| `admin` | `false` | Member can administer the role (optional, omit for default) |
 
 ## Convergent model
 

--- a/docs/src/pages/docs/memberships.md
+++ b/docs/src/pages/docs/memberships.md
@@ -23,8 +23,10 @@ memberships:
 | Field | Default | Description |
 |---|---|---|
 | `name` | *required* | The member role name |
-| `inherit` | `true` | Whether the member inherits the role's privileges |
-| `admin` | `false` | Whether the member can grant the role to others |
+| `inherit` | `true` | Whether the member inherits the role's privileges (omit for default) |
+| `admin` | `false` | Whether the member can grant the role to others (omit for default) |
+
+Both `inherit` and `admin` can be omitted entirely — they default to `true` and `false` respectively. Omitting default values is recommended because it keeps the Kubernetes resource minimal and avoids perpetual diffs in GitOps tools like ArgoCD.
 
 ## Generated SQL
 

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -269,14 +269,16 @@
                       "properties": {
                         "members": {
                           "items": {
-                            "description": "A single member of a role.",
+                            "description": "A single member of a role.\n\nBoth `inherit` and `admin` are optional. When omitted, they default to\n`inherit: true` and `admin: false` at resolution time (in `RoleGraph`\nconstruction). Keeping them optional in the CRD avoids Kubernetes\ninjecting default values into the stored resource, which causes\nperpetual diffs in GitOps tools like ArgoCD.",
                             "properties": {
                               "admin": {
-                                "default": false,
+                                "description": "Whether the member can administer the role. Defaults to `false`.",
+                                "nullable": true,
                                 "type": "boolean"
                               },
                               "inherit": {
-                                "default": true,
+                                "description": "Whether the member inherits the role's privileges. Defaults to `true`.",
+                                "nullable": true,
                                 "type": "boolean"
                               },
                               "name": {


### PR DESCRIPTION
## Summary

When using pgroles with ArgoCD and ServerSideApply, the `PostgresPolicy` CRD caused perpetual diffs on every membership entry. This is because the CRD declared `default: true` for `inherit` and `default: false` for `admin` — the K8s API server injected these into the stored resource even when the user omitted them, creating a diff against the source YAML.

## What changed

- `MemberSpec.inherit`: `bool` with `#[serde(default = "default_true")]` → `Option<bool>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`
- `MemberSpec.admin`: same pattern
- Accessor methods `inherit()` and `admin()` resolve `None` to the expected defaults (`true` and `false`)
- `RoleGraph` construction uses the accessors
- Export emits `None` for default values (so generated manifests stay minimal)
- CRD regenerated — `default:` annotations removed, fields now `nullable: true`
- Docs updated to note that omitting default values is recommended

## Backward compatibility

Fully backward compatible:
- `{ name: app, inherit: true, admin: false }` → works as before
- `{ name: app }` → works as before, no longer causes ArgoCD diffs

## Test plan

- [x] `cargo fmt` / `cargo clippy -D warnings` / `cargo test --workspace` — all green
- [x] CRD drift check passes
- [x] Existing tests updated to verify `None` when fields are omitted
- [x] Accessor methods tested for correct default resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role membership `inherit` and `admin` fields are now optional, defaulting to `inherit: true` and `admin: false` when omitted.
  
* **Documentation**
  * Updated documentation to clarify optional membership fields and their default behaviors, reducing manifest verbosity and GitOps diffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->