### PR TITLE
feat: structured connection params for Zalando/CNPG/PGO secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,27 @@ jobs:
           wait_for_event_reason rotated-secret-policy Recovered
 
           # ----------------------------------------------------------------
+          # Structured params connection mode (#86): create, verify, rotate credentials
+          # ----------------------------------------------------------------
+          upsert_secret params-pg-credentials username=postgres password=devpassword
+          kubectl apply -f k8s/samples/params-e2e-policy.yaml
+          wait_for_ready_true params-e2e-policy
+
+          assert_role_exists params-test-role
+          echo "params-mode: basic reconciliation works"
+
+          # Rotate credential Secret to bad password — should fail to connect
+          upsert_secret params-pg-credentials username=postgres password=wrongpassword
+          wait_for_ready_reason params-e2e-policy DatabaseConnectionFailed
+          echo "params-mode: credential rotation detected (bad password)"
+
+          # Rotate back to correct password — should recover
+          upsert_secret params-pg-credentials username=postgres password=devpassword
+          wait_for_ready_true params-e2e-policy
+          wait_for_event_reason params-e2e-policy Recovered
+          echo "params-mode: credential rotation recovery works"
+
+          # ----------------------------------------------------------------
           # Password lifecycle (#46): create with Secret, verify, rotate
           # ----------------------------------------------------------------
           upsert_secret role-passwords password-user='e2e_initial_pw!'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Structured connection parameters** — the operator now supports `connection.params` with individual fields for host, port, dbname, username, password, and sslMode. Each field accepts either a literal value or a `*Secret` reference (SecretKeySelector). This integrates natively with Zalando postgres-operator, CloudNativePG, and CrunchyData PGO without requiring an ExternalSecret intermediary. The existing `secretRef` + `secretKey` (DATABASE_URL) mode is unchanged. (#86)
+
 ### Fixed
 
 - **Wildcard grant convergence on empty schemas** — wildcard grants (`name: "*"`) on sequences, functions, and other types now converge correctly when a schema contains no objects of that type. Previously the operator re-issued the grant on every reconcile, causing unbounded plan creation. (#84)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "percent-encoding",
  "pgroles-core",
  "pgroles-inspect",
  "rand 0.9.2",

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -83,7 +83,8 @@
                         "nullable": true,
                         "properties": {
                           "dbname": {
-                            "anyOf": [
+                            "description": "Database name.",
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -91,7 +92,6 @@
                                 ]
                               }
                             ],
-                            "description": "Database name.",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -112,10 +112,12 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "host": {
-                            "anyOf": [
+                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -123,7 +125,6 @@
                                 ]
                               }
                             ],
-                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -144,10 +145,12 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "password": {
-                            "anyOf": [
+                            "description": "Password for authentication.",
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -155,7 +158,6 @@
                                 ]
                               }
                             ],
-                            "description": "Password for authentication.",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -176,19 +178,20 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "port": {
-                            "anyOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
                             "description": "Port number. Defaults to `5432` if omitted.",
                             "nullable": true,
+                            "oneOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -209,43 +212,13 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "sslMode": {
-                            "anyOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
                             "description": "SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.",
                             "nullable": true,
-                            "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "username": {
-                            "anyOf": [
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -253,7 +226,6 @@
                                 ]
                               }
                             ],
-                            "description": "Username for authentication.",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -274,7 +246,41 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "username": {
+                            "description": "Username for authentication.",
+                            "oneOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           }
                         },
                         "required": [

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -123,7 +123,7 @@
                                 ]
                               }
                             ],
