### PR TITLE
fix: wildcard grants on empty schemas now converge without hot-looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Wildcard grant convergence on empty schemas** — wildcard grants (`name: "*"`) on sequences, functions, and other types now converge correctly when a schema contains no objects of that type. Previously the operator re-issued the grant on every reconcile, causing unbounded plan creation. (#84)
+- **Missing-object SQL errors classified as non-transient** — errors like `schema "etl" does not exist` (SQLSTATE 3F000, 42P01, 42883, 42704) are now classified as `Slow` retry with a `MissingDatabaseObject` reason instead of hot-looping with exponential backoff. (#79)
+- **Pre-flight schema validation** — the operator validates that every schema referenced by the policy exists in the target database before issuing DDL, surfacing a clear `MissingDatabaseObject` status condition. (#80)
+- **Plan resource deduplication** — recently-failed plans with the same SQL hash are deduplicated within a 120-second window to prevent accumulation during fast retries. (#81)
+- **MemberSpec defaults removed from CRD** — `inherit` and `admin` fields on membership entries are now `Option<bool>` with defaults applied at resolution time, avoiding perpetual ArgoCD diffs when using ServerSideApply. (#83)
+
 ## [0.2.0] - 2026-03-12
 
 ### Added

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -13,7 +13,7 @@ mod roles;
 mod safety;
 mod version;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use sqlx::PgPool;
 use thiserror::Error;
@@ -48,6 +48,10 @@ pub(crate) struct WildcardGrantPattern {
     pub role: String,
     pub object_type: pgroles_core::manifest::ObjectType,
     pub schema: String,
+    /// The desired privileges for this wildcard grant. Used to construct a
+    /// vacuously-satisfied wildcard when no objects of this type exist in the
+    /// schema, so the diff engine sees exact parity and produces no change.
+    pub privileges: std::collections::BTreeSet<pgroles_core::manifest::Privilege>,
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +89,10 @@ impl InspectConfig {
     ) -> Self {
         let mut managed_roles: BTreeSet<String> = BTreeSet::new();
         let mut managed_schemas: BTreeSet<String> = BTreeSet::new();
-        let mut wildcard_grants: BTreeSet<WildcardGrantPattern> = BTreeSet::new();
+        // Key for deduplicating wildcard grants: (role, object_type, schema).
+        type WildcardKey = (String, pgroles_core::manifest::ObjectType, String);
+        let mut wildcard_map: BTreeMap<WildcardKey, BTreeSet<pgroles_core::manifest::Privilege>> =
+            BTreeMap::new();
 
         // Collect role names
         for role_def in &expanded.roles {
@@ -111,11 +118,11 @@ impl InspectConfig {
                 )
                 && let Some(schema) = &grant.object.schema
             {
-                wildcard_grants.insert(WildcardGrantPattern {
-                    role: grant.role.clone(),
-                    object_type: grant.object.object_type,
-                    schema: schema.clone(),
-                });
+                let key = (grant.role.clone(), grant.object.object_type, schema.clone());
+                wildcard_map
+                    .entry(key)
+                    .or_default()
+                    .extend(grant.privileges.iter().copied());
             }
         }
 
@@ -128,7 +135,17 @@ impl InspectConfig {
             managed_roles: managed_roles.into_iter().collect(),
             managed_schemas: managed_schemas.into_iter().collect(),
             include_database_privileges,
-            wildcard_grants: wildcard_grants.into_iter().collect(),
+            wildcard_grants: wildcard_map
+                .into_iter()
+                .map(
+                    |((role, object_type, schema), privileges)| WildcardGrantPattern {
+                        role,
+                        object_type,
+                        schema,
+                        privileges,
+                    },
+                )
+                .collect(),
         }
     }
 

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -222,15 +222,30 @@ fn normalize_wildcard_grants(
     wildcard_grants: &[WildcardGrantPattern],
 ) -> BTreeMap<GrantKey, GrantState> {
     for wildcard in wildcard_grants {
-        let Some(object_names) = inventory.get(&(wildcard.object_type, wildcard.schema.clone()))
-        else {
-            continue;
-        };
+        let object_names = inventory.get(&(wildcard.object_type, wildcard.schema.clone()));
 
-        if object_names.is_empty() {
+        // When no objects of this type exist in the schema, the wildcard grant
+        // is vacuously satisfied — all zero objects have the requested
+        // privileges. Insert the wildcard key with the exact desired privileges
+        // so the diff engine sees parity and does not re-issue
+        // `GRANT ... ON ALL <type> IN SCHEMA` on every reconcile.
+        if object_names.is_none() || object_names.is_some_and(|names| names.is_empty()) {
+            let wildcard_key = GrantKey {
+                role: wildcard.role.clone(),
+                object_type: wildcard.object_type,
+                schema: Some(wildcard.schema.clone()),
+                name: Some("*".to_string()),
+            };
+            grants.insert(
+                wildcard_key,
+                GrantState {
+                    privileges: wildcard.privileges.clone(),
+                },
+            );
             continue;
         }
 
+        let object_names = object_names.unwrap();
         let mut shared_privileges = all_privileges();
 
         for object_name in object_names {
@@ -623,6 +638,12 @@ mod tests {
             role: "inventory-editor".to_string(),
             object_type: ObjectType::Table,
             schema: "inventory".to_string(),
+            privileges: BTreeSet::from([
+                Privilege::Select,
+                Privilege::Insert,
+                Privilege::Update,
+                Privilege::Delete,
+            ]),
         }];
 
         let normalized = normalize_wildcard_grants(grants, &inventory, &selectors);
@@ -646,5 +667,137 @@ mod tests {
             })
             .expect("extra object-specific privileges should remain");
         assert_eq!(specific.privileges, BTreeSet::from([Privilege::Insert]));
+    }
+
+    #[test]
+    fn normalize_wildcard_empty_inventory_inserts_vacuous_wildcard() {
+        // When no objects of the wildcard type exist in the schema, the
+        // normalizer should insert a wildcard key with all privileges so
+        // the diff sees the desired wildcard as already satisfied.
+        let grants = BTreeMap::new();
+        let inventory = BTreeMap::new(); // empty — no sequences in "accounts"
+
+        let desired_privs =
+            BTreeSet::from([Privilege::Select, Privilege::Update, Privilege::Usage]);
+        let wildcards = vec![WildcardGrantPattern {
+            role: "accounts-editor".to_string(),
+            object_type: ObjectType::Sequence,
+            schema: "accounts".to_string(),
+            privileges: desired_privs.clone(),
+        }];
+
+        let result = normalize_wildcard_grants(grants, &inventory, &wildcards);
+
+        let wildcard_key = GrantKey {
+            role: "accounts-editor".to_string(),
+            object_type: ObjectType::Sequence,
+            schema: Some("accounts".to_string()),
+            name: Some("*".to_string()),
+        };
+
+        let entry = result
+            .get(&wildcard_key)
+            .expect("vacuous wildcard should be present");
+        assert_eq!(
+            entry.privileges, desired_privs,
+            "vacuous wildcard should have the desired privileges"
+        );
+    }
+
+    #[test]
+    fn normalize_wildcard_empty_set_in_inventory_inserts_vacuous_wildcard() {
+        // Same as above but the inventory has the key with an empty set.
+        let grants = BTreeMap::new();
+        let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
+        inventory.insert(
+            (ObjectType::Function, "accounts".to_string()),
+            BTreeSet::new(),
+        );
+
+        let wildcards = vec![WildcardGrantPattern {
+            role: "accounts-editor".to_string(),
+            object_type: ObjectType::Function,
+            schema: "accounts".to_string(),
+            privileges: BTreeSet::from([Privilege::Execute]),
+        }];
+
+        let result = normalize_wildcard_grants(grants, &inventory, &wildcards);
+
+        let wildcard_key = GrantKey {
+            role: "accounts-editor".to_string(),
+            object_type: ObjectType::Function,
+            schema: Some("accounts".to_string()),
+            name: Some("*".to_string()),
+        };
+
+        assert!(
+            result.contains_key(&wildcard_key),
+            "vacuous wildcard should be present for empty object set"
+        );
+    }
+
+    #[test]
+    fn normalize_wildcard_nonempty_inventory_still_collapses() {
+        // Ensure the existing behavior for non-empty inventories is preserved.
+        let mut grants = BTreeMap::new();
+        grants.insert(
+            GrantKey {
+                role: "app".to_string(),
+                object_type: ObjectType::Sequence,
+                schema: Some("public".to_string()),
+                name: Some("seq1".to_string()),
+            },
+            GrantState {
+                privileges: BTreeSet::from([Privilege::Select, Privilege::Usage]),
+            },
+        );
+        grants.insert(
+            GrantKey {
+                role: "app".to_string(),
+                object_type: ObjectType::Sequence,
+                schema: Some("public".to_string()),
+                name: Some("seq2".to_string()),
+            },
+            GrantState {
+                privileges: BTreeSet::from([
+                    Privilege::Select,
+                    Privilege::Usage,
+                    Privilege::Update,
+                ]),
+            },
+        );
+
+        let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
+        inventory.insert(
+            (ObjectType::Sequence, "public".to_string()),
+            BTreeSet::from(["seq1".to_string(), "seq2".to_string()]),
+        );
+
+        let wildcards = vec![WildcardGrantPattern {
+            role: "app".to_string(),
+            object_type: ObjectType::Sequence,
+            schema: "public".to_string(),
+            privileges: BTreeSet::from([Privilege::Select, Privilege::Update, Privilege::Usage]),
+        }];
+
+        let result = normalize_wildcard_grants(grants, &inventory, &wildcards);
+
+        let wildcard_key = GrantKey {
+            role: "app".to_string(),
+            object_type: ObjectType::Sequence,
+            schema: Some("public".to_string()),
+            name: Some("*".to_string()),
+        };
+
+        let entry = result
+            .get(&wildcard_key)
+            .expect("wildcard should be present");
+        // shared privileges are Select + Usage (the intersection)
+        assert!(entry.privileges.contains(&Privilege::Select));
+        assert!(entry.privileges.contains(&Privilege::Usage));
+        assert!(
+            !entry.privileges.contains(&Privilege::Update),
+            "Update is not shared across all sequences"
+        );
     }
 }

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -216,36 +216,46 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     ))
 }
 
+/// Insert a vacuously-satisfied wildcard into the grants map. Used when no
+/// objects of the target type exist in the schema — the wildcard is satisfied
+/// by definition, so we populate the current state with the desired privileges
+/// to prevent the diff engine from re-issuing the grant on every reconcile.
+fn insert_vacuous_wildcard(
+    grants: &mut BTreeMap<GrantKey, GrantState>,
+    wildcard: &WildcardGrantPattern,
+) {
+    let wildcard_key = GrantKey {
+        role: wildcard.role.clone(),
+        object_type: wildcard.object_type,
+        schema: Some(wildcard.schema.clone()),
+        name: Some("*".to_string()),
+    };
+    grants.insert(
+        wildcard_key,
+        GrantState {
+            privileges: wildcard.privileges.clone(),
+        },
+    );
+}
+
 fn normalize_wildcard_grants(
     mut grants: BTreeMap<GrantKey, GrantState>,
     inventory: &BTreeMap<(ObjectType, String), BTreeSet<String>>,
     wildcard_grants: &[WildcardGrantPattern],
 ) -> BTreeMap<GrantKey, GrantState> {
     for wildcard in wildcard_grants {
-        let object_names = inventory.get(&(wildcard.object_type, wildcard.schema.clone()));
+        let Some(object_names) = inventory.get(&(wildcard.object_type, wildcard.schema.clone()))
+        else {
+            // No inventory entry at all — insert vacuous wildcard.
+            insert_vacuous_wildcard(&mut grants, wildcard);
+            continue;
+        };
 
-        // When no objects of this type exist in the schema, the wildcard grant
-        // is vacuously satisfied — all zero objects have the requested
-        // privileges. Insert the wildcard key with the exact desired privileges
-        // so the diff engine sees parity and does not re-issue
-        // `GRANT ... ON ALL <type> IN SCHEMA` on every reconcile.
-        if object_names.is_none() || object_names.is_some_and(|names| names.is_empty()) {
-            let wildcard_key = GrantKey {
-                role: wildcard.role.clone(),
-                object_type: wildcard.object_type,
-                schema: Some(wildcard.schema.clone()),
-                name: Some("*".to_string()),
-            };
-            grants.insert(
-                wildcard_key,
-                GrantState {
-                    privileges: wildcard.privileges.clone(),
-                },
-            );
+        if object_names.is_empty() {
+            // Inventory entry exists but is empty — same treatment.
+            insert_vacuous_wildcard(&mut grants, wildcard);
             continue;
         }
-
-        let object_names = object_names.unwrap();
         let mut shared_privileges = all_privileges();
 
         for object_name in object_names {
@@ -730,9 +740,13 @@ mod tests {
             name: Some("*".to_string()),
         };
 
-        assert!(
-            result.contains_key(&wildcard_key),
-            "vacuous wildcard should be present for empty object set"
+        let entry = result
+            .get(&wildcard_key)
+            .expect("vacuous wildcard should be present for empty object set");
+        assert_eq!(
+            entry.privileges,
+            BTreeSet::from([Privilege::Execute]),
+            "vacuous wildcard should carry the desired privileges"
         );
     }
 

--- a/docs/src/pages/docs/grants.md
+++ b/docs/src/pages/docs/grants.md
@@ -80,6 +80,8 @@ requested type in that schema. That keeps `table`, `view`, and
 `materialized_view` grants scoped correctly instead of letting one subtype
 touch the others.
 
+If a schema has no objects of the declared type (e.g. no sequences yet), the wildcard grant is treated as vacuously satisfied — pgroles will not re-issue the statement on subsequent reconciles. When objects are later added, the next reconcile detects the new objects and applies the appropriate grants.
+
 ### Specific object
 
 ```yaml


### PR DESCRIPTION
## Summary

Wildcard grants like `GRANT SELECT ON ALL SEQUENCES IN SCHEMA "accounts"` were re-issued on every reconcile when the schema had zero sequences (or functions). This caused the operator to create a new plan every ~2 seconds — observed in production on the HQ cluster with 1600+ identical Applied plans.

## Root cause

The inventory normalizer in `normalize_wildcard_grants()` skipped schemas with no objects of the target type. The diff engine then saw "desired wildcard grant, no matching current grant" and produced a change — which is a no-op in PostgreSQL but generates a plan every reconcile.

## Fix

When no objects of a wildcard type exist in a schema, insert a vacuously-satisfied wildcard into the current state with the **exact desired privileges**. The diff engine sees parity and produces no change.

Extended `WildcardGrantPattern` to carry the desired privilege set (needed so the vacuous wildcard matches exactly — using `all_privileges()` would cause spurious REVOKE diffs for privilege types invalid on the target object type).

## Verified locally against PostgreSQL 18

```
# Empty schema:
apply → 6 changes (create roles, grant USAGE)
diff  → "No changes needed" ✓  (previously looped forever)

# After adding a sequence:
diff  → 2 changes (grant on new sequence)
apply → 2 changes applied
diff  → "No changes needed" ✓
```

## Test plan

- [x] 3 new unit tests for `normalize_wildcard_grants`: empty inventory, empty set, non-empty (regression)
- [x] Local PG 18 integration: empty schema converges, adding objects triggers correct grants, re-converges
- [x] `cargo fmt` / `cargo clippy -D warnings` / `cargo test --workspace` — all green
- [ ] CI (E2E in kind cluster)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wildcard grants now deduplicate and aggregate privileges correctly; vacuous wildcard grants are treated satisfied when a schema has no matching objects.
  * SQL errors for missing database objects are now classified as non-transient with slower retry.
  * Pre-flight schema validation prevents issuing DDL for missing schemas.
  * Recently-failed plans are deduplicated within a 120s window.
  * CRD membership defaults adjusted to avoid perpetual diffs.

* **Documentation**
  * Clarified wildcard-grant behavior in grants docs.

* **Tests**
  * Added tests covering wildcard normalization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->