-                            "description": "PostgreSQL host (e.g. `partly-postgres` — K8s DNS, namespace-relative).",
+                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -83,212 +83,153 @@
                         "nullable": true,
                         "properties": {
                           "dbname": {
-                            "description": "Database name.",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "Database name as a literal value.",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "dbnameSecret": {
+                            "description": "Database name from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "host": {
-                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "PostgreSQL host as a literal value.",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "hostSecret": {
+                            "description": "PostgreSQL host from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "password": {
-                            "description": "Password for authentication.",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "Password as a literal value (not recommended for production).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "passwordSecret": {
+                            "description": "Password from a Secret key (recommended).",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "port": {
-                            "description": "Port number. Defaults to `5432` if omitted.",
+                            "description": "Port as a literal value. Defaults to 5432 if neither port nor portSecret is set.",
+                            "format": "uint16",
+                            "maximum": 65535.0,
+                            "minimum": 0.0,
                             "nullable": true,
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "type": "integer"
+                          },
+                          "portSecret": {
+                            "description": "Port from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "sslMode": {
-                            "description": "SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.",
+                            "description": "SSL mode as a literal value.",
                             "nullable": true,
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "type": "string"
+                          },
+                          "sslModeSecret": {
+                            "description": "SSL mode from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "username": {
-                            "description": "Username for authentication.",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "Username as a literal value.",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "usernameSecret": {
+                            "description": "Username from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           }
                         },
-                        "required": [
-                          "dbname",
-                          "host",
-                          "password",
-                          "username"
-                        ],
                         "type": "object"
                       },
                       "secretKey": {

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -78,13 +78,221 @@
                   "connection": {
                     "description": "Database connection configuration.",
                     "properties": {
+                      "params": {
+                        "description": "Structured connection parameters. Each field is either a plain string\nor a reference to a Secret key. Mutually exclusive with `secretRef`.",
+                        "nullable": true,
+                        "properties": {
+                          "dbname": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Database name.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "host": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "PostgreSQL host (e.g. `partly-postgres` — K8s DNS, namespace-relative).",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "password": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Password for authentication.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Port number. Defaults to `5432` if omitted.",
+                            "nullable": true,
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "sslMode": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.",
+                            "nullable": true,
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "username": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Username for authentication.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "dbname",
+                          "host",
+                          "password",
+                          "username"
+                        ],
+                        "type": "object"
+                      },
                       "secretKey": {
-                        "default": "DATABASE_URL",
-                        "description": "Override the key in the Secret to read. Defaults to `DATABASE_URL`.",
+                        "description": "Key within the Secret to read. Defaults to `DATABASE_URL`.\nOnly used with `secretRef`.",
+                        "nullable": true,
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "Reference to a Kubernetes Secret containing the connection string.\nThe secret must have a key named `DATABASE_URL`.",
+                        "description": "Reference to a Kubernetes Secret containing a connection URL.\nMutually exclusive with `params`.",
+                        "nullable": true,
                         "properties": {
                           "name": {
                             "description": "Name of the Secret.",
@@ -97,9 +305,6 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "secretRef"
-                    ],
                     "type": "object"
                   },
                   "default_owner": {

--- a/crates/pgroles-operator/Cargo.toml
+++ b/crates/pgroles-operator/Cargo.toml
@@ -39,6 +39,7 @@ rand = "0.9"
 jiff = "0.2"
 base64 = "0.22"
 sha2 = "0.10"
+percent-encoding = "2"
 
 [[bin]]
 name = "pgroles-operator"

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -27,6 +27,8 @@ const _: () = assert!(POOL_MAX_CONNECTIONS >= 2);
 #[derive(Clone)]
 struct CachedPool {
     resource_version: Option<String>,
+    /// Fingerprint of all referenced secrets' resourceVersions (params mode).
+    secret_fingerprint: Option<String>,
     pool: PgPool,
 }
 
@@ -173,18 +175,44 @@ impl OperatorContext {
         } else if let Some(ref params) = connection.params {
             // Params mode — resolve each field and build the URL.
             let host = self.resolve_value_source(namespace, &params.host).await?;
+            if host.trim().is_empty() {
+                return Err(ContextError::EmptyResolvedValue {
+                    field: "host".to_string(),
+                });
+            }
             let port = if let Some(ref port_source) = params.port {
-                self.resolve_value_source(namespace, port_source).await?
+                let p = self.resolve_value_source(namespace, port_source).await?;
+                if p.trim().is_empty() {
+                    return Err(ContextError::EmptyResolvedValue {
+                        field: "port".to_string(),
+                    });
+                }
+                p
             } else {
                 "5432".to_string()
             };
             let dbname = self.resolve_value_source(namespace, &params.dbname).await?;
+            if dbname.trim().is_empty() {
+                return Err(ContextError::EmptyResolvedValue {
+                    field: "dbname".to_string(),
+                });
+            }
             let username = self
                 .resolve_value_source(namespace, &params.username)
                 .await?;
+            if username.trim().is_empty() {
+                return Err(ContextError::EmptyResolvedValue {
+                    field: "username".to_string(),
+                });
+            }
             let password = self
                 .resolve_value_source(namespace, &params.password)
                 .await?;
+            if password.trim().is_empty() {
+                return Err(ContextError::EmptyResolvedValue {
+                    field: "password".to_string(),
+                });
+            }
 
             use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
             let encoded_username = utf8_percent_encode(&username, NON_ALPHANUMERIC).to_string();
@@ -198,6 +226,11 @@ impl OperatorContext {
                 let ssl_mode = self
                     .resolve_value_source(namespace, ssl_mode_source)
                     .await?;
+                // Validate sslMode at runtime — CRD validation only catches
+                // literal values; a secretKeyRef could resolve to anything.
+                if !crate::crd::VALID_SSL_MODES.contains(&ssl_mode.as_str()) {
+                    return Err(ContextError::InvalidResolvedSslMode { value: ssl_mode });
+                }
                 url.push_str("?sslmode=");
                 url.push_str(&ssl_mode);
             }
@@ -223,30 +256,69 @@ impl OperatorContext {
         let cache_key = connection.cache_key(namespace);
 
         // For URL mode, we can do resource-version-based cache invalidation.
-        // For params mode, we skip version checking (multiple secrets may be involved).
-        let resource_version = if let Some(ref secret_ref) = connection.secret_ref {
-            let secrets_api: kube::Api<k8s_openapi::api::core::v1::Secret> =
-                kube::Api::namespaced(self.kube_client.clone(), namespace);
-            let secret = secrets_api.get(&secret_ref.name).await.map_err(|err| {
-                ContextError::SecretFetch {
-                    name: secret_ref.name.clone(),
-                    namespace: namespace.to_string(),
-                    source: err,
+        // For params mode, compute a fingerprint from all referenced secrets'
+        // resourceVersions so that secret rotations invalidate the cache.
+        let (resource_version, secret_fingerprint) =
+            if let Some(ref secret_ref) = connection.secret_ref {
+                let secrets_api: kube::Api<k8s_openapi::api::core::v1::Secret> =
+                    kube::Api::namespaced(self.kube_client.clone(), namespace);
+                let secret = secrets_api.get(&secret_ref.name).await.map_err(|err| {
+                    ContextError::SecretFetch {
+                        name: secret_ref.name.clone(),
+                        namespace: namespace.to_string(),
+                        source: err,
+                    }
+                })?;
+                (secret.metadata.resource_version, None)
+            } else if connection.params.is_some() {
+                // Params mode — collect all referenced secret names and fetch their
+                // resourceVersions to build a fingerprint.
+                let mut secret_names = std::collections::BTreeSet::new();
+                connection.collect_secret_names(&mut secret_names);
+
+                if secret_names.is_empty() {
+                    // All values are literals — no secrets to watch.
+                    (None, Some(String::new()))
+                } else {
+                    let secrets_api: kube::Api<k8s_openapi::api::core::v1::Secret> =
+                        kube::Api::namespaced(self.kube_client.clone(), namespace);
+                    let mut fingerprint_parts = Vec::new();
+                    for name in &secret_names {
+                        let secret = secrets_api.get(name).await.map_err(|err| {
+                            ContextError::SecretFetch {
+                                name: name.clone(),
+                                namespace: namespace.to_string(),
+                                source: err,
+                            }
+                        })?;
+                        let rv = secret
+                            .metadata
+                            .resource_version
+                            .unwrap_or_else(|| "unknown".to_string());
+                        fingerprint_parts.push(format!("{name}={rv}"));
+                    }
+                    (None, Some(fingerprint_parts.join(",")))
                 }
-            })?;
-            secret.metadata.resource_version
-        } else {
-            // Params mode — no single resource version, always re-resolve.
-            None
-        };
+            } else {
+                (None, None)
+            };
 
         // Check cache.
         {
             let cache = self.pool_cache.read().await;
             if let Some(cached) = cache.get(&cache_key) {
-                // For URL mode, only reuse if the Secret hasn't changed.
-                // For params mode (resource_version is None), always reuse cached pool.
-                if resource_version.is_none() || cached.resource_version == resource_version {
+                // URL mode: reuse if the Secret's resource_version matches.
+                // Params mode: reuse if the secret fingerprint matches.
+                let version_matches = match (&resource_version, &cached.resource_version) {
+                    (Some(current), Some(cached_rv)) => current == cached_rv,
+                    _ => true,
+                };
+                let fingerprint_matches = match (&secret_fingerprint, &cached.secret_fingerprint) {
+                    (Some(current), Some(cached_fp)) => current == cached_fp,
+                    (None, None) => true,
+                    _ => false,
+                };
+                if version_matches && fingerprint_matches {
                     return Ok(cached.pool.clone());
                 }
             }
@@ -271,6 +343,7 @@ impl OperatorContext {
                 cache_key,
                 CachedPool {
                     resource_version,
+                    secret_fingerprint,
                     pool: pool.clone(),
                 },
             );
@@ -342,6 +415,14 @@ pub enum ContextError {
 
     #[error("failed to connect to database: {source}")]
     DatabaseConnect { source: sqlx::Error },
+
+    #[error("connection param \"{field}\" resolved to an empty or whitespace-only value")]
+    EmptyResolvedValue { field: String },
+
+    #[error(
+        "connection param sslMode resolved to invalid value \"{value}\" (expected one of: disable, allow, prefer, require, verify-ca, verify-full)"
+    )]
+    InvalidResolvedSslMode { value: String },
 }
 
 impl ContextError {

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tokio::sync::{Mutex, RwLock};
 
-use crate::crd::{ConnectionSpec, ValueSource};
+use crate::crd::{ConnectionSpec, SecretKeySelector};
 use crate::observability::OperatorObservability;
 
 /// Minimum pool size required for reconciliation.
@@ -137,22 +137,25 @@ impl OperatorContext {
         })
     }
 
-    /// Resolve a [`ValueSource`] to its string value.
+    /// Resolve a param from either its literal value or a Secret reference.
     ///
-    /// For literals, returns the value directly. For secret references, fetches
-    /// the value from the Kubernetes API.
-    async fn resolve_value_source(
+    /// Returns `Ok(Some(value))` if one is set, `Ok(None)` if neither is set.
+    async fn resolve_param(
         &self,
         namespace: &str,
-        source: &ValueSource,
-    ) -> Result<String, ContextError> {
-        match source {
-            ValueSource::Literal(value) => Ok(value.clone()),
-            ValueSource::SecretRef { secret_key_ref } => {
-                self.fetch_secret_value(namespace, &secret_key_ref.name, &secret_key_ref.key)
-                    .await
-            }
+        literal: &Option<String>,
+        secret: &Option<SecretKeySelector>,
+    ) -> Result<Option<String>, ContextError> {
+        if let Some(val) = literal {
+            return Ok(Some(val.clone()));
         }
+        if let Some(sel) = secret {
+            return Ok(Some(
+                self.fetch_secret_value(namespace, &sel.name, &sel.key)
+                    .await?,
+            ));
+        }
+        Ok(None)
     }
 
     /// Resolve a [`ConnectionSpec`] into a PostgreSQL connection URL string.
@@ -174,40 +177,59 @@ impl OperatorContext {
             .await
         } else if let Some(ref params) = connection.params {
             // Params mode — resolve each field and build the URL.
-            let host = self.resolve_value_source(namespace, &params.host).await?;
+            let host = self
+                .resolve_param(namespace, &params.host, &params.host_secret)
+                .await?
+                .ok_or_else(|| ContextError::EmptyResolvedValue {
+                    field: "host".to_string(),
+                })?;
             if host.trim().is_empty() {
                 return Err(ContextError::EmptyResolvedValue {
                     field: "host".to_string(),
                 });
             }
-            let port = if let Some(ref port_source) = params.port {
-                let p = self.resolve_value_source(namespace, port_source).await?;
-                if p.trim().is_empty() {
-                    return Err(ContextError::EmptyResolvedValue {
-                        field: "port".to_string(),
-                    });
-                }
-                p
-            } else {
-                "5432".to_string()
-            };
-            let dbname = self.resolve_value_source(namespace, &params.dbname).await?;
+
+            let port_str = params.port.map(|p| p.to_string());
+            let port = self
+                .resolve_param(namespace, &port_str, &params.port_secret)
+                .await?
+                .unwrap_or_else(|| "5432".to_string());
+            if port.trim().is_empty() {
+                return Err(ContextError::EmptyResolvedValue {
+                    field: "port".to_string(),
+                });
+            }
+
+            let dbname = self
+                .resolve_param(namespace, &params.dbname, &params.dbname_secret)
+                .await?
+                .ok_or_else(|| ContextError::EmptyResolvedValue {
+                    field: "dbname".to_string(),
+                })?;
             if dbname.trim().is_empty() {
                 return Err(ContextError::EmptyResolvedValue {
                     field: "dbname".to_string(),
                 });
             }
+
             let username = self
-                .resolve_value_source(namespace, &params.username)
-                .await?;
+                .resolve_param(namespace, &params.username, &params.username_secret)
+                .await?
+                .ok_or_else(|| ContextError::EmptyResolvedValue {
+                    field: "username".to_string(),
+                })?;
             if username.trim().is_empty() {
                 return Err(ContextError::EmptyResolvedValue {
                     field: "username".to_string(),
                 });
             }
+
             let password = self
-                .resolve_value_source(namespace, &params.password)
-                .await?;
+                .resolve_param(namespace, &params.password, &params.password_secret)
+                .await?
+                .ok_or_else(|| ContextError::EmptyResolvedValue {
+                    field: "password".to_string(),
+                })?;
             if password.trim().is_empty() {
                 return Err(ContextError::EmptyResolvedValue {
                     field: "password".to_string(),
@@ -222,12 +244,12 @@ impl OperatorContext {
                 "postgresql://{encoded_username}:{encoded_password}@{host}:{port}/{dbname}"
             );
 
-            if let Some(ref ssl_mode_source) = params.ssl_mode {
-                let ssl_mode = self
-                    .resolve_value_source(namespace, ssl_mode_source)
-                    .await?;
+            if let Some(ssl_mode) = self
+                .resolve_param(namespace, &params.ssl_mode, &params.ssl_mode_secret)
+                .await?
+            {
                 // Validate sslMode at runtime — CRD validation only catches
-                // literal values; a secretKeyRef could resolve to anything.
+                // literal values; a secret ref could resolve to anything.
                 if !crate::crd::VALID_SSL_MODES.contains(&ssl_mode.as_str()) {
                     return Err(ContextError::InvalidResolvedSslMode { value: ssl_mode });
                 }

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tokio::sync::{Mutex, RwLock};
 
+use crate::crd::{ConnectionSpec, ValueSource};
 use crate::observability::OperatorObservability;
 
 /// Minimum pool size required for reconciliation.
@@ -134,61 +135,124 @@ impl OperatorContext {
         })
     }
 
-    /// Get or create a PgPool for the given secret reference.
+    /// Resolve a [`ValueSource`] to its string value.
     ///
-    /// Reads the `DATABASE_URL` (or custom key) from the referenced Secret,
+    /// For literals, returns the value directly. For secret references, fetches
+    /// the value from the Kubernetes API.
+    async fn resolve_value_source(
+        &self,
+        namespace: &str,
+        source: &ValueSource,
+    ) -> Result<String, ContextError> {
+        match source {
+            ValueSource::Literal(value) => Ok(value.clone()),
+            ValueSource::SecretRef { secret_key_ref } => {
+                self.fetch_secret_value(namespace, &secret_key_ref.name, &secret_key_ref.key)
+                    .await
+            }
+        }
+    }
+
+    /// Resolve a [`ConnectionSpec`] into a PostgreSQL connection URL string.
+    ///
+    /// - **URL mode** (`secret_ref` is Some): reads the Secret key as a connection URL.
+    /// - **Params mode** (`params` is Some): resolves each field and constructs a URL.
+    pub async fn resolve_connection_url(
+        &self,
+        namespace: &str,
+        connection: &ConnectionSpec,
+    ) -> Result<String, ContextError> {
+        if let Some(ref secret_ref) = connection.secret_ref {
+            // URL mode — read the full connection URL from the Secret.
+            self.fetch_secret_value(
+                namespace,
+                &secret_ref.name,
+                connection.effective_secret_key(),
+            )
+            .await
+        } else if let Some(ref params) = connection.params {
+            // Params mode — resolve each field and build the URL.
+            let host = self.resolve_value_source(namespace, &params.host).await?;
+            let port = if let Some(ref port_source) = params.port {
+                self.resolve_value_source(namespace, port_source).await?
+            } else {
+                "5432".to_string()
+            };
+            let dbname = self.resolve_value_source(namespace, &params.dbname).await?;
+            let username = self
+                .resolve_value_source(namespace, &params.username)
+                .await?;
+            let password = self
+                .resolve_value_source(namespace, &params.password)
+                .await?;
+
+            use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+            let encoded_username = utf8_percent_encode(&username, NON_ALPHANUMERIC).to_string();
+            let encoded_password = utf8_percent_encode(&password, NON_ALPHANUMERIC).to_string();
+
+            let mut url = format!(
+                "postgresql://{encoded_username}:{encoded_password}@{host}:{port}/{dbname}"
+            );
+
+            if let Some(ref ssl_mode_source) = params.ssl_mode {
+                let ssl_mode = self
+                    .resolve_value_source(namespace, ssl_mode_source)
+                    .await?;
+                url.push_str("?sslmode=");
+                url.push_str(&ssl_mode);
+            }
+
+            Ok(url)
+        } else {
+            Err(ContextError::SecretMissing {
+                name: "connection".to_string(),
+                key: "neither secretRef nor params is set".to_string(),
+            })
+        }
+    }
+
+    /// Get or create a PgPool for the given connection spec.
+    ///
+    /// Resolves the connection URL from the referenced Secret(s),
     /// and caches the resulting pool for reuse.
     pub async fn get_or_create_pool(
         &self,
         namespace: &str,
-        secret_name: &str,
-        secret_key: &str,
+        connection: &ConnectionSpec,
     ) -> Result<PgPool, ContextError> {
-        let cache_key = format!("{namespace}/{secret_name}/{secret_key}");
+        let cache_key = connection.cache_key(namespace);
 
-        // Fetch secret from k8s API.
-        let secrets_api: kube::Api<k8s_openapi::api::core::v1::Secret> =
-            kube::Api::namespaced(self.kube_client.clone(), namespace);
-
-        let secret =
-            secrets_api
-                .get(secret_name)
-                .await
-                .map_err(|err| ContextError::SecretFetch {
-                    name: secret_name.to_string(),
+        // For URL mode, we can do resource-version-based cache invalidation.
+        // For params mode, we skip version checking (multiple secrets may be involved).
+        let resource_version = if let Some(ref secret_ref) = connection.secret_ref {
+            let secrets_api: kube::Api<k8s_openapi::api::core::v1::Secret> =
+                kube::Api::namespaced(self.kube_client.clone(), namespace);
+            let secret = secrets_api.get(&secret_ref.name).await.map_err(|err| {
+                ContextError::SecretFetch {
+                    name: secret_ref.name.clone(),
                     namespace: namespace.to_string(),
                     source: err,
-                })?;
+                }
+            })?;
+            secret.metadata.resource_version
+        } else {
+            // Params mode — no single resource version, always re-resolve.
+            None
+        };
 
-        let resource_version = secret.metadata.resource_version.clone();
-
-        // Check cache after reading the current Secret version.
+        // Check cache.
         {
             let cache = self.pool_cache.read().await;
-            if let Some(cached) = cache.get(&cache_key)
-                && cached.resource_version == resource_version
-            {
-                return Ok(cached.pool.clone());
+            if let Some(cached) = cache.get(&cache_key) {
+                // For URL mode, only reuse if the Secret hasn't changed.
+                // For params mode (resource_version is None), always reuse cached pool.
+                if resource_version.is_none() || cached.resource_version == resource_version {
+                    return Ok(cached.pool.clone());
+                }
             }
         }
 
-        let data = secret.data.ok_or_else(|| ContextError::SecretMissing {
-            name: secret_name.to_string(),
-            key: secret_key.to_string(),
-        })?;
-
-        let url_bytes = data
-            .get(secret_key)
-            .ok_or_else(|| ContextError::SecretMissing {
-                name: secret_name.to_string(),
-                key: secret_key.to_string(),
-            })?;
-
-        let database_url =
-            String::from_utf8(url_bytes.0.clone()).map_err(|_| ContextError::SecretMissing {
-                name: secret_name.to_string(),
-                key: secret_key.to_string(),
-            })?;
+        let database_url = self.resolve_connection_url(namespace, connection).await?;
 
         // Create pool with explicit sizing. Reconciliation holds one dedicated
         // connection for PostgreSQL advisory locking and needs additional pool
@@ -256,8 +320,8 @@ impl OperatorContext {
     }
 
     /// Remove a cached pool (e.g. when secret changes or CR is deleted).
-    pub async fn evict_pool(&self, namespace: &str, secret_name: &str, secret_key: &str) {
-        let cache_key = format!("{namespace}/{secret_name}/{secret_key}");
+    pub async fn evict_pool(&self, namespace: &str, connection: &ConnectionSpec) {
+        let cache_key = connection.cache_key(namespace);
         let mut cache = self.pool_cache.write().await;
         cache.remove(&cache_key);
     }

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -209,12 +209,10 @@ impl From<CrdReconciliationMode> for pgroles_core::diff::ReconciliationMode {
 /// connection:
 ///   params:
 ///     host: my-cluster-postgres
-///     port: "5432"
+///     port: 5432
 ///     dbname: mydb
-///     username:
-///       secretKeyRef: { name: zalando-creds, key: username }
-///     password:
-///       secretKeyRef: { name: zalando-creds, key: password }
+///     usernameSecret: { name: zalando-creds, key: username }
+///     passwordSecret: { name: zalando-creds, key: password }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -247,15 +245,18 @@ impl ConnectionSpec {
             names.insert(secret_ref.name.clone());
         }
         if let Some(ref params) = self.params {
-            params.host.collect_secret_name(names);
-            if let Some(ref port) = params.port {
-                port.collect_secret_name(names);
-            }
-            params.dbname.collect_secret_name(names);
-            params.username.collect_secret_name(names);
-            params.password.collect_secret_name(names);
-            if let Some(ref ssl_mode) = params.ssl_mode {
-                ssl_mode.collect_secret_name(names);
+            for sel in [
+                &params.host_secret,
+                &params.port_secret,
+                &params.dbname_secret,
+                &params.username_secret,
+                &params.password_secret,
+                &params.ssl_mode_secret,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                names.insert(sel.name.clone());
             }
         }
     }
@@ -273,13 +274,17 @@ impl ConnectionSpec {
         } else if let Some(ref params) = self.params {
             format!(
                 "params\0{}\0{}\0{}\0{}",
-                params.host.identity_repr(),
-                params.dbname.identity_repr(),
-                params.username.identity_repr(),
+                field_identity_repr(&params.host, &params.host_secret),
+                field_identity_repr(&params.dbname, &params.dbname_secret),
+                field_identity_repr(&params.username, &params.username_secret),
                 params
                     .port
                     .as_ref()
-                    .map(|p| p.identity_repr())
+                    .map(|p| format!("literal={p}"))
+                    .or_else(|| params
+                        .port_secret
+                        .as_ref()
+                        .map(|s| format!("secret={}\0{}", s.name, s.key)))
                     .unwrap_or_else(|| "5432".to_string()),
             )
         } else {
@@ -288,14 +293,20 @@ impl ConnectionSpec {
         }
     }
 
-    /// Cache key for pool lookup. Includes all params (identity + sslMode + port)
+    /// Cache key for pool lookup. Includes all params (identity + sslMode + password)
     /// so that any configuration change invalidates the cached pool.
     pub fn cache_key(&self, namespace: &str) -> String {
         if let Some(ref params) = self.params {
             let ssl_part = params
                 .ssl_mode
                 .as_ref()
-                .map(|s| s.identity_repr())
+                .map(|v| format!("literal={v}"))
+                .or_else(|| {
+                    params
+                        .ssl_mode_secret
+                        .as_ref()
+                        .map(|s| format!("secret={}\0{}", s.name, s.key))
+                })
                 .unwrap_or_default();
             format!("{namespace}/{}\0ssl={ssl_part}", self.identity_key())
         } else {
@@ -304,78 +315,84 @@ impl ConnectionSpec {
     }
 }
 
-impl ValueSource {
-    /// Deterministic string representation for identity/cache keys.
-    ///
-    /// Uses a `literal=` / `secret=` prefix scheme so that a literal value
-    /// can never collide with a secret reference representation.
-    pub fn identity_repr(&self) -> String {
-        match self {
-            ValueSource::Literal(value) => format!("literal={value}"),
-            ValueSource::SecretRef { secret_key_ref } => {
-                format!("secret={}\0{}", secret_key_ref.name, secret_key_ref.key)
-            }
-        }
-    }
-}
-
-impl ValueSource {
-    /// If this is a SecretRef, add the secret name to the set.
-    pub fn collect_secret_name(&self, names: &mut BTreeSet<String>) {
-        if let ValueSource::SecretRef { secret_key_ref } = self {
-            names.insert(secret_key_ref.name.clone());
-        }
+/// Deterministic string representation for a literal/secret field pair.
+///
+/// Uses a `literal=` / `secret=` prefix scheme so that a literal value
+/// can never collide with a secret reference representation.
+fn field_identity_repr(literal: &Option<String>, secret: &Option<SecretKeySelector>) -> String {
+    if let Some(value) = literal {
+        format!("literal={value}")
+    } else if let Some(sel) = secret {
+        format!("secret={}\0{}", sel.name, sel.key)
+    } else {
+        String::new()
     }
 }
 
 /// Structured connection parameters for building a PostgreSQL connection URL.
+///
+/// Each field supports either a literal value or a reference to a Kubernetes
+/// Secret key. For each parameter, set either the literal field or the
+/// corresponding `*Secret` field — not both.
+///
+/// ```yaml
+/// # Zalando pattern — literals for non-sensitive, secrets for credentials
+/// params:
+///   host: my-cluster-postgres
+///   port: 5432
+///   dbname: mydb
+///   sslMode: require
+///   usernameSecret:
+///     name: pg-creds
+///     key: username
+///   passwordSecret:
+///     name: pg-creds
+///     key: password
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionParams {
-    /// PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).
-    pub host: ValueSource,
-
-    /// Port number. Defaults to `5432` if omitted.
+    /// PostgreSQL host as a literal value.
     #[serde(default)]
-    pub port: Option<ValueSource>,
-
-    /// Database name.
-    pub dbname: ValueSource,
-
-    /// Username for authentication.
-    pub username: ValueSource,
-
-    /// Password for authentication.
-    pub password: ValueSource,
-
-    /// SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.
+    pub host: Option<String>,
+    /// PostgreSQL host from a Secret key.
     #[serde(default)]
-    pub ssl_mode: Option<ValueSource>,
-}
+    pub host_secret: Option<SecretKeySelector>,
 
-/// A value that can come from a literal string or a Secret key reference.
-///
-/// Supports shorthand for the common case:
-/// ```yaml
-/// # Literal string (shorthand)
-/// host: my-cluster-postgres
-///
-/// # Secret reference
-/// password:
-///   secretKeyRef:
-///     name: my-creds
-///     key: password
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum ValueSource {
-    /// A literal string value.
-    Literal(String),
-    /// A reference to a key in a Kubernetes Secret.
-    SecretRef {
-        #[serde(rename = "secretKeyRef")]
-        secret_key_ref: SecretKeySelector,
-    },
+    /// Port as a literal value. Defaults to 5432 if neither port nor portSecret is set.
+    #[serde(default)]
+    pub port: Option<u16>,
+    /// Port from a Secret key.
+    #[serde(default)]
+    pub port_secret: Option<SecretKeySelector>,
+
+    /// Database name as a literal value.
+    #[serde(default)]
+    pub dbname: Option<String>,
+    /// Database name from a Secret key.
+    #[serde(default)]
+    pub dbname_secret: Option<SecretKeySelector>,
+
+    /// Username as a literal value.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// Username from a Secret key.
+    #[serde(default)]
+    pub username_secret: Option<SecretKeySelector>,
+
+    /// Password as a literal value (not recommended for production).
+    #[serde(default)]
+    pub password: Option<String>,
+    /// Password from a Secret key (recommended).
+    #[serde(default)]
+    pub password_secret: Option<SecretKeySelector>,
+
+    /// SSL mode as a literal value.
+    #[serde(default)]
+    pub ssl_mode: Option<String>,
+    /// SSL mode from a Secret key.
+    #[serde(default)]
+    pub ssl_mode_secret: Option<SecretKeySelector>,
 }
 
 /// Reference to a specific key within a Kubernetes Secret.
@@ -385,42 +402,6 @@ pub struct SecretKeySelector {
     pub name: String,
     /// Key within the Secret.
     pub key: String,
-}
-
-/// Manual `JsonSchema` implementation for [`ValueSource`].
-///
-/// The derived schema for `#[serde(untagged)]` enums produces `type: object`
-/// which causes the K8s API server to reject plain string literals like
-/// `host: "my-cluster"`. We use `x-kubernetes-int-or-string` to tell the API
-/// server this field accepts heterogeneous types (string or object), and add
-/// a `oneOf` for documentation/validation.
-impl schemars::JsonSchema for ValueSource {
-    fn schema_name() -> std::borrow::Cow<'static, str> {
-        "ValueSource".into()
-    }
-
-    fn schema_id() -> std::borrow::Cow<'static, str> {
-        concat!(module_path!(), "::ValueSource").into()
-    }
-
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-        let secret_key_ref_schema = generator.subschema_for::<SecretKeySelector>();
-
-        schemars::json_schema!({
-            "x-kubernetes-int-or-string": true,
-            "oneOf": [
-                { "type": "string" },
-                {
-                    "type": "object",
-                    "required": ["secretKeyRef"],
-                    "properties": {
-                        "secretKeyRef": secret_key_ref_schema
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        })
-    }
 }
 
 /// Reference to a Kubernetes Secret in the same namespace.
@@ -600,7 +581,7 @@ pub enum ConnectionValidationError {
     #[error("connection: exactly one of secretRef or params must be set, but neither was provided")]
     NeitherModeSet,
 
-    #[error("connection.params.{field}: secretKeyRef {detail}")]
+    #[error("connection.params.{field}: secret {detail}")]
     EmptySecretKeyRef { field: String, detail: String },
 
     #[error(
@@ -610,6 +591,14 @@ pub enum ConnectionValidationError {
 
     #[error("connection.params.{field}: literal value must not be empty or whitespace-only")]
     EmptyLiteral { field: String },
+
+    #[error("connection.params: exactly one of {field} or {field}Secret must be set")]
+    NeitherFieldSet { field: String },
+
+    #[error(
+        "connection.params: only one of {field} or {field}Secret may be set, but both were provided"
+    )]
+    BothFieldsSet { field: String },
 }
 
 /// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules:
@@ -1019,53 +1008,101 @@ impl PostgresPolicySpec {
                 Ok(())
             }
             (None, Some(params)) => {
-                // Params mode — validate all values have non-empty content.
-                fn validate_value_source(
+                // Validate a required field pair: exactly one must be set.
+                fn validate_required_field(
                     field: &str,
-                    value: &ValueSource,
+                    literal: &Option<String>,
+                    secret: &Option<SecretKeySelector>,
                 ) -> Result<(), ConnectionValidationError> {
-                    match value {
-                        ValueSource::Literal(s) if s.trim().is_empty() => {
-                            return Err(ConnectionValidationError::EmptyLiteral {
+                    match (literal, secret) {
+                        (Some(_), Some(_)) => {
+                            return Err(ConnectionValidationError::BothFieldsSet {
                                 field: field.to_string(),
                             });
                         }
-                        ValueSource::SecretRef { secret_key_ref } => {
-                            if secret_key_ref.name.is_empty() {
-                                return Err(ConnectionValidationError::EmptySecretKeyRef {
+                        (None, None) => {
+                            return Err(ConnectionValidationError::NeitherFieldSet {
+                                field: field.to_string(),
+                            });
+                        }
+                        (Some(s), None) => {
+                            if s.trim().is_empty() {
+                                return Err(ConnectionValidationError::EmptyLiteral {
                                     field: field.to_string(),
-                                    detail: "name must not be empty".to_string(),
-                                });
-                            }
-                            if secret_key_ref.key.is_empty() {
-                                return Err(ConnectionValidationError::EmptySecretKeyRef {
-                                    field: field.to_string(),
-                                    detail: "key must not be empty".to_string(),
                                 });
                             }
                         }
-                        _ => {}
+                        (None, Some(sel)) => {
+                            validate_secret_selector(field, sel)?;
+                        }
                     }
                     Ok(())
                 }
 
-                validate_value_source("host", &params.host)?;
-                validate_value_source("dbname", &params.dbname)?;
-                validate_value_source("username", &params.username)?;
-                validate_value_source("password", &params.password)?;
-                if let Some(ref port) = params.port {
-                    validate_value_source("port", port)?;
-                }
-                if let Some(ref ssl_mode) = params.ssl_mode {
-                    validate_value_source("sslMode", ssl_mode)?;
-                    // Validate ssl_mode value if it's a literal.
-                    if let ValueSource::Literal(value) = ssl_mode
-                        && !VALID_SSL_MODES.contains(&value.as_str())
-                    {
-                        return Err(ConnectionValidationError::InvalidSslMode {
-                            value: value.clone(),
+                // Validate an optional field pair: at most one may be set.
+                fn validate_optional_field(
+                    field: &str,
+                    literal: &Option<impl AsRef<str>>,
+                    secret: &Option<SecretKeySelector>,
+                ) -> Result<(), ConnectionValidationError> {
+                    let has_literal = literal.is_some();
+                    if has_literal && secret.is_some() {
+                        return Err(ConnectionValidationError::BothFieldsSet {
+                            field: field.to_string(),
                         });
                     }
+                    if let Some(s) = literal
+                        && s.as_ref().trim().is_empty()
+                    {
+                        return Err(ConnectionValidationError::EmptyLiteral {
+                            field: field.to_string(),
+                        });
+                    }
+                    if let Some(sel) = secret {
+                        validate_secret_selector(field, sel)?;
+                    }
+                    Ok(())
+                }
+
+                fn validate_secret_selector(
+                    field: &str,
+                    sel: &SecretKeySelector,
+                ) -> Result<(), ConnectionValidationError> {
+                    if sel.name.trim().is_empty() {
+                        return Err(ConnectionValidationError::EmptySecretKeyRef {
+                            field: field.to_string(),
+                            detail: "name must not be empty".to_string(),
+                        });
+                    }
+                    if sel.key.trim().is_empty() {
+                        return Err(ConnectionValidationError::EmptySecretKeyRef {
+                            field: field.to_string(),
+                            detail: "key must not be empty".to_string(),
+                        });
+                    }
+                    Ok(())
+                }
+
+                // Required fields: host, dbname, username, password.
+                validate_required_field("host", &params.host, &params.host_secret)?;
+                validate_required_field("dbname", &params.dbname, &params.dbname_secret)?;
+                validate_required_field("username", &params.username, &params.username_secret)?;
+                validate_required_field("password", &params.password, &params.password_secret)?;
+
+                // Optional fields: port, sslMode.
+                // Port is u16 so we wrap it for the generic check.
+                let port_str = params.port.map(|p| p.to_string());
+                validate_optional_field("port", &port_str, &params.port_secret)?;
+
+                validate_optional_field("sslMode", &params.ssl_mode, &params.ssl_mode_secret)?;
+
+                // Validate sslMode value if it's a literal.
+                if let Some(value) = &params.ssl_mode
+                    && !VALID_SSL_MODES.contains(&value.as_str())
+                {
+                    return Err(ConnectionValidationError::InvalidSslMode {
+                        value: value.clone(),
+                    });
                 }
 
                 Ok(())
@@ -1602,29 +1639,39 @@ mod tests {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("my-host".into()),
+                host: Some("my-host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("mydb".into()),
-                username: ValueSource::Literal("secret=creds\0password".into()),
-                password: ValueSource::Literal("pass".into()),
+                port_secret: None,
+                dbname: Some("mydb".into()),
+                dbname_secret: None,
+                username: Some("secret=creds\0password".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
                 ssl_mode: None,
+                ssl_mode_secret: None,
             }),
         };
         let secret_conn = ConnectionSpec {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("my-host".into()),
+                host: Some("my-host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("mydb".into()),
-                username: ValueSource::SecretRef {
-                    secret_key_ref: SecretKeySelector {
-                        name: "creds".into(),
-                        key: "password".into(),
-                    },
-                },
-                password: ValueSource::Literal("pass".into()),
+                port_secret: None,
+                dbname: Some("mydb".into()),
+                dbname_secret: None,
+                username: None,
+                username_secret: Some(SecretKeySelector {
+                    name: "creds".into(),
+                    key: "password".into(),
+                }),
+                password: Some("pass".into()),
+                password_secret: None,
                 ssl_mode: None,
+                ssl_mode_secret: None,
             }),
         };
 
@@ -1641,24 +1688,36 @@ mod tests {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("host".into()),
+                host: Some("host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("db".into()),
-                username: ValueSource::Literal("user".into()),
-                password: ValueSource::Literal("pass".into()),
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
                 ssl_mode: None,
+                ssl_mode_secret: None,
             }),
         };
         let conn_with_ssl = ConnectionSpec {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("host".into()),
+                host: Some("host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("db".into()),
-                username: ValueSource::Literal("user".into()),
-                password: ValueSource::Literal("pass".into()),
-                ssl_mode: Some(ValueSource::Literal("require".into())),
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
+                ssl_mode: Some("require".into()),
+                ssl_mode_secret: None,
             }),
         };
 
@@ -1671,33 +1730,24 @@ mod tests {
 
     #[test]
     fn validate_connection_rejects_empty_literal_host() {
-        let spec = PostgresPolicySpec {
-            connection: ConnectionSpec {
-                secret_ref: None,
-                secret_key: None,
-                params: Some(ConnectionParams {
-                    host: ValueSource::Literal("".into()),
-                    port: None,
-                    dbname: ValueSource::Literal("mydb".into()),
-                    username: ValueSource::Literal("user".into()),
-                    password: ValueSource::Literal("pass".into()),
-                    ssl_mode: None,
-                }),
-            },
-            interval: "5m".into(),
-            suspend: false,
-            mode: PolicyMode::Apply,
-            reconciliation_mode: CrdReconciliationMode::default(),
-            default_owner: None,
-            profiles: Default::default(),
-            schemas: vec![],
-            roles: vec![],
-            grants: vec![],
-            default_privileges: vec![],
-            memberships: vec![],
-            retirements: vec![],
-            approval: None,
-        };
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("mydb".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
 
         let err = spec.validate_connection_spec().unwrap_err();
         assert!(
@@ -1708,33 +1758,24 @@ mod tests {
 
     #[test]
     fn validate_connection_rejects_whitespace_literal_dbname() {
-        let spec = PostgresPolicySpec {
-            connection: ConnectionSpec {
-                secret_ref: None,
-                secret_key: None,
-                params: Some(ConnectionParams {
-                    host: ValueSource::Literal("host".into()),
-                    port: None,
-                    dbname: ValueSource::Literal("  ".into()),
-                    username: ValueSource::Literal("user".into()),
-                    password: ValueSource::Literal("pass".into()),
-                    ssl_mode: None,
-                }),
-            },
-            interval: "5m".into(),
-            suspend: false,
-            mode: PolicyMode::Apply,
-            reconciliation_mode: CrdReconciliationMode::default(),
-            default_owner: None,
-            profiles: Default::default(),
-            schemas: vec![],
-            roles: vec![],
-            grants: vec![],
-            default_privileges: vec![],
-            memberships: vec![],
-            retirements: vec![],
-            approval: None,
-        };
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("host".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("  ".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
 
         let err = spec.validate_connection_spec().unwrap_err();
         assert!(
@@ -1778,22 +1819,24 @@ mod tests {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("my-postgres".into()),
+                host: Some("my-postgres".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("mydb".into()),
-                username: ValueSource::SecretRef {
-                    secret_key_ref: SecretKeySelector {
-                        name: "pg-creds".into(),
-                        key: "username".into(),
-                    },
-                },
-                password: ValueSource::SecretRef {
-                    secret_key_ref: SecretKeySelector {
-                        name: "pg-creds".into(),
-                        key: "password".into(),
-                    },
-                },
+                port_secret: None,
+                dbname: Some("mydb".into()),
+                dbname_secret: None,
+                username: None,
+                username_secret: Some(SecretKeySelector {
+                    name: "pg-creds".into(),
+                    key: "username".into(),
+                }),
+                password: None,
+                password_secret: Some(SecretKeySelector {
+                    name: "pg-creds".into(),
+                    key: "password".into(),
+                }),
                 ssl_mode: None,
+                ssl_mode_secret: None,
             }),
         }
     }
@@ -1820,12 +1863,18 @@ mod tests {
             }),
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("host".into()),
+                host: Some("host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("db".into()),
-                username: ValueSource::Literal("user".into()),
-                password: ValueSource::Literal("pass".into()),
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
                 ssl_mode: None,
+                ssl_mode_secret: None,
             }),
         });
         assert!(matches!(
@@ -1850,12 +1899,18 @@ mod tests {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("host".into()),
+                host: Some("host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("db".into()),
-                username: ValueSource::Literal("user".into()),
-                password: ValueSource::Literal("pass".into()),
-                ssl_mode: Some(ValueSource::Literal("invalid-mode".into())),
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
+                ssl_mode: Some("invalid-mode".into()),
+                ssl_mode_secret: None,
             }),
         });
         assert!(spec.validate_connection_spec().is_err());
@@ -1875,12 +1930,18 @@ mod tests {
                 secret_ref: None,
                 secret_key: None,
                 params: Some(ConnectionParams {
-                    host: ValueSource::Literal("host".into()),
+                    host: Some("host".into()),
+                    host_secret: None,
                     port: None,
-                    dbname: ValueSource::Literal("db".into()),
-                    username: ValueSource::Literal("user".into()),
-                    password: ValueSource::Literal("pass".into()),
-                    ssl_mode: Some(ValueSource::Literal((*mode).into())),
+                    port_secret: None,
+                    dbname: Some("db".into()),
+                    dbname_secret: None,
+                    username: Some("user".into()),
+                    username_secret: None,
+                    password: Some("pass".into()),
+                    password_secret: None,
+                    ssl_mode: Some((*mode).into()),
+                    ssl_mode_secret: None,
                 }),
             });
             assert!(
@@ -1891,51 +1952,84 @@ mod tests {
     }
 
     #[test]
-    fn validate_connection_rejects_empty_secret_key_ref_name() {
+    fn validate_connection_rejects_empty_secret_name() {
         let spec = spec_with_connection(ConnectionSpec {
             secret_ref: None,
             secret_key: None,
             params: Some(ConnectionParams {
-                host: ValueSource::Literal("host".into()),
+                host: Some("host".into()),
+                host_secret: None,
                 port: None,
-                dbname: ValueSource::Literal("db".into()),
-                username: ValueSource::SecretRef {
-                    secret_key_ref: SecretKeySelector {
-                        name: "".into(),
-                        key: "username".into(),
-                    },
-                },
-                password: ValueSource::Literal("pass".into()),
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: None,
+                username_secret: Some(SecretKeySelector {
+                    name: "".into(),
+                    key: "username".into(),
+                }),
+                password: Some("pass".into()),
+                password_secret: None,
                 ssl_mode: None,
+                ssl_mode_secret: None,
             }),
         });
         assert!(spec.validate_connection_spec().is_err());
     }
 
-    // -- ValueSource serde tests ---------------------------------------------
-
     #[test]
-    fn value_source_deserializes_plain_string() {
-        let yaml = r#""my-host""#;
-        let vs: ValueSource = serde_yaml::from_str(yaml).unwrap();
-        assert!(matches!(vs, ValueSource::Literal(ref s) if s == "my-host"));
+    fn validate_connection_rejects_both_literal_and_secret_for_same_field() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("host".into()),
+                host_secret: Some(SecretKeySelector {
+                    name: "s".into(),
+                    key: "k".into(),
+                }),
+                port: None,
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
+        assert!(matches!(
+            spec.validate_connection_spec(),
+            Err(ConnectionValidationError::BothFieldsSet { ref field }) if field == "host"
+        ));
     }
 
     #[test]
-    fn value_source_deserializes_secret_key_ref() {
-        let yaml = r#"
-secretKeyRef:
-  name: my-secret
-  key: password
-"#;
-        let vs: ValueSource = serde_yaml::from_str(yaml).unwrap();
-        match vs {
-            ValueSource::SecretRef { secret_key_ref } => {
-                assert_eq!(secret_key_ref.name, "my-secret");
-                assert_eq!(secret_key_ref.key, "password");
-            }
-            _ => panic!("expected SecretRef variant"),
-        }
+    fn validate_connection_rejects_neither_literal_nor_secret_for_required_field() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: None,
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("db".into()),
+                dbname_secret: None,
+                username: Some("user".into()),
+                username_secret: None,
+                password: Some("pass".into()),
+                password_secret: None,
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
+        assert!(matches!(
+            spec.validate_connection_spec(),
+            Err(ConnectionValidationError::NeitherFieldSet { ref field }) if field == "host"
+        ));
     }
 
     // -- ConnectionSpec backward compatibility --------------------------------
@@ -1965,28 +2059,58 @@ secretRef:
     }
 
     #[test]
-    fn connection_spec_params_mode_deserializes() {
+    fn connection_spec_params_mode_deserializes_keycloak_style() {
         let yaml = r#"
 params:
   host: my-postgres
-  port: "5432"
+  port: 5432
   dbname: mydb
-  username:
-    secretKeyRef:
-      name: creds
-      key: username
-  password:
-    secretKeyRef:
-      name: creds
-      key: password
+  usernameSecret:
+    name: creds
+    key: username
+  passwordSecret:
+    name: creds
+    key: password
   sslMode: require
 "#;
         let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
         assert!(conn.secret_ref.is_none());
         let params = conn.params.unwrap();
-        assert!(matches!(params.host, ValueSource::Literal(ref s) if s == "my-postgres"));
-        assert!(matches!(params.username, ValueSource::SecretRef { .. }));
-        assert!(matches!(params.ssl_mode, Some(ValueSource::Literal(ref s)) if s == "require"));
+        assert_eq!(params.host.as_deref(), Some("my-postgres"));
+        assert_eq!(params.port, Some(5432));
+        assert!(params.username_secret.is_some());
+        assert_eq!(params.username_secret.as_ref().unwrap().name, "creds");
+        assert_eq!(params.ssl_mode.as_deref(), Some("require"));
+    }
+
+    #[test]
+    fn connection_spec_params_mode_all_secrets() {
+        // CNPG/PGO pattern — everything from one secret.
+        let yaml = r#"
+params:
+  hostSecret:
+    name: cluster-app
+    key: host
+  portSecret:
+    name: cluster-app
+    key: port
+  dbnameSecret:
+    name: cluster-app
+    key: dbname
+  usernameSecret:
+    name: cluster-app
+    key: user
+  passwordSecret:
+    name: cluster-app
+    key: password
+"#;
+        let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
+        let params = conn.params.unwrap();
+        assert!(params.host.is_none());
+        assert!(params.host_secret.is_some());
+        assert_eq!(params.host_secret.as_ref().unwrap().name, "cluster-app");
+        assert!(params.port.is_none());
+        assert!(params.port_secret.is_some());
     }
 
     // -- referenced_secret_names with params mode ----------------------------
@@ -2050,6 +2174,10 @@ params:
         assert!(
             params.port.is_none(),
             "port should default to None (resolved as 5432 at runtime)"
+        );
+        assert!(
+            params.port_secret.is_none(),
+            "portSecret should also default to None"
         );
     }
 

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -184,20 +184,182 @@ impl From<CrdReconciliationMode> for pgroles_core::diff::ReconciliationMode {
 }
 
 /// Database connection configuration.
+///
+/// Supports two mutually exclusive modes:
+///
+/// **Mode 1 — Single URL** (backward-compatible):
+/// ```yaml
+/// connection:
+///   secretRef: { name: my-secret }
+///   secretKey: DATABASE_URL        # optional, defaults to DATABASE_URL
+/// ```
+///
+/// **Mode 2 — Structured params** (for Zalando/CNPG/PGO secrets):
+/// ```yaml
+/// connection:
+///   params:
+///     host: partly-postgres
+///     port: "5432"
+///     dbname: partly
+///     username:
+///       secretKeyRef: { name: zalando-creds, key: username }
+///     password:
+///       secretKeyRef: { name: zalando-creds, key: password }
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionSpec {
-    /// Reference to a Kubernetes Secret containing the connection string.
-    /// The secret must have a key named `DATABASE_URL`.
-    pub secret_ref: SecretReference,
+    /// Reference to a Kubernetes Secret containing a connection URL.
+    /// Mutually exclusive with `params`.
+    #[serde(default)]
+    pub secret_ref: Option<SecretReference>,
 
-    /// Override the key in the Secret to read. Defaults to `DATABASE_URL`.
-    #[serde(default = "default_secret_key")]
-    pub secret_key: String,
+    /// Key within the Secret to read. Defaults to `DATABASE_URL`.
+    /// Only used with `secretRef`.
+    #[serde(default)]
+    pub secret_key: Option<String>,
+
+    /// Structured connection parameters. Each field is either a plain string
+    /// or a reference to a Secret key. Mutually exclusive with `secretRef`.
+    #[serde(default)]
+    pub params: Option<ConnectionParams>,
 }
 
-fn default_secret_key() -> String {
-    "DATABASE_URL".to_string()
+impl ConnectionSpec {
+    /// Effective secret key for URL mode. Defaults to `DATABASE_URL`.
+    pub fn effective_secret_key(&self) -> &str {
+        self.secret_key.as_deref().unwrap_or("DATABASE_URL")
+    }
+
+    /// Collect all Secret names referenced by this connection spec.
+    pub fn collect_secret_names(&self, names: &mut BTreeSet<String>) {
+        if let Some(ref secret_ref) = self.secret_ref {
+            names.insert(secret_ref.name.clone());
+        }
+        if let Some(ref params) = self.params {
+            params.host.collect_secret_name(names);
+            if let Some(ref port) = params.port {
+                port.collect_secret_name(names);
+            }
+            params.dbname.collect_secret_name(names);
+            params.username.collect_secret_name(names);
+            params.password.collect_secret_name(names);
+            if let Some(ref ssl_mode) = params.ssl_mode {
+                ssl_mode.collect_secret_name(names);
+            }
+        }
+    }
+
+    /// Deterministic identity key for this connection spec.
+    ///
+    /// - URL mode: `{secret_ref.name}/{secret_key}`
+    /// - Params mode: canonical representation of the params
+    pub fn identity_key(&self) -> String {
+        if let Some(ref secret_ref) = self.secret_ref {
+            format!("{}/{}", secret_ref.name, self.effective_secret_key())
+        } else if let Some(ref params) = self.params {
+            format!(
+                "params:{}:{}:{}:{}",
+                params.host.identity_repr(),
+                params.dbname.identity_repr(),
+                params.username.identity_repr(),
+                params
+                    .port
+                    .as_ref()
+                    .map(|p| p.identity_repr())
+                    .unwrap_or_else(|| "5432".to_string()),
+            )
+        } else {
+            // Fallback for invalid specs (missing both modes).
+            "invalid-connection".to_string()
+        }
+    }
+
+    /// Cache key for pool lookup. Same as identity_key but could diverge if
+    /// needed in the future.
+    pub fn cache_key(&self, namespace: &str) -> String {
+        format!("{namespace}/{}", self.identity_key())
+    }
+}
+
+impl ValueSource {
+    /// Deterministic string representation for identity/cache keys.
+    pub fn identity_repr(&self) -> String {
+        match self {
+            ValueSource::Literal(value) => value.clone(),
+            ValueSource::SecretRef { secret_key_ref } => {
+                format!("secret:{}:{}", secret_key_ref.name, secret_key_ref.key)
+            }
+        }
+    }
+}
+
+impl ValueSource {
+    /// If this is a SecretRef, add the secret name to the set.
+    pub fn collect_secret_name(&self, names: &mut BTreeSet<String>) {
+        if let ValueSource::SecretRef { secret_key_ref } = self {
+            names.insert(secret_key_ref.name.clone());
+        }
+    }
+}
+
+/// Structured connection parameters for building a PostgreSQL connection URL.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionParams {
+    /// PostgreSQL host (e.g. `partly-postgres` — K8s DNS, namespace-relative).
+    pub host: ValueSource,
+
+    /// Port number. Defaults to `5432` if omitted.
+    #[serde(default)]
+    pub port: Option<ValueSource>,
+
+    /// Database name.
+    pub dbname: ValueSource,
+
+    /// Username for authentication.
+    pub username: ValueSource,
+
+    /// Password for authentication.
+    pub password: ValueSource,
+
+    /// SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.
+    #[serde(default)]
+    pub ssl_mode: Option<ValueSource>,
+}
+
+/// A value that can come from a literal string or a Secret key reference.
+///
+/// Supports shorthand for the common case:
+/// ```yaml
+/// # Literal string (shorthand)
+/// host: partly-postgres
+///
+/// # Secret reference
+/// password:
+///   secretKeyRef:
+///     name: my-creds
+///     key: password
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ValueSource {
+    /// A literal string value.
+    Literal(String),
+    /// A reference to a key in a Kubernetes Secret.
+    SecretRef {
+        #[serde(rename = "secretKeyRef")]
+        secret_key_ref: SecretKeySelector,
+    },
+}
+
+/// Reference to a specific key within a Kubernetes Secret.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SecretKeySelector {
+    /// Name of the Secret.
+    pub name: String,
+    /// Key within the Secret.
+    pub key: String,
 }
 
 /// Reference to a Kubernetes Secret in the same namespace.
@@ -366,6 +528,24 @@ pub enum PasswordValidationError {
         "role \"{role}\" password.generate.secretKey \"{key}\" is reserved for the SCRAM verifier"
     )]
     ReservedGeneratedSecretKey { role: String, key: String },
+}
+
+/// Errors from connection spec validation.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ConnectionValidationError {
+    #[error("connection: exactly one of secretRef or params must be set, but both were provided")]
+    BothModesSet,
+
+    #[error("connection: exactly one of secretRef or params must be set, but neither was provided")]
+    NeitherModeSet,
+
+    #[error("connection.params.{field}: secretKeyRef {detail}")]
+    EmptySecretKeyRef { field: String, detail: String },
+
+    #[error(
+        "connection.params.sslMode: \"{value}\" is not valid (expected one of: disable, allow, prefer, require, verify-ca, verify-full)"
+    )]
+    InvalidSslMode { value: String },
 }
 
 /// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules:
@@ -645,8 +825,9 @@ impl std::fmt::Display for PlanPhase {
 pub struct DatabaseIdentity(String);
 
 impl DatabaseIdentity {
-    pub fn new(namespace: &str, secret_name: &str, secret_key: &str) -> Self {
-        Self(format!("{namespace}/{secret_name}/{secret_key}"))
+    /// Create a database identity from the namespace and connection spec's identity key.
+    pub fn from_connection(namespace: &str, connection: &ConnectionSpec) -> Self {
+        Self(format!("{namespace}/{}", connection.identity_key()))
     }
 
     pub fn as_str(&self) -> &str {
@@ -762,6 +943,74 @@ impl PostgresPolicySpec {
         Ok(())
     }
 
+    /// Validate the connection spec.
+    ///
+    /// Ensures exactly one of `secretRef` or `params` is set, and that params
+    /// mode has all required fields with valid values.
+    pub fn validate_connection_spec(&self) -> Result<(), ConnectionValidationError> {
+        let conn = &self.connection;
+        match (&conn.secret_ref, &conn.params) {
+            (Some(_), None) => {
+                // URL mode — valid.
+                Ok(())
+            }
+            (None, Some(params)) => {
+                // Params mode — validate all secretKeyRef values have non-empty name/key.
+                fn validate_value_source(
+                    field: &str,
+                    value: &ValueSource,
+                ) -> Result<(), ConnectionValidationError> {
+                    if let ValueSource::SecretRef { secret_key_ref } = value {
+                        if secret_key_ref.name.is_empty() {
+                            return Err(ConnectionValidationError::EmptySecretKeyRef {
+                                field: field.to_string(),
+                                detail: "name must not be empty".to_string(),
+                            });
+                        }
+                        if secret_key_ref.key.is_empty() {
+                            return Err(ConnectionValidationError::EmptySecretKeyRef {
+                                field: field.to_string(),
+                                detail: "key must not be empty".to_string(),
+                            });
+                        }
+                    }
+                    Ok(())
+                }
+
+                validate_value_source("host", &params.host)?;
+                validate_value_source("dbname", &params.dbname)?;
+                validate_value_source("username", &params.username)?;
+                validate_value_source("password", &params.password)?;
+                if let Some(ref port) = params.port {
+                    validate_value_source("port", port)?;
+                }
+                if let Some(ref ssl_mode) = params.ssl_mode {
+                    validate_value_source("sslMode", ssl_mode)?;
+                    // Validate ssl_mode value if it's a literal.
+                    if let ValueSource::Literal(value) = ssl_mode {
+                        const VALID_SSL_MODES: &[&str] = &[
+                            "disable",
+                            "allow",
+                            "prefer",
+                            "require",
+                            "verify-ca",
+                            "verify-full",
+                        ];
+                        if !VALID_SSL_MODES.contains(&value.as_str()) {
+                            return Err(ConnectionValidationError::InvalidSslMode {
+                                value: value.clone(),
+                            });
+                        }
+                    }
+                }
+
+                Ok(())
+            }
+            (Some(_), Some(_)) => Err(ConnectionValidationError::BothModesSet),
+            (None, None) => Err(ConnectionValidationError::NeitherModeSet),
+        }
+    }
+
     /// All Kubernetes Secret names referenced by this spec.
     ///
     /// Includes the connection Secret, password `secretRef` Secrets, and
@@ -769,7 +1018,8 @@ impl PostgresPolicySpec {
     /// reconciliation when any of these Secrets change (or are deleted).
     pub fn referenced_secret_names(&self, policy_name: &str) -> BTreeSet<String> {
         let mut names = BTreeSet::new();
-        names.insert(self.connection.secret_ref.name.clone());
+        // Connection secrets — either URL mode or structured params.
+        self.connection.collect_secret_names(&mut names);
         for role in &self.roles {
             if let Some(pw) = &role.password {
                 if let Some(secret_ref) = &pw.secret_ref {
@@ -1098,10 +1348,11 @@ mod tests {
     fn spec_to_policy_manifest_roundtrip() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-secret".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1198,10 +1449,11 @@ mod tests {
 
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-secret".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1266,8 +1518,15 @@ mod tests {
     }
 
     #[test]
-    fn database_identity_uses_namespace_secret_and_key() {
-        let identity = DatabaseIdentity::new("prod", "db-creds", "DATABASE_URL");
+    fn database_identity_uses_namespace_and_identity_key() {
+        let conn = ConnectionSpec {
+            secret_ref: Some(SecretReference {
+                name: "db-creds".to_string(),
+            }),
+            secret_key: Some("DATABASE_URL".to_string()),
+            params: None,
+        };
+        let identity = DatabaseIdentity::from_connection("prod", &conn);
         assert_eq!(identity.as_str(), "prod/db-creds/DATABASE_URL");
     }
 
@@ -1370,17 +1629,38 @@ mod tests {
 
     #[test]
     fn database_identity_equality() {
-        let a = DatabaseIdentity::new("prod", "db-creds", "DATABASE_URL");
-        let b = DatabaseIdentity::new("prod", "db-creds", "DATABASE_URL");
-        let c = DatabaseIdentity::new("staging", "db-creds", "DATABASE_URL");
+        let conn_a = ConnectionSpec {
+            secret_ref: Some(SecretReference {
+                name: "db-creds".to_string(),
+            }),
+            secret_key: Some("DATABASE_URL".to_string()),
+            params: None,
+        };
+        let a = DatabaseIdentity::from_connection("prod", &conn_a);
+        let b = DatabaseIdentity::from_connection("prod", &conn_a);
+        let c = DatabaseIdentity::from_connection("staging", &conn_a);
         assert_eq!(a, b);
         assert_ne!(a, c);
     }
 
     #[test]
     fn database_identity_different_key() {
-        let a = DatabaseIdentity::new("prod", "db-creds", "DATABASE_URL");
-        let b = DatabaseIdentity::new("prod", "db-creds", "CUSTOM_URL");
+        let conn_a = ConnectionSpec {
+            secret_ref: Some(SecretReference {
+                name: "db-creds".to_string(),
+            }),
+            secret_key: Some("DATABASE_URL".to_string()),
+            params: None,
+        };
+        let conn_b = ConnectionSpec {
+            secret_ref: Some(SecretReference {
+                name: "db-creds".to_string(),
+            }),
+            secret_key: Some("CUSTOM_URL".to_string()),
+            params: None,
+        };
+        let a = DatabaseIdentity::from_connection("prod", &conn_a);
+        let b = DatabaseIdentity::from_connection("prod", &conn_b);
         assert_ne!(a, b);
     }
 
@@ -1717,10 +1997,11 @@ retirements:
     fn referenced_secret_names_includes_connection_secret() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1746,10 +2027,11 @@ retirements:
     fn referenced_secret_names_includes_password_secrets() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1841,10 +2123,11 @@ retirements:
     fn validate_password_specs_rejects_password_without_login() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1890,10 +2173,11 @@ retirements:
     fn validate_password_specs_rejects_password_with_login_omitted() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1939,10 +2223,11 @@ retirements:
     fn validate_password_specs_rejects_invalid_password_mode() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -1992,10 +2277,11 @@ retirements:
     fn validate_password_specs_rejects_invalid_generated_length() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -2043,10 +2329,11 @@ retirements:
     fn validate_password_specs_rejects_invalid_generated_secret_key() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -2095,10 +2382,11 @@ retirements:
     fn validate_password_specs_rejects_invalid_generated_secret_name() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -2146,10 +2434,11 @@ retirements:
     fn validate_password_specs_rejects_reserved_generated_secret_key() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "pg-conn".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,
@@ -2226,10 +2515,11 @@ retirements:
     fn effective_approval_infers_from_mode() {
         let base = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "test".into(),
-                },
-                secret_key: "DATABASE_URL".into(),
+                }),
+                secret_key: Some("DATABASE_URL".into()),
+                params: None,
             },
             interval: "5m".into(),
             suspend: false,
@@ -2338,10 +2628,11 @@ retirements:
     fn effective_approval_explicit_auto_overrides_plan_mode() {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "test".into(),
-                },
-                secret_key: "DATABASE_URL".into(),
+                }),
+                secret_key: Some("DATABASE_URL".into()),
+                params: None,
             },
             interval: "5m".into(),
             suspend: false,

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -1743,6 +1743,316 @@ mod tests {
         );
     }
 
+    /// Helper to build a minimal spec with the given connection and no roles/grants.
+    fn spec_with_connection(connection: ConnectionSpec) -> PostgresPolicySpec {
+        PostgresPolicySpec {
+            connection,
+            interval: "5m".into(),
+            suspend: false,
+            mode: PolicyMode::Apply,
+            reconciliation_mode: CrdReconciliationMode::default(),
+            default_owner: None,
+            profiles: Default::default(),
+            schemas: vec![],
+            roles: vec![],
+            grants: vec![],
+            default_privileges: vec![],
+            memberships: vec![],
+            retirements: vec![],
+            approval: None,
+        }
+    }
+
+    fn url_mode_connection() -> ConnectionSpec {
+        ConnectionSpec {
+            secret_ref: Some(SecretReference {
+                name: "pg-creds".into(),
+            }),
+            secret_key: Some("DATABASE_URL".into()),
+            params: None,
+        }
+    }
+
+    fn params_mode_connection() -> ConnectionSpec {
+        ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("my-postgres".into()),
+                port: None,
+                dbname: ValueSource::Literal("mydb".into()),
+                username: ValueSource::SecretRef {
+                    secret_key_ref: SecretKeySelector {
+                        name: "pg-creds".into(),
+                        key: "username".into(),
+                    },
+                },
+                password: ValueSource::SecretRef {
+                    secret_key_ref: SecretKeySelector {
+                        name: "pg-creds".into(),
+                        key: "password".into(),
+                    },
+                },
+                ssl_mode: None,
+            }),
+        }
+    }
+
+    // -- Connection validation tests -----------------------------------------
+
+    #[test]
+    fn validate_connection_accepts_url_mode() {
+        let spec = spec_with_connection(url_mode_connection());
+        assert!(spec.validate_connection_spec().is_ok());
+    }
+
+    #[test]
+    fn validate_connection_accepts_params_mode() {
+        let spec = spec_with_connection(params_mode_connection());
+        assert!(spec.validate_connection_spec().is_ok());
+    }
+
+    #[test]
+    fn validate_connection_rejects_both_modes_set() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: Some(SecretReference {
+                name: "pg-creds".into(),
+            }),
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("host".into()),
+                port: None,
+                dbname: ValueSource::Literal("db".into()),
+                username: ValueSource::Literal("user".into()),
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: None,
+            }),
+        });
+        assert!(matches!(
+            spec.validate_connection_spec(),
+            Err(ConnectionValidationError::BothModesSet)
+        ));
+    }
+
+    #[test]
+    fn validate_connection_rejects_neither_mode_set() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: None,
+        });
+        assert!(spec.validate_connection_spec().is_err());
+    }
+
+    #[test]
+    fn validate_connection_rejects_invalid_ssl_mode() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("host".into()),
+                port: None,
+                dbname: ValueSource::Literal("db".into()),
+                username: ValueSource::Literal("user".into()),
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: Some(ValueSource::Literal("invalid-mode".into())),
+            }),
+        });
+        assert!(spec.validate_connection_spec().is_err());
+    }
+
+    #[test]
+    fn validate_connection_accepts_valid_ssl_modes() {
+        for mode in &[
+            "disable",
+            "allow",
+            "prefer",
+            "require",
+            "verify-ca",
+            "verify-full",
+        ] {
+            let spec = spec_with_connection(ConnectionSpec {
+                secret_ref: None,
+                secret_key: None,
+                params: Some(ConnectionParams {
+                    host: ValueSource::Literal("host".into()),
+                    port: None,
+                    dbname: ValueSource::Literal("db".into()),
+                    username: ValueSource::Literal("user".into()),
+                    password: ValueSource::Literal("pass".into()),
+                    ssl_mode: Some(ValueSource::Literal((*mode).into())),
+                }),
+            });
+            assert!(
+                spec.validate_connection_spec().is_ok(),
+                "sslMode '{mode}' should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_connection_rejects_empty_secret_key_ref_name() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("host".into()),
+                port: None,
+                dbname: ValueSource::Literal("db".into()),
+                username: ValueSource::SecretRef {
+                    secret_key_ref: SecretKeySelector {
+                        name: "".into(),
+                        key: "username".into(),
+                    },
+                },
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: None,
+            }),
+        });
+        assert!(spec.validate_connection_spec().is_err());
+    }
+
+    // -- ValueSource serde tests ---------------------------------------------
+
+    #[test]
+    fn value_source_deserializes_plain_string() {
+        let yaml = r#""my-host""#;
+        let vs: ValueSource = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(vs, ValueSource::Literal(ref s) if s == "my-host"));
+    }
+
+    #[test]
+    fn value_source_deserializes_secret_key_ref() {
+        let yaml = r#"
+secretKeyRef:
+  name: my-secret
+  key: password
+"#;
+        let vs: ValueSource = serde_yaml::from_str(yaml).unwrap();
+        match vs {
+            ValueSource::SecretRef { secret_key_ref } => {
+                assert_eq!(secret_key_ref.name, "my-secret");
+                assert_eq!(secret_key_ref.key, "password");
+            }
+            _ => panic!("expected SecretRef variant"),
+        }
+    }
+
+    // -- ConnectionSpec backward compatibility --------------------------------
+
+    #[test]
+    fn connection_spec_backward_compat_url_mode() {
+        // The old format with required secretRef should still deserialize.
+        let yaml = r#"
+secretRef:
+  name: pg-creds
+secretKey: DATABASE_URL
+"#;
+        let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
+        assert!(conn.secret_ref.is_some());
+        assert_eq!(conn.effective_secret_key(), "DATABASE_URL");
+        assert!(conn.params.is_none());
+    }
+
+    #[test]
+    fn connection_spec_backward_compat_default_secret_key() {
+        let yaml = r#"
+secretRef:
+  name: pg-creds
+"#;
+        let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(conn.effective_secret_key(), "DATABASE_URL");
+    }
+
+    #[test]
+    fn connection_spec_params_mode_deserializes() {
+        let yaml = r#"
+params:
+  host: my-postgres
+  port: "5432"
+  dbname: mydb
+  username:
+    secretKeyRef:
+      name: creds
+      key: username
+  password:
+    secretKeyRef:
+      name: creds
+      key: password
+  sslMode: require
+"#;
+        let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
+        assert!(conn.secret_ref.is_none());
+        let params = conn.params.unwrap();
+        assert!(matches!(params.host, ValueSource::Literal(ref s) if s == "my-postgres"));
+        assert!(matches!(params.username, ValueSource::SecretRef { .. }));
+        assert!(matches!(params.ssl_mode, Some(ValueSource::Literal(ref s)) if s == "require"));
+    }
+
+    // -- referenced_secret_names with params mode ----------------------------
+
+    #[test]
+    fn referenced_secret_names_includes_params_secrets() {
+        let spec = spec_with_connection(params_mode_connection());
+        let names = spec.referenced_secret_names("test-policy");
+        assert!(
+            names.contains("pg-creds"),
+            "should include the credential secret from params"
+        );
+    }
+
+    #[test]
+    fn referenced_secret_names_deduplicates_across_modes() {
+        // Same secret name used in both connection and password secretRef.
+        let mut spec = spec_with_connection(params_mode_connection());
+        spec.roles = vec![RoleSpec {
+            name: "app".into(),
+            login: Some(true),
+            password: Some(PasswordSpec {
+                secret_ref: Some(SecretReference {
+                    name: "pg-creds".into(),
+                }),
+                secret_key: Some("app-password".into()),
+                generate: None,
+            }),
+            password_valid_until: None,
+            superuser: None,
+            createdb: None,
+            createrole: None,
+            inherit: None,
+            replication: None,
+            bypassrls: None,
+            connection_limit: None,
+            comment: None,
+        }];
+        let names = spec.referenced_secret_names("test-policy");
+        // pg-creds appears in both connection params and password — should be deduped.
+        assert_eq!(
+            names.iter().filter(|n| *n == "pg-creds").count(),
+            1,
+            "BTreeSet should deduplicate"
+        );
+    }
+
+    // -- ConnectionParams port default ---------------------------------------
+
+    #[test]
+    fn connection_params_port_defaults_to_none() {
+        let yaml = r#"
+params:
+  host: my-host
+  dbname: mydb
+  username: user
+  password: pass
+"#;
+        let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
+        let params = conn.params.unwrap();
+        assert!(
+            params.port.is_none(),
+            "port should default to None (resolved as 5432 at runtime)"
+        );
+    }
+
     #[test]
     fn now_rfc3339_produces_valid_format() {
         let ts = now_rfc3339();

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -13,6 +13,16 @@ use pgroles_core::manifest::{
     DefaultPrivilege, Grant, Membership, ObjectType, Privilege, RoleRetirement, SchemaBinding,
 };
 
+/// Valid PostgreSQL SSL modes for connection params.
+pub const VALID_SSL_MODES: &[&str] = &[
+    "disable",
+    "allow",
+    "prefer",
+    "require",
+    "verify-ca",
+    "verify-full",
+];
+
 // ---------------------------------------------------------------------------
 // CRD spec
 // ---------------------------------------------------------------------------
@@ -254,12 +264,15 @@ impl ConnectionSpec {
     ///
     /// - URL mode: `{secret_ref.name}/{secret_key}`
     /// - Params mode: canonical representation of the params
+    ///
+    /// Uses `\0` as field separator since null bytes cannot appear in K8s names
+    /// or secret values, avoiding ambiguity from colons in literal values.
     pub fn identity_key(&self) -> String {
         if let Some(ref secret_ref) = self.secret_ref {
             format!("{}/{}", secret_ref.name, self.effective_secret_key())
         } else if let Some(ref params) = self.params {
             format!(
-                "params:{}:{}:{}:{}",
+                "params\0{}\0{}\0{}\0{}",
                 params.host.identity_repr(),
                 params.dbname.identity_repr(),
                 params.username.identity_repr(),
@@ -275,20 +288,32 @@ impl ConnectionSpec {
         }
     }
 
-    /// Cache key for pool lookup. Same as identity_key but could diverge if
-    /// needed in the future.
+    /// Cache key for pool lookup. Includes all params (identity + sslMode + port)
+    /// so that any configuration change invalidates the cached pool.
     pub fn cache_key(&self, namespace: &str) -> String {
-        format!("{namespace}/{}", self.identity_key())
+        if let Some(ref params) = self.params {
+            let ssl_part = params
+                .ssl_mode
+                .as_ref()
+                .map(|s| s.identity_repr())
+                .unwrap_or_default();
+            format!("{namespace}/{}\0ssl={ssl_part}", self.identity_key())
+        } else {
+            format!("{namespace}/{}", self.identity_key())
+        }
     }
 }
 
 impl ValueSource {
     /// Deterministic string representation for identity/cache keys.
+    ///
+    /// Uses a `literal=` / `secret=` prefix scheme so that a literal value
+    /// can never collide with a secret reference representation.
     pub fn identity_repr(&self) -> String {
         match self {
-            ValueSource::Literal(value) => value.clone(),
+            ValueSource::Literal(value) => format!("literal={value}"),
             ValueSource::SecretRef { secret_key_ref } => {
-                format!("secret:{}:{}", secret_key_ref.name, secret_key_ref.key)
+                format!("secret={}\0{}", secret_key_ref.name, secret_key_ref.key)
             }
         }
     }
@@ -341,7 +366,7 @@ pub struct ConnectionParams {
 ///     name: my-creds
 ///     key: password
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ValueSource {
     /// A literal string value.
@@ -360,6 +385,42 @@ pub struct SecretKeySelector {
     pub name: String,
     /// Key within the Secret.
     pub key: String,
+}
+
+/// Manual `JsonSchema` implementation for [`ValueSource`].
+///
+/// The derived schema for `#[serde(untagged)]` enums produces `type: object`
+/// which causes the K8s API server to reject plain string literals like
+/// `host: "my-cluster"`. We use `x-kubernetes-int-or-string` to tell the API
+/// server this field accepts heterogeneous types (string or object), and add
+/// a `oneOf` for documentation/validation.
+impl schemars::JsonSchema for ValueSource {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ValueSource".into()
+    }
+
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        concat!(module_path!(), "::ValueSource").into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let secret_key_ref_schema = generator.subschema_for::<SecretKeySelector>();
+
+        schemars::json_schema!({
+            "x-kubernetes-int-or-string": true,
+            "oneOf": [
+                { "type": "string" },
+                {
+                    "type": "object",
+                    "required": ["secretKeyRef"],
+                    "properties": {
+                        "secretKeyRef": secret_key_ref_schema
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        })
+    }
 }
 
 /// Reference to a Kubernetes Secret in the same namespace.
@@ -546,6 +607,9 @@ pub enum ConnectionValidationError {
         "connection.params.sslMode: \"{value}\" is not valid (expected one of: disable, allow, prefer, require, verify-ca, verify-full)"
     )]
     InvalidSslMode { value: String },
+
+    #[error("connection.params.{field}: literal value must not be empty or whitespace-only")]
+    EmptyLiteral { field: String },
 }
 
 /// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules:
@@ -955,24 +1019,32 @@ impl PostgresPolicySpec {
                 Ok(())
             }
             (None, Some(params)) => {
-                // Params mode — validate all secretKeyRef values have non-empty name/key.
+                // Params mode — validate all values have non-empty content.
                 fn validate_value_source(
                     field: &str,
                     value: &ValueSource,
                 ) -> Result<(), ConnectionValidationError> {
-                    if let ValueSource::SecretRef { secret_key_ref } = value {
-                        if secret_key_ref.name.is_empty() {
-                            return Err(ConnectionValidationError::EmptySecretKeyRef {
+                    match value {
+                        ValueSource::Literal(s) if s.trim().is_empty() => {
+                            return Err(ConnectionValidationError::EmptyLiteral {
                                 field: field.to_string(),
-                                detail: "name must not be empty".to_string(),
                             });
                         }
-                        if secret_key_ref.key.is_empty() {
-                            return Err(ConnectionValidationError::EmptySecretKeyRef {
-                                field: field.to_string(),
-                                detail: "key must not be empty".to_string(),
-                            });
+                        ValueSource::SecretRef { secret_key_ref } => {
+                            if secret_key_ref.name.is_empty() {
+                                return Err(ConnectionValidationError::EmptySecretKeyRef {
+                                    field: field.to_string(),
+                                    detail: "name must not be empty".to_string(),
+                                });
+                            }
+                            if secret_key_ref.key.is_empty() {
+                                return Err(ConnectionValidationError::EmptySecretKeyRef {
+                                    field: field.to_string(),
+                                    detail: "key must not be empty".to_string(),
+                                });
+                            }
                         }
+                        _ => {}
                     }
                     Ok(())
                 }
@@ -987,20 +1059,12 @@ impl PostgresPolicySpec {
                 if let Some(ref ssl_mode) = params.ssl_mode {
                     validate_value_source("sslMode", ssl_mode)?;
                     // Validate ssl_mode value if it's a literal.
-                    if let ValueSource::Literal(value) = ssl_mode {
-                        const VALID_SSL_MODES: &[&str] = &[
-                            "disable",
-                            "allow",
-                            "prefer",
-                            "require",
-                            "verify-ca",
-                            "verify-full",
-                        ];
-                        if !VALID_SSL_MODES.contains(&value.as_str()) {
-                            return Err(ConnectionValidationError::InvalidSslMode {
-                                value: value.clone(),
-                            });
-                        }
+                    if let ValueSource::Literal(value) = ssl_mode
+                        && !VALID_SSL_MODES.contains(&value.as_str())
+                    {
+                        return Err(ConnectionValidationError::InvalidSslMode {
+                            value: value.clone(),
+                        });
                     }
                 }
 
@@ -1528,6 +1592,155 @@ mod tests {
         };
         let identity = DatabaseIdentity::from_connection("prod", &conn);
         assert_eq!(identity.as_str(), "prod/db-creds/DATABASE_URL");
+    }
+
+    #[test]
+    fn identity_key_no_collision_between_literal_and_secret() {
+        // A literal value containing "secret=" should not collide with a
+        // real secret reference.
+        let literal_conn = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("my-host".into()),
+                port: None,
+                dbname: ValueSource::Literal("mydb".into()),
+                username: ValueSource::Literal("secret=creds\0password".into()),
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: None,
+            }),
+        };
+        let secret_conn = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("my-host".into()),
+                port: None,
+                dbname: ValueSource::Literal("mydb".into()),
+                username: ValueSource::SecretRef {
+                    secret_key_ref: SecretKeySelector {
+                        name: "creds".into(),
+                        key: "password".into(),
+                    },
+                },
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: None,
+            }),
+        };
+
+        assert_ne!(
+            literal_conn.identity_key(),
+            secret_conn.identity_key(),
+            "literal and secret ref should produce different identity keys"
+        );
+    }
+
+    #[test]
+    fn cache_key_includes_ssl_mode() {
+        let conn_no_ssl = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("host".into()),
+                port: None,
+                dbname: ValueSource::Literal("db".into()),
+                username: ValueSource::Literal("user".into()),
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: None,
+            }),
+        };
+        let conn_with_ssl = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: ValueSource::Literal("host".into()),
+                port: None,
+                dbname: ValueSource::Literal("db".into()),
+                username: ValueSource::Literal("user".into()),
+                password: ValueSource::Literal("pass".into()),
+                ssl_mode: Some(ValueSource::Literal("require".into())),
+            }),
+        };
+
+        assert_ne!(
+            conn_no_ssl.cache_key("ns"),
+            conn_with_ssl.cache_key("ns"),
+            "cache key should differ when sslMode is present"
+        );
+    }
+
+    #[test]
+    fn validate_connection_rejects_empty_literal_host() {
+        let spec = PostgresPolicySpec {
+            connection: ConnectionSpec {
+                secret_ref: None,
+                secret_key: None,
+                params: Some(ConnectionParams {
+                    host: ValueSource::Literal("".into()),
+                    port: None,
+                    dbname: ValueSource::Literal("mydb".into()),
+                    username: ValueSource::Literal("user".into()),
+                    password: ValueSource::Literal("pass".into()),
+                    ssl_mode: None,
+                }),
+            },
+            interval: "5m".into(),
+            suspend: false,
+            mode: PolicyMode::Apply,
+            reconciliation_mode: CrdReconciliationMode::default(),
+            default_owner: None,
+            profiles: Default::default(),
+            schemas: vec![],
+            roles: vec![],
+            grants: vec![],
+            default_privileges: vec![],
+            memberships: vec![],
+            retirements: vec![],
+            approval: None,
+        };
+
+        let err = spec.validate_connection_spec().unwrap_err();
+        assert!(
+            matches!(err, ConnectionValidationError::EmptyLiteral { ref field } if field == "host"),
+            "expected EmptyLiteral for host, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_connection_rejects_whitespace_literal_dbname() {
+        let spec = PostgresPolicySpec {
+            connection: ConnectionSpec {
+                secret_ref: None,
+                secret_key: None,
+                params: Some(ConnectionParams {
+                    host: ValueSource::Literal("host".into()),
+                    port: None,
+                    dbname: ValueSource::Literal("  ".into()),
+                    username: ValueSource::Literal("user".into()),
+                    password: ValueSource::Literal("pass".into()),
+                    ssl_mode: None,
+                }),
+            },
+            interval: "5m".into(),
+            suspend: false,
+            mode: PolicyMode::Apply,
+            reconciliation_mode: CrdReconciliationMode::default(),
+            default_owner: None,
+            profiles: Default::default(),
+            schemas: vec![],
+            roles: vec![],
+            grants: vec![],
+            default_privileges: vec![],
+            memberships: vec![],
+            retirements: vec![],
+            approval: None,
+        };
+
+        let err = spec.validate_connection_spec().unwrap_err();
+        assert!(
+            matches!(err, ConnectionValidationError::EmptyLiteral { ref field } if field == "dbname"),
+            "expected EmptyLiteral for dbname, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -198,9 +198,9 @@ impl From<CrdReconciliationMode> for pgroles_core::diff::ReconciliationMode {
 /// ```yaml
 /// connection:
 ///   params:
-///     host: partly-postgres
+///     host: my-cluster-postgres
 ///     port: "5432"
-///     dbname: partly
+///     dbname: mydb
 ///     username:
 ///       secretKeyRef: { name: zalando-creds, key: username }
 ///     password:
@@ -307,7 +307,7 @@ impl ValueSource {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionParams {
-    /// PostgreSQL host (e.g. `partly-postgres` — K8s DNS, namespace-relative).
+    /// PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).
     pub host: ValueSource,
 
     /// Port number. Defaults to `5432` if omitted.
@@ -333,7 +333,7 @@ pub struct ConnectionParams {
 /// Supports shorthand for the common case:
 /// ```yaml
 /// # Literal string (shorthand)
-/// host: partly-postgres
+/// host: my-cluster-postgres
 ///
 /// # Secret reference
 /// password:

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -268,35 +268,45 @@ impl ConnectionSpec {
     ///
     /// Uses `\0` as field separator since null bytes cannot appear in K8s names
     /// or secret values, avoiding ambiguity from colons in literal values.
+    /// Deterministic identity key for per-database locking and conflict detection.
+    ///
+    /// Identifies the target database (host + port + dbname) but NOT the
+    /// credentials. Two policies targeting the same database with different
+    /// users should still be considered as targeting the same database for
+    /// locking and overlap checks.
     pub fn identity_key(&self) -> String {
         if let Some(ref secret_ref) = self.secret_ref {
             format!("{}/{}", secret_ref.name, self.effective_secret_key())
         } else if let Some(ref params) = self.params {
-            format!(
-                "params\0{}\0{}\0{}\0{}",
-                field_identity_repr(&params.host, &params.host_secret),
-                field_identity_repr(&params.dbname, &params.dbname_secret),
-                field_identity_repr(&params.username, &params.username_secret),
-                params
-                    .port
-                    .as_ref()
-                    .map(|p| format!("literal={p}"))
-                    .or_else(|| params
+            let port_part = params
+                .port
+                .as_ref()
+                .map(|p| format!("literal={p}"))
+                .or_else(|| {
+                    params
                         .port_secret
                         .as_ref()
-                        .map(|s| format!("secret={}\0{}", s.name, s.key)))
-                    .unwrap_or_else(|| "5432".to_string()),
+                        .map(|s| format!("secret={}\0{}", s.name, s.key))
+                })
+                .unwrap_or_else(|| "5432".to_string());
+            format!(
+                "params\0{}\0{}\0{}",
+                field_identity_repr(&params.host, &params.host_secret),
+                field_identity_repr(&params.dbname, &params.dbname_secret),
+                port_part,
             )
         } else {
-            // Fallback for invalid specs (missing both modes).
             "invalid-connection".to_string()
         }
     }
 
-    /// Cache key for pool lookup. Includes all params (identity + sslMode + password)
-    /// so that any configuration change invalidates the cached pool.
+    /// Cache key for pool lookup. Includes ALL connection params so that any
+    /// configuration change (credentials, sslMode, host, etc.) invalidates
+    /// the cached pool. This is strictly more specific than `identity_key`.
     pub fn cache_key(&self, namespace: &str) -> String {
         if let Some(ref params) = self.params {
+            let user_part = field_identity_repr(&params.username, &params.username_secret);
+            let pass_part = field_identity_repr(&params.password, &params.password_secret);
             let ssl_part = params
                 .ssl_mode
                 .as_ref()
@@ -308,7 +318,10 @@ impl ConnectionSpec {
                         .map(|s| format!("secret={}\0{}", s.name, s.key))
                 })
                 .unwrap_or_default();
-            format!("{namespace}/{}\0ssl={ssl_part}", self.identity_key())
+            format!(
+                "{namespace}/{}\0user={user_part}\0pass={pass_part}\0ssl={ssl_part}",
+                self.identity_key()
+            )
         } else {
             format!("{namespace}/{}", self.identity_key())
         }
@@ -1632,9 +1645,63 @@ mod tests {
     }
 
     #[test]
-    fn identity_key_no_collision_between_literal_and_secret() {
-        // A literal value containing "secret=" should not collide with a
-        // real secret reference.
+    fn identity_key_same_database_different_users_are_equal() {
+        // Two policies targeting the same database but with different users
+        // should have the SAME identity key (for locking/conflict detection).
+        let user_a = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("my-host".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("mydb".into()),
+                dbname_secret: None,
+                username: Some("alice".into()),
+                username_secret: None,
+                password: Some("pass-a".into()),
+                password_secret: None,
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        };
+        let user_b = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("my-host".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("mydb".into()),
+                dbname_secret: None,
+                username: Some("bob".into()),
+                username_secret: None,
+                password: Some("pass-b".into()),
+                password_secret: None,
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        };
+
+        assert_eq!(
+            user_a.identity_key(),
+            user_b.identity_key(),
+            "same database with different users should have the same identity key"
+        );
+        // But cache keys should differ (different credentials = different pool).
+        assert_ne!(
+            user_a.cache_key("default"),
+            user_b.cache_key("default"),
+            "different credentials should produce different cache keys"
+        );
+    }
+
+    #[test]
+    fn cache_key_no_collision_between_literal_and_secret_username() {
+        // A literal username containing "secret=" should not collide with a
+        // real secret reference in the cache key.
         let literal_conn = ConnectionSpec {
             secret_ref: None,
             secret_key: None,
@@ -1676,9 +1743,9 @@ mod tests {
         };
 
         assert_ne!(
-            literal_conn.identity_key(),
-            secret_conn.identity_key(),
-            "literal and secret ref should produce different identity keys"
+            literal_conn.cache_key("default"),
+            secret_conn.cache_key("default"),
+            "literal and secret ref should produce different cache keys"
         );
     }
 

--- a/crates/pgroles-operator/src/main.rs
+++ b/crates/pgroles-operator/src/main.rs
@@ -214,10 +214,11 @@ mod tests {
     fn test_policy() -> PostgresPolicy {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "db-credentials".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: "5m".to_string(),
             suspend: false,

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -368,6 +368,8 @@ fn retry_class_for_reconcile_error(error: &ReconcileError) -> RetryClass {
                 }
             }
             ContextError::DatabaseConnect { .. } => RetryClass::Transient,
+            ContextError::EmptyResolvedValue { .. }
+            | ContextError::InvalidResolvedSslMode { .. } => RetryClass::Slow,
         },
         ReconcileError::Inspect(error) => {
             if inspect_error_is_non_transient(error) {
@@ -2026,6 +2028,8 @@ impl ReconcileError {
                 ContextError::SecretFetch { .. } => "SecretFetchFailed",
                 ContextError::SecretMissing { .. } => "SecretMissing",
                 ContextError::DatabaseConnect { .. } => "DatabaseConnectionFailed",
+                ContextError::EmptyResolvedValue { .. } => "InvalidConnectionParams",
+                ContextError::InvalidResolvedSslMode { .. } => "InvalidConnectionParams",
             },
             ReconcileError::Inspect(error) => match error {
                 pgroles_inspect::InspectError::Database(sql_err) => {

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -3117,6 +3117,45 @@ mod tests {
     }
 
     #[test]
+    fn retry_classifies_empty_resolved_value_as_slow() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
+            crate::context::ContextError::EmptyResolvedValue {
+                field: "password".to_string(),
+            },
+        )));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
+    }
+
+    #[test]
+    fn error_reason_empty_resolved_value() {
+        let err =
+            ReconcileError::Context(Box::new(crate::context::ContextError::EmptyResolvedValue {
+                field: "host".to_string(),
+            }));
+        assert_eq!(err.reason(), "InvalidConnectionParams");
+    }
+
+    #[test]
+    fn retry_classifies_invalid_resolved_ssl_mode_as_slow() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
+            crate::context::ContextError::InvalidResolvedSslMode {
+                value: "bogus".to_string(),
+            },
+        )));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
+    }
+
+    #[test]
+    fn error_reason_invalid_resolved_ssl_mode() {
+        let err = ReconcileError::Context(Box::new(
+            crate::context::ContextError::InvalidResolvedSslMode {
+                value: "bogus".to_string(),
+            },
+        ));
+        assert_eq!(err.reason(), "InvalidConnectionParams");
+    }
+
+    #[test]
     fn error_reason_sql_exec_transient_is_apply_failed() {
         let err = ReconcileError::SqlExec(transient_sqlx_error());
         assert_eq!(err.reason(), "ApplyFailed");

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -520,11 +520,7 @@ async fn reconcile_apply(
 
     // Derive database identity early so we can acquire the in-process lock.
     let namespace = resource.namespace().ok_or(ReconcileError::NoNamespace)?;
-    let identity = DatabaseIdentity::new(
-        &namespace,
-        &resource.spec.connection.secret_ref.name,
-        &resource.spec.connection.secret_key,
-    );
+    let identity = DatabaseIdentity::from_connection(&namespace, &resource.spec.connection);
 
     // Acquire in-process lock for this database target.
     let _db_lock = match ctx.try_lock_database(identity.as_str()).await {
@@ -655,6 +651,8 @@ async fn reconcile_apply_inner(
     })
     .await?;
 
+    spec.validate_connection_spec()
+        .map_err(|err| ReconcileError::InvalidSpec(err.to_string()))?;
     spec.validate_password_specs(&name)
         .map_err(|err| ReconcileError::InvalidSpec(err.to_string()))?;
 
@@ -707,11 +705,7 @@ async fn reconcile_apply_inner(
 
     // 4. Get a database pool.
     let pool = ctx
-        .get_or_create_pool(
-            &namespace,
-            &spec.connection.secret_ref.name,
-            &spec.connection.secret_key,
-        )
+        .get_or_create_pool(&namespace, &spec.connection)
         .await
         .map_err(Box::new)?;
 
@@ -1738,13 +1732,8 @@ async fn reconcile_cleanup(
 
     info!(name, namespace, "cleaning up (resource deleted)");
 
-    // Evict any cached pool for this resource's secret.
-    ctx.evict_pool(
-        &namespace,
-        &resource.spec.connection.secret_ref.name,
-        &resource.spec.connection.secret_key,
-    )
-    .await;
+    // Evict any cached pool for this resource's connection.
+    ctx.evict_pool(&namespace, &resource.spec.connection).await;
 
     // Note: we do NOT revoke grants on deletion. The resource being deleted
     // means the user no longer wants pgroles to manage these roles — it does
@@ -1981,11 +1970,7 @@ fn detect_policy_conflict_in_list(
             continue;
         }
 
-        let other_identity = DatabaseIdentity::new(
-            &other_ns,
-            &other.spec.connection.secret_ref.name,
-            &other.spec.connection.secret_key,
-        );
+        let other_identity = DatabaseIdentity::from_connection(&other_ns, &other.spec.connection);
         if &other_identity != identity {
             continue;
         }
@@ -2171,10 +2156,11 @@ mod tests {
     fn test_policy(interval: &str, transient_failure_count: i32) -> Arc<PostgresPolicy> {
         let spec = PostgresPolicySpec {
             connection: ConnectionSpec {
-                secret_ref: SecretReference {
+                secret_ref: Some(SecretReference {
                     name: "db-credentials".to_string(),
-                },
-                secret_key: "DATABASE_URL".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
             },
             interval: interval.to_string(),
             suspend: false,
@@ -2210,10 +2196,11 @@ mod tests {
             name,
             PostgresPolicySpec {
                 connection: ConnectionSpec {
-                    secret_ref: SecretReference {
+                    secret_ref: Some(SecretReference {
                         name: secret_name.to_string(),
-                    },
-                    secret_key: "DATABASE_URL".to_string(),
+                    }),
+                    secret_key: Some("DATABASE_URL".to_string()),
+                    params: None,
                 },
                 interval: "5m".to_string(),
                 suspend: false,
@@ -2250,10 +2237,11 @@ mod tests {
             name,
             PostgresPolicySpec {
                 connection: ConnectionSpec {
-                    secret_ref: SecretReference {
+                    secret_ref: Some(SecretReference {
                         name: secret_name.to_string(),
-                    },
-                    secret_key: "DATABASE_URL".to_string(),
+                    }),
+                    secret_key: Some("DATABASE_URL".to_string()),
+                    params: None,
                 },
                 interval: "5m".to_string(),
                 suspend: false,
@@ -2282,10 +2270,11 @@ mod tests {
             "password-policy",
             PostgresPolicySpec {
                 connection: ConnectionSpec {
-                    secret_ref: SecretReference {
+                    secret_ref: Some(SecretReference {
                         name: "db-credentials".to_string(),
-                    },
-                    secret_key: "DATABASE_URL".to_string(),
+                    }),
+                    secret_key: Some("DATABASE_URL".to_string()),
+                    params: None,
                 },
                 interval: "5m".to_string(),
                 suspend: false,
@@ -3311,7 +3300,7 @@ mod tests {
     #[test]
     fn conflict_detection_ignores_invalid_peer_policies() {
         let resource = valid_role_policy("valid-policy", "analytics", "shared-db-secret");
-        let identity = DatabaseIdentity::new("default", "shared-db-secret", "DATABASE_URL");
+        let identity = DatabaseIdentity::from_connection("default", &resource.spec.connection);
         let ownership = resource.spec.ownership_claims().unwrap();
         let invalid_peer = invalid_profile_policy("invalid-peer", "shared-db-secret");
 
@@ -3549,7 +3538,7 @@ mod tests {
     #[test]
     fn conflict_detection_still_reports_overlapping_valid_peers() {
         let resource = valid_role_policy("valid-policy", "analytics", "shared-db-secret");
-        let identity = DatabaseIdentity::new("default", "shared-db-secret", "DATABASE_URL");
+        let identity = DatabaseIdentity::from_connection("default", &resource.spec.connection);
         let ownership = resource.spec.ownership_claims().unwrap();
         let overlapping_peer =
             valid_role_policy("overlapping-peer", "analytics", "shared-db-secret");

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -157,7 +157,7 @@ Scheduled coverage on `main` additionally exercises:
 
 ## Custom resource
 
-A `PostgresPolicy` spec mirrors the CLI manifest format with added Kubernetes-specific fields for connection and scheduling.
+A `PostgresPolicy` spec mirrors the CLI manifest format with added Kubernetes-specific fields for connection and scheduling. The example below uses a connection URL Secret; see [Database connection](#database-connection) for structured parameter support (Zalando, CloudNativePG, PGO).
 
 ```yaml
 apiVersion: pgroles.io/v1alpha1
@@ -222,7 +222,11 @@ spec:
       drop_owned: true
 ```
 
-### Database secret
+### Database connection
+
+The operator supports two connection modes: a single connection URL from a Secret, or structured parameters with separate fields for host, port, database, and credentials.
+
+#### Connection URL (single Secret)
 
 Create a Secret containing your PostgreSQL connection string:
 
@@ -231,7 +235,71 @@ kubectl create secret generic mydb-credentials \
   --from-literal=DATABASE_URL='postgresql://user:password@host:5432/database'
 ```
 
-The operator reads the Secret from the same namespace as the `PostgresPolicy` resource. When the Secret's `resourceVersion` changes (e.g. credential rotation), the operator automatically reconnects with updated credentials.
+Reference it in the policy:
+
+```yaml
+connection:
+  secretRef:
+    name: mydb-credentials
+  secretKey: DATABASE_URL  # optional, defaults to DATABASE_URL
+```
+
+When the Secret's `resourceVersion` changes (e.g. credential rotation), the operator automatically reconnects with updated credentials.
+
+#### Structured parameters
+
+Use `connection.params` to build the connection from individual fields. Each field is either a literal value or a reference to a key in a Kubernetes Secret. This integrates natively with PostgreSQL operators that create credential Secrets (Zalando, CloudNativePG, CrunchyData PGO).
+
+**Zalando postgres-operator** — credentials in a Secret, host/port/database as literals:
+
+```yaml
+connection:
+  params:
+    host: my-cluster-postgres              # K8s service name (namespace-relative)
+    port: 5432
+    dbname: mydb
+    sslMode: require
+    usernameSecret:
+      name: postgres.my-cluster-postgres.credentials.postgresql.acid.zalan.do
+      key: username
+    passwordSecret:
+      name: postgres.my-cluster-postgres.credentials.postgresql.acid.zalan.do
+      key: password
+```
+
+**CloudNativePG / CrunchyData PGO** — all fields from the operator-created Secret:
+
+```yaml
+connection:
+  params:
+    hostSecret:
+      name: cluster-example-app
+      key: host
+    dbnameSecret:
+      name: cluster-example-app
+      key: dbname
+    usernameSecret:
+      name: cluster-example-app
+      key: user
+    passwordSecret:
+      name: cluster-example-app
+      key: password
+```
+
+Each connection field supports a literal value and a `*Secret` variant:
+
+| Field | Literal | Secret | Required |
+|---|---|---|---|
+| `host` / `hostSecret` | Hostname string | SecretKeySelector | Yes (exactly one) |
+| `port` / `portSecret` | Integer (default 5432) | SecretKeySelector | No |
+| `dbname` / `dbnameSecret` | Database name | SecretKeySelector | Yes (exactly one) |
+| `username` / `usernameSecret` | Username string | SecretKeySelector | Yes (exactly one) |
+| `password` / `passwordSecret` | Password string | SecretKeySelector | Yes (exactly one) |
+| `sslMode` / `sslModeSecret` | SSL mode string | SecretKeySelector | No |
+
+Valid `sslMode` values: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.
+
+For required fields, exactly one of the literal or Secret variant must be set. For optional fields, at most one may be set. When a Secret referenced by `params` changes, the operator detects the `resourceVersion` change and reconnects automatically.
 
 ### Role passwords
 
@@ -414,6 +482,7 @@ The operator also emits transition-based Kubernetes Events such as:
 - `PlanClean`
 - `DatabaseConnectionFailed`
 - `InsufficientPrivileges`
+- `InvalidConnectionParams`
 - `MissingDatabaseObject`
 - `UnsafeRoleDropsBlocked`
 

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -83,7 +83,8 @@
                         "nullable": true,
                         "properties": {
                           "dbname": {
-                            "anyOf": [
+                            "description": "Database name.",
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -91,7 +92,6 @@
                                 ]
                               }
                             ],
-                            "description": "Database name.",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -112,10 +112,12 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "host": {
-                            "anyOf": [
+                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -123,7 +125,6 @@
                                 ]
                               }
                             ],
-                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -144,10 +145,12 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "password": {
-                            "anyOf": [
+                            "description": "Password for authentication.",
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -155,7 +158,6 @@
                                 ]
                               }
                             ],
-                            "description": "Password for authentication.",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -176,19 +178,20 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "port": {
-                            "anyOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
                             "description": "Port number. Defaults to `5432` if omitted.",
                             "nullable": true,
+                            "oneOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -209,43 +212,13 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           },
                           "sslMode": {
-                            "anyOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
                             "description": "SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.",
                             "nullable": true,
-                            "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
-                              }
-                            },
-                            "type": "object"
-                          },
-                          "username": {
-                            "anyOf": [
+                            "oneOf": [
                               {},
                               {
                                 "required": [
@@ -253,7 +226,6 @@
                                 ]
                               }
                             ],
-                            "description": "Username for authentication.",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",
@@ -274,7 +246,41 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "username": {
+                            "description": "Username for authentication.",
+                            "oneOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-int-or-string": true
                           }
                         },
                         "required": [

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -123,7 +123,7 @@
                                 ]
                               }
                             ],
-                            "description": "PostgreSQL host (e.g. `partly-postgres` — K8s DNS, namespace-relative).",
+                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
                             "properties": {
                               "secretKeyRef": {
                                 "description": "Reference to a specific key within a Kubernetes Secret.",

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -83,212 +83,153 @@
                         "nullable": true,
                         "properties": {
                           "dbname": {
-                            "description": "Database name.",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "Database name as a literal value.",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "dbnameSecret": {
+                            "description": "Database name from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "host": {
-                            "description": "PostgreSQL host (e.g. `my-cluster-postgres` — K8s DNS, namespace-relative).",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "PostgreSQL host as a literal value.",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "hostSecret": {
+                            "description": "PostgreSQL host from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "password": {
-                            "description": "Password for authentication.",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "Password as a literal value (not recommended for production).",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "passwordSecret": {
+                            "description": "Password from a Secret key (recommended).",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "port": {
-                            "description": "Port number. Defaults to `5432` if omitted.",
+                            "description": "Port as a literal value. Defaults to 5432 if neither port nor portSecret is set.",
+                            "format": "uint16",
+                            "maximum": 65535.0,
+                            "minimum": 0.0,
                             "nullable": true,
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "type": "integer"
+                          },
+                          "portSecret": {
+                            "description": "Port from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "sslMode": {
-                            "description": "SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.",
+                            "description": "SSL mode as a literal value.",
                             "nullable": true,
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "type": "string"
+                          },
+                          "sslModeSecret": {
+                            "description": "SSL mode from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "username": {
-                            "description": "Username for authentication.",
-                            "oneOf": [
-                              {},
-                              {
-                                "required": [
-                                  "secretKeyRef"
-                                ]
-                              }
-                            ],
+                            "description": "Username as a literal value.",
+                            "nullable": true,
+                            "type": "string"
+                          },
+                          "usernameSecret": {
+                            "description": "Username from a Secret key.",
+                            "nullable": true,
                             "properties": {
-                              "secretKeyRef": {
-                                "description": "Reference to a specific key within a Kubernetes Secret.",
-                                "properties": {
-                                  "key": {
-                                    "description": "Key within the Secret.",
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "description": "Name of the Secret.",
-                                    "type": "string"
-                                  }
-                                },
-                                "required": [
-                                  "key",
-                                  "name"
-                                ],
-                                "type": "object"
+                              "key": {
+                                "description": "Key within the Secret.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the Secret.",
+                                "type": "string"
                               }
                             },
-                            "type": "object",
-                            "x-kubernetes-int-or-string": true
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object"
                           }
                         },
-                        "required": [
-                          "dbname",
-                          "host",
-                          "password",
-                          "username"
-                        ],
                         "type": "object"
                       },
                       "secretKey": {

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -78,13 +78,221 @@
                   "connection": {
                     "description": "Database connection configuration.",
                     "properties": {
+                      "params": {
+                        "description": "Structured connection parameters. Each field is either a plain string\nor a reference to a Secret key. Mutually exclusive with `secretRef`.",
+                        "nullable": true,
+                        "properties": {
+                          "dbname": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Database name.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "host": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "PostgreSQL host (e.g. `partly-postgres` — K8s DNS, namespace-relative).",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "password": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Password for authentication.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Port number. Defaults to `5432` if omitted.",
+                            "nullable": true,
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "sslMode": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "SSL mode. One of: disable, allow, prefer, require, verify-ca, verify-full.",
+                            "nullable": true,
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "username": {
+                            "anyOf": [
+                              {},
+                              {
+                                "required": [
+                                  "secretKeyRef"
+                                ]
+                              }
+                            ],
+                            "description": "Username for authentication.",
+                            "properties": {
+                              "secretKeyRef": {
+                                "description": "Reference to a specific key within a Kubernetes Secret.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key within the Secret.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the Secret.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "dbname",
+                          "host",
+                          "password",
+                          "username"
+                        ],
+                        "type": "object"
+                      },
                       "secretKey": {
-                        "default": "DATABASE_URL",
-                        "description": "Override the key in the Secret to read. Defaults to `DATABASE_URL`.",
+                        "description": "Key within the Secret to read. Defaults to `DATABASE_URL`.\nOnly used with `secretRef`.",
+                        "nullable": true,
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "Reference to a Kubernetes Secret containing the connection string.\nThe secret must have a key named `DATABASE_URL`.",
+                        "description": "Reference to a Kubernetes Secret containing a connection URL.\nMutually exclusive with `params`.",
+                        "nullable": true,
                         "properties": {
                           "name": {
                             "description": "Name of the Secret.",
@@ -97,9 +305,6 @@
                         "type": "object"
                       }
                     },
-                    "required": [
-                      "secretRef"
-                    ],
                     "type": "object"
                   },
                   "default_owner": {

--- a/k8s/samples/params-connection-policy.yaml
+++ b/k8s/samples/params-connection-policy.yaml
@@ -8,16 +8,14 @@ spec:
   connection:
     params:
       host: my-cluster-postgres
-      port: "5432"
+      port: 5432
       dbname: mydb
-      username:
-        secretKeyRef:
-          name: zalando-creds
-          key: username
-      password:
-        secretKeyRef:
-          name: zalando-creds
-          key: password
+      usernameSecret:
+        name: zalando-creds
+        key: username
+      passwordSecret:
+        name: zalando-creds
+        key: password
       sslMode: require
   interval: "5m"
   default_owner: postgres

--- a/k8s/samples/params-connection-policy.yaml
+++ b/k8s/samples/params-connection-policy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: params-connection-policy
+  namespace: default
+spec:
+  connection:
+    params:
+      host: partly-postgres
+      port: "5432"
+      dbname: partly
+      username:
+        secretKeyRef:
+          name: zalando-creds
+          key: username
+      password:
+        secretKeyRef:
+          name: zalando-creds
+          key: password
+      sslMode: require
+  interval: "5m"
+  default_owner: postgres
+
+  roles:
+    - name: app_reader
+      login: false
+    - name: app_writer
+      login: false
+
+  grants:
+    - role: app_reader
+      object: { type: schema, name: public }
+      privileges: [USAGE]
+    - role: app_reader
+      object: { type: table, name: "*", schema: public }
+      privileges: [SELECT]
+    - role: app_writer
+      object: { type: schema, name: public }
+      privileges: [USAGE]
+    - role: app_writer
+      object: { type: table, name: "*", schema: public }
+      privileges: [SELECT, INSERT, UPDATE, DELETE]

--- a/k8s/samples/params-connection-policy.yaml
+++ b/k8s/samples/params-connection-policy.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   connection:
     params:
-      host: partly-postgres
+      host: my-cluster-postgres
       port: "5432"
-      dbname: partly
+      dbname: mydb
       username:
         secretKeyRef:
           name: zalando-creds

--- a/k8s/samples/params-e2e-policy.yaml
+++ b/k8s/samples/params-e2e-policy.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: params-e2e-policy
+  namespace: default
+spec:
+  connection:
+    params:
+      host: postgres.default.svc.cluster.local
+      port: 5432
+      dbname: postgres
+      sslMode: disable
+      usernameSecret:
+        name: params-pg-credentials
+        key: username
+      passwordSecret:
+        name: params-pg-credentials
+        key: password
+  interval: "15s"
+
+  roles:
+    - name: params-test-role
+      login: false
+      comment: "E2E test: role created via params connection mode"
+
+  grants:
+    - role: params-test-role
+      privileges: [CONNECT]
+      object: { type: database, name: postgres }


### PR DESCRIPTION
## Summary

Closes #86.

Adds a `params` mode to `ConnectionSpec` that constructs a PostgreSQL connection URL from individual fields. Each field can be a literal string or a `secretKeyRef`, eliminating the need for ExternalSecrets to bridge between PG operator credential formats and pgroles.

## Examples

**Zalando postgres-operator** (credentials in Secret, host/port/db known):
```yaml
connection:
  params:
    host: my-cluster-postgres
    port: "5432"
    dbname: mydb
    sslMode: require
    username:
      secretKeyRef:
        name: postgres.my-cluster-postgres.credentials.postgresql.acid.zalan.do
        key: username
    password:
      secretKeyRef:
        name: postgres.my-cluster-postgres.credentials.postgresql.acid.zalan.do
        key: password
```

**CNPG/PGO** (everything in one Secret):
```yaml
connection:
  params:
    host:
      secretKeyRef: { name: cluster-app, key: host }
    dbname:
      secretKeyRef: { name: cluster-app, key: dbname }
    username:
      secretKeyRef: { name: cluster-app, key: user }
    password:
      secretKeyRef: { name: cluster-app, key: password }
```

**Existing mode** (unchanged, backward-compatible):
```yaml
connection:
  secretRef:
    name: my-secret
  secretKey: DATABASE_URL
```

## What changed

- `ConnectionSpec` fields `secret_ref` and `secret_key` are now optional (backward-compatible via serde defaults)
- New `params: ConnectionParams` field with `host`, `port`, `dbname`, `username`, `password`, `sslMode`
- `ValueSource` untagged enum: `"literal-string"` or `{ secretKeyRef: { name, key } }`
- `resolve_connection_url()` in context.rs handles both modes, with percent-encoded credentials
- `validate_connection_spec()` enforces mutual exclusion and field presence
- Secret watcher extended for params-mode secret references
- DatabaseIdentity and pool cache key updated for both modes
- CRDs regenerated

## Test plan

- [x] `cargo fmt` / `cargo clippy -D warnings` / `cargo test --workspace` — all green
- [x] CRD drift check passes
- [ ] CI (E2E suites)
- [ ] Manual test: deploy with params mode against a Zalando-managed PG instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure PostgreSQL connections using structured params (host, port, dbname, username, password, sslMode) with fields accepting inline values or secret key references.
  * Added a sample manifest demonstrating the params-based connection mode.

* **Chores**
  * Made secretKey/secretRef optional and clarified mutual-exclusivity with params.

* **Bug Fixes**
  * Validation enforces exactly one connection mode and surfaces clearer errors for empty/invalid connection values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->