### PR TITLE
feat: manage schema ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,13 @@ jobs:
           wait_for_ready_true disjoint-policy
           assert_role_exists analytics
 
+          pg_query 'DROP SCHEMA IF EXISTS operator_owned_schema CASCADE; DROP ROLE IF EXISTS operator_schema_owner;'
+          kubectl apply -f k8s/samples/schema-owner-policy.yaml
+          wait_for_ready_true schema-owner-policy
+          assert_role_exists operator_schema_owner
+          assert_schema_exists operator_owned_schema
+          assert_schema_owner operator_owned_schema operator_schema_owner
+
           kubectl apply -f k8s/samples/second-disjoint-policy.yaml
           wait_for_ready_true second-disjoint-policy
           assert_role_exists reporting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -169,9 +169,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -261,6 +261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,10 +315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clap"
-version = "4.6.0"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -329,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -344,6 +364,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -367,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +419,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -432,6 +473,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,7 +530,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -509,10 +568,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -827,6 +898,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -911,7 +983,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -920,7 +992,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -987,6 +1068,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1533,7 +1623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1550,9 +1640,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1708,7 +1798,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.3",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -1754,12 +1844,12 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.11.2",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1827,7 +1917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1854,14 +1944,14 @@ name = "pgroles-core"
 version = "0.5.0"
 dependencies = [
  "base64",
- "hmac",
+ "hmac 0.13.0",
  "pbkdf2",
- "rand 0.9.3",
+ "rand 0.10.1",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -1873,6 +1963,7 @@ dependencies = [
  "pgroles-core",
  "sqlx",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
@@ -1893,12 +1984,12 @@ dependencies = [
  "percent-encoding",
  "pgroles-core",
  "pgroles-inspect",
- "rand 0.9.3",
+ "rand 0.10.1",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -2110,12 +2201,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2155,6 +2257,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -2277,8 +2385,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2557,8 +2665,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2568,8 +2676,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2603,7 +2722,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2690,7 +2809,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -2728,7 +2847,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -2750,7 +2869,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2760,7 +2879,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -2771,7 +2890,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2798,7 +2917,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -2808,7 +2927,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2996,9 +3115,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3013,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3229,9 +3348,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ thiserror = "2"
 anyhow = "1"
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.52.1", features = ["full"] }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "tls-rustls"] }
 
 # CLI
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
 
 # Logging / tracing
 tracing = "0.1"
@@ -43,14 +43,14 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Async utilities
 futures = "0.3"
-axum = "0.8"
+axum = "0.8.9"
 opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", features = ["metrics", "rt-tokio", "testing"] }
 opentelemetry-otlp = { version = "0.31", features = ["metrics", "grpc-tonic"] }
 
 # Kubernetes
-kube = { version = "3.0.1", features = ["runtime", "derive", "client", "unstable-runtime"] }
-k8s-openapi = { version = "0.27", features = ["latest", "schemars"] }
+kube = { version = "3.1.0", features = ["runtime", "derive", "client", "unstable-runtime"] }
+k8s-openapi = { version = "0.27.1", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Internal crates

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 Declarative PostgreSQL access control. Define roles, schema ownership, grants, and memberships in YAML — pgroles diffs against your live database and generates the exact SQL to converge it.
 
+For simple setups, use a single manifest. For larger teams, the CLI also supports bundle composition: shared profiles plus multiple scoped policy fragments merged into one desired plan with conflict checks before any database diff or apply.
+
 By default, anything not in the manifest gets revoked or dropped. Same model as Terraform, applied to PostgreSQL. For incremental adoption, use `--mode additive` to only grant and never revoke, or `--mode adopt` to manage declared roles fully without dropping undeclared ones.
 
 ## How it works
@@ -143,6 +145,7 @@ docker run --rm ghcr.io/hardbyte/pgroles --help
 - **Convergent** — the manifest is the desired state. Missing roles get created, extra roles get dropped, drifted grants get fixed.
 - **Reconciliation modes** — `--mode authoritative` (default) for full convergence, `--mode additive` to only grant and never revoke, `--mode adopt` to manage declared roles without dropping undeclared ones. Additive mode is the safest way to start using pgroles on an existing database.
 - **Profiles** — define privilege templates once, apply them across schemas. Each `schema x profile` pair becomes a role.
+- **Bundle composition** — compose shared profiles plus multiple scoped policy fragments in the CLI, with duplicate/conflict detection and managed-scope enforcement before diff or apply.
 - **Schema management** — declared schemas can be created and have ownership converged, while undeclared referenced schemas must already exist.
 - **Safer privilege bundles** — common application profiles can pair table, sequence, and function privileges so identity columns and trigger-driven routines are covered together.
 - **Brownfield adoption** — `pgroles generate` introspects an existing database and produces a manifest you can refine.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 </div>
 
-Declarative PostgreSQL access control. Define roles, grants, and memberships in YAML — pgroles diffs against your live database and generates the exact SQL to converge it.
+Declarative PostgreSQL access control. Define roles, schema ownership, grants, and memberships in YAML — pgroles diffs against your live database and generates the exact SQL to converge it.
 
 By default, anything not in the manifest gets revoked or dropped. Same model as Terraform, applied to PostgreSQL. For incremental adoption, use `--mode additive` to only grant and never revoke, or `--mode adopt` to manage declared roles fully without dropping undeclared ones.
 
@@ -50,6 +50,7 @@ profiles:
 
 schemas:
   - name: inventory
+    owner: app_owner
     profiles: [editor, viewer]
   - name: catalog
     profiles: [viewer]
@@ -64,7 +65,7 @@ memberships:
       - name: app-service
 ```
 
-This generates roles `inventory-editor`, `inventory-viewer`, and `catalog-viewer`, each scoped to their schema. `app-service` gets `inventory-editor` membership.
+This generates roles `inventory-editor`, `inventory-viewer`, and `catalog-viewer`, each scoped to their schema. pgroles will create `inventory` if it is missing and keep it owned by `app_owner`. `app-service` gets `inventory-editor` membership.
 
 Run `pgroles diff` to see exactly what SQL will be executed:
 
@@ -142,6 +143,7 @@ docker run --rm ghcr.io/hardbyte/pgroles --help
 - **Convergent** — the manifest is the desired state. Missing roles get created, extra roles get dropped, drifted grants get fixed.
 - **Reconciliation modes** — `--mode authoritative` (default) for full convergence, `--mode additive` to only grant and never revoke, `--mode adopt` to manage declared roles without dropping undeclared ones. Additive mode is the safest way to start using pgroles on an existing database.
 - **Profiles** — define privilege templates once, apply them across schemas. Each `schema x profile` pair becomes a role.
+- **Schema management** — declared schemas can be created and have ownership converged, while undeclared referenced schemas must already exist.
 - **Safer privilege bundles** — common application profiles can pair table, sequence, and function privileges so identity columns and trigger-driven routines are covered together.
 - **Brownfield adoption** — `pgroles generate` introspects an existing database and produces a manifest you can refine.
 - **Reproducible export** — `pgroles generate --output` writes the current database state directly to a manifest file.

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -809,68 +809,76 @@
                     "nullable": true,
                     "properties": {
                       "default_privileges_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "default_privileges_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_removed": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "passwords_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_altered": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_dropped": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schema_owners_altered": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schemas_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "sessions_terminated": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "total": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       }
                     },
-                    "required": [
-                      "default_privileges_revoked",
-                      "default_privileges_set",
-                      "grants_added",
-                      "grants_revoked",
-                      "members_added",
-                      "members_removed",
-                      "passwords_set",
-                      "roles_altered",
-                      "roles_created",
-                      "roles_dropped",
-                      "sessions_terminated",
-                      "total"
-                    ],
                     "type": "object"
                   },
                   "conditions": {

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -762,6 +762,7 @@
                           "type": "string"
                         },
                         "profiles": {
+                          "default": [],
                           "items": {
                             "type": "string"
                           },
@@ -774,8 +775,7 @@
                         }
                       },
                       "required": [
-                        "name",
-                        "profiles"
+                        "name"
                       ],
                       "type": "object"
                     },

--- a/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml
@@ -152,68 +152,76 @@
                     "nullable": true,
                     "properties": {
                       "default_privileges_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "default_privileges_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_removed": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "passwords_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_altered": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_dropped": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schema_owners_altered": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schemas_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "sessions_terminated": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "total": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       }
                     },
-                    "required": [
-                      "default_privileges_revoked",
-                      "default_privileges_set",
-                      "grants_added",
-                      "grants_revoked",
-                      "members_added",
-                      "members_removed",
-                      "passwords_set",
-                      "roles_altered",
-                      "roles_created",
-                      "roles_dropped",
-                      "sessions_terminated",
-                      "total"
-                    ],
                     "type": "object"
                   },
                   "computedAt": {

--- a/crates/pgroles-cli/Cargo.toml
+++ b/crates/pgroles-cli/Cargo.toml
@@ -28,6 +28,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = "2"
+assert_cmd = "2.2.1"
 predicates = "3"
 tempfile = "3"

--- a/crates/pgroles-cli/src/lib.rs
+++ b/crates/pgroles-cli/src/lib.rs
@@ -151,6 +151,8 @@ fn redacted_changes(changes: &[Change]) -> Vec<Change> {
 pub struct PlanSummary {
     pub roles_created: usize,
     pub roles_altered: usize,
+    pub schemas_created: usize,
+    pub schema_owners_altered: usize,
     pub roles_dropped: usize,
     pub comments_changed: usize,
     pub sessions_terminated: usize,
@@ -172,6 +174,8 @@ impl PlanSummary {
         for change in changes {
             match change {
                 Change::CreateRole { .. } => summary.roles_created += 1,
+                Change::CreateSchema { .. } => summary.schemas_created += 1,
+                Change::AlterSchemaOwner { .. } => summary.schema_owners_altered += 1,
                 Change::AlterRole { .. } => summary.roles_altered += 1,
                 Change::DropRole { .. } => summary.roles_dropped += 1,
                 Change::SetComment { .. } => summary.comments_changed += 1,
@@ -194,6 +198,8 @@ impl PlanSummary {
     pub fn total(&self) -> usize {
         self.roles_created
             + self.roles_altered
+            + self.schemas_created
+            + self.schema_owners_altered
             + self.roles_dropped
             + self.comments_changed
             + self.sessions_terminated
@@ -241,6 +247,8 @@ impl PlanSummary {
         let items: Vec<(&str, usize)> = vec![
             ("role(s) to create", self.roles_created),
             ("role(s) to alter", self.roles_altered),
+            ("schema(s) to create", self.schemas_created),
+            ("schema owner change(s)", self.schema_owners_altered),
             ("role(s) to drop", self.roles_dropped),
             ("comment(s) to change", self.comments_changed),
             ("session termination step(s)", self.sessions_terminated),
@@ -279,6 +287,10 @@ pub fn format_validation_result(validated: &ValidatedManifest) -> String {
     let mut output = String::new();
     output.push_str("Manifest is valid.\n");
     output.push_str(&format!(
+        "  {} schema(s) defined\n",
+        validated.expanded.schemas.len()
+    ));
+    output.push_str(&format!(
         "  {} role(s) defined\n",
         validated.expanded.roles.len()
     ));
@@ -309,6 +321,13 @@ pub fn format_role_graph_summary(graph: &RoleGraph) -> String {
         let login_marker = if state.login { "LOGIN" } else { "NOLOGIN" };
         output.push_str(&format!("  {name} ({login_marker})\n"));
     }
+    output.push_str(&format!("Schemas: {}\n", graph.schemas.len()));
+    for (name, state) in &graph.schemas {
+        match &state.owner {
+            Some(owner) => output.push_str(&format!("  {name} (owner: {owner})\n")),
+            None => output.push_str(&format!("  {name}\n")),
+        }
+    }
     output.push_str(&format!("Grants: {}\n", graph.grants.len()));
     output.push_str(&format!(
         "Default privileges: {}\n",
@@ -331,6 +350,11 @@ mod tests {
 
     const MINIMAL_MANIFEST: &str = r#"
 default_owner: app_owner
+
+schemas:
+  - name: analytics
+    owner: app_owner
+    profiles: []
 
 roles:
   - name: analytics
@@ -431,6 +455,7 @@ schemas:
     fn expand_profile_manifest() {
         let expanded = parse_and_expand(PROFILE_MANIFEST).unwrap();
 
+        assert_eq!(expanded.schemas.len(), 2);
         // inventory-editor, inventory-viewer, catalog-viewer, app-service
         assert_eq!(expanded.roles.len(), 4);
 
@@ -486,6 +511,7 @@ schemas:
 
         let summary = PlanSummary::from_changes(&changes);
         assert_eq!(summary.roles_created, 4); // inventory-editor, inventory-viewer, catalog-viewer, app-service
+        assert_eq!(summary.schemas_created, 2); // inventory, catalog
         assert!(summary.grants > 0);
         assert!(!summary.is_empty());
     }
@@ -509,6 +535,10 @@ schemas:
         let changes = compute_plan(&current, &validated.desired);
 
         let sql_output = format_plan_sql(&changes);
+        assert!(
+            sql_output.contains("CREATE SCHEMA"),
+            "expected CREATE SCHEMA in: {sql_output}"
+        );
         assert!(
             sql_output.contains("CREATE ROLE"),
             "expected CREATE ROLE in: {sql_output}"
@@ -577,13 +607,15 @@ schemas:
     fn plan_summary_display_with_changes() {
         let summary = PlanSummary {
             roles_created: 2,
+            schemas_created: 1,
             grants: 5,
             members_added: 1,
             ..Default::default()
         };
         let display = summary.to_string();
-        assert!(display.contains("8 change(s)"), "got: {display}");
+        assert!(display.contains("9 change(s)"), "got: {display}");
         assert!(display.contains("2 role(s) to create"), "got: {display}");
+        assert!(display.contains("1 schema(s) to create"), "got: {display}");
         assert!(display.contains("5 grant(s) to add"), "got: {display}");
         assert!(display.contains("1 membership(s) to add"), "got: {display}");
         // Should not mention zero-count items
@@ -600,6 +632,7 @@ schemas:
         let validated = validate_manifest(PROFILE_MANIFEST).unwrap();
         let output = format_validation_result(&validated);
         assert!(output.contains("Manifest is valid"), "got: {output}");
+        assert!(output.contains("2 schema(s)"), "got: {output}");
         assert!(output.contains("4 role(s)"), "got: {output}");
     }
 
@@ -627,6 +660,7 @@ schemas:
         let validated = validate_manifest(MINIMAL_MANIFEST).unwrap();
         let summary = format_role_graph_summary(&validated.desired);
         assert!(summary.contains("Roles: 1"), "got: {summary}");
+        assert!(summary.contains("Schemas: 1"), "got: {summary}");
         assert!(summary.contains("analytics (LOGIN)"), "got: {summary}");
     }
 
@@ -638,6 +672,7 @@ schemas:
     fn has_structural_changes_true_for_non_password_changes() {
         let summary = PlanSummary {
             roles_created: 1,
+            schemas_created: 1,
             grants: 2,
             ..Default::default()
         };
@@ -807,16 +842,18 @@ schemas:
     fn format_applied_uses_applied_header() {
         let summary = PlanSummary {
             roles_created: 1,
+            schemas_created: 1,
             grants: 2,
             ..Default::default()
         };
 
         let display = summary.format_applied();
         assert!(
-            display.starts_with("Applied: 3 change(s)\n"),
+            display.starts_with("Applied: 4 change(s)\n"),
             "got: {display}"
         );
         assert!(display.contains("1 role(s) to create"), "got: {display}");
+        assert!(display.contains("1 schema(s) to create"), "got: {display}");
         assert!(display.contains("2 grant(s) to add"), "got: {display}");
         assert!(!display.contains("Plan:"), "got: {display}");
     }

--- a/crates/pgroles-cli/src/lib.rs
+++ b/crates/pgroles-cli/src/lib.rs
@@ -8,9 +8,12 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
+use pgroles_core::composition::{self, ComposedPolicy, PolicyBundle, PolicyDocument};
 use pgroles_core::diff::{self, Change};
 use pgroles_core::manifest::{self, ExpandedManifest, PolicyManifest, RoleRetirement};
 use pgroles_core::model::RoleGraph;
+use pgroles_core::ownership::ManagedScope;
+use pgroles_core::report::{self, PlanOutputMode};
 use pgroles_core::sql;
 
 // ---------------------------------------------------------------------------
@@ -74,6 +77,52 @@ pub struct ValidatedManifest {
     pub desired: RoleGraph,
 }
 
+/// Load, validate, and compose a policy bundle from disk.
+pub fn validate_bundle_file(path: &Path) -> Result<ValidatedBundle> {
+    let yaml = read_manifest_file(path)?;
+    let bundle = composition::parse_policy_bundle(&yaml).map_err(|err| anyhow::anyhow!("{err}"))?;
+    let documents = load_policy_documents(path, &bundle)?;
+    let composed =
+        composition::compose_bundle(&bundle, &documents).map_err(|err| anyhow::anyhow!("{err}"))?;
+
+    Ok(ValidatedBundle {
+        bundle,
+        documents,
+        composed,
+    })
+}
+
+fn load_policy_documents(path: &Path, bundle: &PolicyBundle) -> Result<Vec<PolicyDocument>> {
+    let base_dir = path
+        .parent()
+        .with_context(|| format!("bundle path has no parent directory: {}", path.display()))?;
+
+    bundle
+        .sources
+        .iter()
+        .map(|source| {
+            let source_path = base_dir.join(&source.file);
+            let yaml = read_manifest_file(&source_path)?;
+            let fragment = composition::parse_policy_fragment(&yaml)
+                .map_err(|err| anyhow::anyhow!("{err}"))
+                .with_context(|| {
+                    format!("failed to parse policy document: {}", source_path.display())
+                })?;
+            Ok(PolicyDocument {
+                source: source.file.clone(),
+                fragment,
+            })
+        })
+        .collect()
+}
+
+/// The result of successfully validating a composed policy bundle.
+pub struct ValidatedBundle {
+    pub bundle: PolicyBundle,
+    pub documents: Vec<PolicyDocument>,
+    pub composed: ComposedPolicy,
+}
+
 // ---------------------------------------------------------------------------
 // Plan computation (pure — given both role graphs)
 // ---------------------------------------------------------------------------
@@ -125,25 +174,26 @@ pub fn format_plan_sql(changes: &[Change]) -> String {
 
 /// Format a plan as SQL statements using an explicit SQL context.
 pub fn format_plan_sql_with_context(changes: &[Change], ctx: &sql::SqlContext) -> String {
-    sql::render_all_with_context(&redacted_changes(changes), ctx)
+    sql::render_all_with_context(
+        &report::shape_plan_changes(changes, PlanOutputMode::Redacted),
+        ctx,
+    )
 }
 
 /// Format a plan as JSON for machine consumption.
 pub fn format_plan_json(changes: &[Change]) -> Result<String> {
-    serde_json::to_string_pretty(&redacted_changes(changes)).map_err(|err| anyhow::anyhow!("{err}"))
+    report::render_plan_json(changes, PlanOutputMode::Redacted)
+        .map_err(|err| anyhow::anyhow!("{err}"))
 }
 
-fn redacted_changes(changes: &[Change]) -> Vec<Change> {
-    changes
-        .iter()
-        .map(|change| match change {
-            Change::SetPassword { name, .. } => Change::SetPassword {
-                name: name.clone(),
-                password: "[REDACTED]".to_string(),
-            },
-            other => other.clone(),
-        })
-        .collect()
+/// Format a bundle plan as JSON with ownership annotations for each change.
+pub fn format_bundle_plan_json(changes: &[Change], composed: &ComposedPolicy) -> Result<String> {
+    report::render_bundle_plan_json(
+        changes,
+        &composed.report_context(),
+        PlanOutputMode::Redacted,
+    )
+    .map_err(|err| anyhow::anyhow!("{err}"))
 }
 
 /// Summary statistics for a plan.
@@ -182,7 +232,9 @@ impl PlanSummary {
                 Change::TerminateSessions { .. } => summary.sessions_terminated += 1,
                 Change::ReassignOwned { .. } => summary.ownerships_reassigned += 1,
                 Change::DropOwned { .. } => summary.owned_objects_dropped += 1,
-                Change::Grant { .. } => summary.grants += 1,
+                Change::Grant { .. } | Change::EnsureSchemaOwnerPrivileges { .. } => {
+                    summary.grants += 1
+                }
                 Change::Revoke { .. } => summary.revokes += 1,
                 Change::SetDefaultPrivilege { .. } => summary.default_privileges_set += 1,
                 Change::RevokeDefaultPrivilege { .. } => summary.default_privileges_revoked += 1,
@@ -309,6 +361,81 @@ pub fn format_validation_result(validated: &ValidatedManifest) -> String {
     output
 }
 
+/// Format bundle validation results for human-readable output.
+pub fn format_bundle_validation_result(validated: &ValidatedBundle) -> String {
+    let mut output = String::new();
+    output.push_str("Policy bundle is valid.\n");
+    output.push_str(&format!(
+        "  {} source document(s) loaded\n",
+        validated.documents.len()
+    ));
+    output.push_str(&format!(
+        "  {} shared profile(s) defined\n",
+        validated.bundle.shared.profiles.len()
+    ));
+    output.push_str(&format!(
+        "  {} schema(s) defined\n",
+        validated.composed.expanded.schemas.len()
+    ));
+    output.push_str(&format!(
+        "  {} role(s) defined\n",
+        validated.composed.expanded.roles.len()
+    ));
+    output.push_str(&format!(
+        "  {} grant(s) defined\n",
+        validated.composed.expanded.grants.len()
+    ));
+    output.push_str(&format!(
+        "  {} default privilege(s) defined\n",
+        validated.composed.expanded.default_privileges.len()
+    ));
+    output.push_str(&format!(
+        "  {} membership(s) defined\n",
+        validated.composed.expanded.memberships.len()
+    ));
+    output
+}
+
+/// Format a composed managed scope for human-readable debug output.
+pub fn format_managed_scope_summary(scope: &ManagedScope) -> String {
+    let mut output = String::new();
+    output.push_str("Managed scope:\n");
+    output.push_str(&format!("  {} role(s)\n", scope.roles.len()));
+    output.push_str(&format!("  {} schema(s)\n", scope.schemas.len()));
+
+    let owner_schemas: Vec<&str> = scope
+        .schemas
+        .iter()
+        .filter_map(|(schema, managed)| managed.owner.then_some(schema.as_str()))
+        .collect();
+    let binding_schemas: Vec<&str> = scope
+        .schemas
+        .iter()
+        .filter_map(|(schema, managed)| managed.bindings.then_some(schema.as_str()))
+        .collect();
+
+    output.push_str(&format!(
+        "  owner-managed schema(s): {}\n",
+        owner_schemas.len()
+    ));
+    if !owner_schemas.is_empty() {
+        output.push_str(&format!("  owner scope: {}\n", owner_schemas.join(", ")));
+    }
+
+    output.push_str(&format!(
+        "  binding-managed schema(s): {}\n",
+        binding_schemas.len()
+    ));
+    if !binding_schemas.is_empty() {
+        output.push_str(&format!(
+            "  binding scope: {}\n",
+            binding_schemas.join(", ")
+        ));
+    }
+
+    output
+}
+
 // ---------------------------------------------------------------------------
 // Inspect output formatting
 // ---------------------------------------------------------------------------
@@ -347,6 +474,7 @@ pub fn format_role_graph_summary(graph: &RoleGraph) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pgroles_core::ownership::ManagedSchemaScope;
 
     const MINIMAL_MANIFEST: &str = r#"
 default_owner: app_owner
@@ -636,6 +764,44 @@ schemas:
         assert!(output.contains("4 role(s)"), "got: {output}");
     }
 
+    #[test]
+    fn managed_scope_summary_lists_owner_and_binding_facets() {
+        let scope = ManagedScope {
+            roles: ["app".to_string(), "app_owner".to_string()]
+                .into_iter()
+                .collect(),
+            schemas: [
+                (
+                    "inventory".to_string(),
+                    ManagedSchemaScope {
+                        owner: true,
+                        bindings: true,
+                    },
+                ),
+                (
+                    "audit".to_string(),
+                    ManagedSchemaScope {
+                        owner: true,
+                        bindings: false,
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        let output = format_managed_scope_summary(&scope);
+
+        assert!(output.contains("Managed scope:"), "got: {output}");
+        assert!(output.contains("2 role(s)"), "got: {output}");
+        assert!(output.contains("2 schema(s)"), "got: {output}");
+        assert!(
+            output.contains("owner scope: audit, inventory"),
+            "got: {output}"
+        );
+        assert!(output.contains("binding scope: inventory"), "got: {output}");
+    }
+
     // -----------------------------------------------------------------------
     // read_manifest_file
     // -----------------------------------------------------------------------
@@ -824,6 +990,44 @@ schemas:
         let json = format_plan_json(&changes).expect("json formatting should succeed");
         assert!(json.contains("[REDACTED]"), "got: {json}");
         assert!(!json.contains("super-secret"), "got: {json}");
+    }
+
+    #[test]
+    fn bundle_plan_json_includes_scope_and_ownership_annotations() {
+        let bundle = composition::parse_policy_bundle(
+            r#"
+sources:
+  - file: app.yaml
+"#,
+        )
+        .unwrap();
+        let documents = vec![composition::PolicyDocument {
+            source: "app.yaml".to_string(),
+            fragment: composition::parse_policy_fragment(
+                r#"
+policy:
+  name: app
+scope:
+  roles: [app]
+roles:
+  - name: app
+    login: false
+"#,
+            )
+            .unwrap(),
+        }];
+        let composed = composition::compose_bundle(&bundle, &documents).unwrap();
+        let changes = compute_plan(&RoleGraph::default(), &composed.desired);
+
+        let json_output = format_bundle_plan_json(&changes, &composed).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_output).unwrap();
+
+        assert!(parsed.is_object());
+        assert_eq!(parsed["schema_version"], "pgroles.bundle_plan.v1");
+        assert_eq!(parsed["managed_scope"]["roles"][0], "app");
+        assert_eq!(parsed["changes"][0]["owner"]["document"], "app");
+        assert_eq!(parsed["changes"][0]["owner"]["managed_key"]["kind"], "role");
+        assert_eq!(parsed["changes"][0]["owner"]["managed_key"]["name"], "app");
     }
 
     #[test]

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -9,13 +9,15 @@ use sqlx::PgPool;
 use tracing::info;
 
 use pgroles_cli::{
-    PlanSummary, apply_role_retirements, compute_plan, format_plan_json,
+    PlanSummary, apply_role_retirements, compute_plan, format_bundle_plan_json,
+    format_bundle_validation_result, format_managed_scope_summary, format_plan_json,
     format_plan_sql_with_context, format_role_graph_summary, format_validation_result,
     inject_password_changes, planned_role_drops, read_manifest_file, resolve_passwords,
-    validate_manifest,
+    validate_bundle_file, validate_manifest,
 };
 use pgroles_core::diff::{ReconciliationMode, filter_changes};
-use pgroles_core::visual::{self, VisualSource};
+use pgroles_core::ownership::validate_changes_against_managed_surface;
+use pgroles_core::visual::{self, VisualManagedScope, VisualSource};
 use pgroles_inspect::{InspectConfig, inspect_drop_role_safety};
 
 // ---------------------------------------------------------------------------
@@ -35,11 +37,15 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Validate a manifest file (parse + expand). No database connection required.
+    /// Validate a manifest or bundle file. No database connection required.
     Validate {
         /// Path to the policy manifest YAML file.
-        #[arg(short, long, default_value = "pgroles.yaml")]
-        file: PathBuf,
+        #[arg(short, long, conflicts_with = "bundle")]
+        file: Option<PathBuf>,
+
+        /// Path to the policy bundle YAML file.
+        #[arg(long, conflicts_with = "file")]
+        bundle: Option<PathBuf>,
     },
 
     /// Show the SQL changes needed to converge the database to the manifest.
@@ -47,8 +53,12 @@ enum Commands {
     #[command(alias = "plan")]
     Diff {
         /// Path to the policy manifest YAML file.
-        #[arg(short, long, default_value = "pgroles.yaml")]
-        file: PathBuf,
+        #[arg(short, long, conflicts_with = "bundle")]
+        file: Option<PathBuf>,
+
+        /// Path to the policy bundle YAML file.
+        #[arg(long, conflicts_with = "file")]
+        bundle: Option<PathBuf>,
 
         /// PostgreSQL connection string (or set DATABASE_URL).
         #[arg(long, env = "DATABASE_URL")]
@@ -78,8 +88,12 @@ enum Commands {
     /// Apply the changes to bring the database in sync with the manifest.
     Apply {
         /// Path to the policy manifest YAML file.
-        #[arg(short, long, default_value = "pgroles.yaml")]
-        file: PathBuf,
+        #[arg(short, long, conflicts_with = "bundle")]
+        file: Option<PathBuf>,
+
+        /// Path to the policy bundle YAML file.
+        #[arg(long, conflicts_with = "file")]
+        bundle: Option<PathBuf>,
 
         /// PostgreSQL connection string (or set DATABASE_URL).
         #[arg(long, env = "DATABASE_URL")]
@@ -103,8 +117,13 @@ enum Commands {
         /// Path to policy manifest YAML. When provided, scopes output to roles
         /// and schemas declared in the manifest. When omitted, shows all
         /// non-system database roles and privileges.
-        #[arg(short, long)]
+        #[arg(short, long, conflicts_with = "bundle")]
         file: Option<PathBuf>,
+
+        /// Path to the policy bundle YAML file. When provided, scopes output to
+        /// the composed bundle ownership boundaries.
+        #[arg(long, conflicts_with = "file")]
+        bundle: Option<PathBuf>,
 
         /// PostgreSQL connection string (or set DATABASE_URL).
         #[arg(long, env = "DATABASE_URL")]
@@ -140,8 +159,12 @@ enum GraphSource {
     /// Build the graph from a manifest file (desired state).
     Desired {
         /// Path to the policy manifest YAML file.
-        #[arg(short, long, default_value = "pgroles.yaml")]
-        file: PathBuf,
+        #[arg(short, long, conflicts_with = "bundle")]
+        file: Option<PathBuf>,
+
+        /// Path to the policy bundle YAML file.
+        #[arg(long, conflicts_with = "file")]
+        bundle: Option<PathBuf>,
 
         /// Output format.
         #[arg(long, default_value = "tree")]
@@ -154,9 +177,13 @@ enum GraphSource {
 
     /// Build the graph from a live database (current state).
     Current {
-        /// Path to the policy manifest YAML file (required when --scope=managed).
-        #[arg(short, long)]
+        /// Path to the policy manifest YAML file (required when --scope=managed unless --bundle is used).
+        #[arg(short, long, conflicts_with = "bundle")]
         file: Option<PathBuf>,
+
+        /// Path to the policy bundle YAML file (required when --scope=managed unless --file is used).
+        #[arg(long, conflicts_with = "file")]
+        bundle: Option<PathBuf>,
 
         /// PostgreSQL connection string (or set DATABASE_URL).
         #[arg(long, env = "DATABASE_URL")]
@@ -246,12 +273,13 @@ const EXIT_DRIFT: u8 = 2;
 
 async fn run(cli: Cli) -> Result<ExitCode> {
     match cli.command {
-        Commands::Validate { file } => {
-            cmd_validate(&file)?;
+        Commands::Validate { file, bundle } => {
+            cmd_validate(file.as_deref(), bundle.as_deref())?;
             Ok(ExitCode::SUCCESS)
         }
         Commands::Diff {
             file,
+            bundle,
             database_url,
             format,
             mode,
@@ -259,7 +287,8 @@ async fn run(cli: Cli) -> Result<ExitCode> {
             no_exit_code,
         } => {
             cmd_diff(
-                &file,
+                file.as_deref(),
+                bundle.as_deref(),
                 &database_url,
                 &format,
                 mode.into(),
@@ -269,15 +298,27 @@ async fn run(cli: Cli) -> Result<ExitCode> {
         }
         Commands::Apply {
             file,
+            bundle,
             database_url,
             dry_run,
             mode,
         } => {
-            cmd_apply(&file, &database_url, dry_run, mode.into()).await?;
+            cmd_apply(
+                file.as_deref(),
+                bundle.as_deref(),
+                &database_url,
+                dry_run,
+                mode.into(),
+            )
+            .await?;
             Ok(ExitCode::SUCCESS)
         }
-        Commands::Inspect { file, database_url } => {
-            cmd_inspect(file.as_deref(), &database_url).await?;
+        Commands::Inspect {
+            file,
+            bundle,
+            database_url,
+        } => {
+            cmd_inspect(file.as_deref(), bundle.as_deref(), &database_url).await?;
             Ok(ExitCode::SUCCESS)
         }
         Commands::Generate {
@@ -290,14 +331,21 @@ async fn run(cli: Cli) -> Result<ExitCode> {
         Commands::Graph { source } => match source {
             GraphSource::Desired {
                 file,
+                bundle,
                 format,
                 output,
             } => {
-                cmd_graph_desired(&file, &format, output.as_deref())?;
+                cmd_graph_desired(
+                    file.as_deref(),
+                    bundle.as_deref(),
+                    &format,
+                    output.as_deref(),
+                )?;
                 Ok(ExitCode::SUCCESS)
             }
             GraphSource::Current {
                 file,
+                bundle,
                 database_url,
                 scope,
                 format,
@@ -305,6 +353,7 @@ async fn run(cli: Cli) -> Result<ExitCode> {
             } => {
                 cmd_graph_current(
                     file.as_deref(),
+                    bundle.as_deref(),
                     &database_url,
                     &scope,
                     &format,
@@ -321,21 +370,90 @@ async fn run(cli: Cli) -> Result<ExitCode> {
 // Subcommand implementations
 // ---------------------------------------------------------------------------
 
-fn cmd_validate(file: &Path) -> Result<()> {
-    let yaml = read_manifest_file(file)?;
+fn cmd_validate(file: Option<&Path>, bundle: Option<&Path>) -> Result<()> {
+    if let Some(bundle_path) = bundle {
+        let validated = validate_bundle_file(bundle_path)?;
+        print!("{}", format_bundle_validation_result(&validated));
+        return Ok(());
+    }
+
+    let file_path = file.unwrap_or_else(|| Path::new("pgroles.yaml"));
+    let yaml = read_manifest_file(file_path)?;
     let validated = validate_manifest(&yaml)?;
     print!("{}", format_validation_result(&validated));
     Ok(())
 }
 
 async fn cmd_diff(
-    file: &Path,
+    file: Option<&Path>,
+    bundle: Option<&Path>,
     database_url: &str,
     format: &OutputFormat,
     mode: ReconciliationMode,
     use_exit_code: bool,
 ) -> Result<ExitCode> {
-    let yaml = read_manifest_file(file)?;
+    if let Some(bundle_path) = bundle {
+        let validated = validate_bundle_file(bundle_path)?;
+        let pool = connect_db(database_url).await?;
+        let inspect_config = inspect_config_for_bundle(&validated);
+        let current = inspect_current_with_config(&pool, &inspect_config).await?;
+        let resolved_passwords = resolve_passwords(&validated.composed.expanded)
+            .context("failed to resolve role passwords")?;
+        info!(%mode, "reconciliation mode");
+        let changes = inject_password_changes(
+            filter_changes(
+                apply_role_retirements(
+                    compute_plan(&current, &validated.composed.desired),
+                    &validated.composed.manifest.retirements,
+                ),
+                mode,
+            ),
+            &resolved_passwords,
+        );
+        validate_changes_against_managed_surface(
+            &changes,
+            &validated.composed.managed_change_surface,
+        )?;
+        let drop_safety =
+            inspect_drop_safety(&pool, &changes, &validated.composed.manifest.retirements).await?;
+        let summary = PlanSummary::from_changes(&changes);
+
+        match format {
+            OutputFormat::Sql => {
+                let sql_ctx = detect_sql_context_with_config(&pool, &inspect_config).await?;
+                if summary.is_empty() {
+                    println!("-- No changes needed. Database is in sync with manifest.");
+                } else {
+                    print!("{}", format_plan_sql_with_context(&changes, &sql_ctx));
+                    eprintln!("\n{summary}");
+                    if !drop_safety.is_empty() {
+                        eprintln!("\n{drop_safety}");
+                    }
+                }
+            }
+            OutputFormat::Summary => {
+                print!("{summary}");
+                if !drop_safety.is_empty() {
+                    eprintln!("\n{drop_safety}");
+                }
+            }
+            OutputFormat::Json => {
+                println!(
+                    "{}",
+                    format_bundle_plan_json(&changes, &validated.composed)?
+                );
+            }
+        }
+
+        return if use_exit_code && summary.has_structural_changes() {
+            Ok(ExitCode::from(EXIT_DRIFT))
+        } else {
+            Ok(ExitCode::SUCCESS)
+        };
+    }
+
+    let file_path = file.unwrap_or_else(|| Path::new("pgroles.yaml"));
+    let yaml = read_manifest_file(file_path)?;
     let validated = validate_manifest(&yaml)?;
 
     let pool = connect_db(database_url).await?;
@@ -391,12 +509,123 @@ async fn cmd_diff(
 }
 
 async fn cmd_apply(
-    file: &Path,
+    file: Option<&Path>,
+    bundle: Option<&Path>,
     database_url: &str,
     dry_run: bool,
     mode: ReconciliationMode,
 ) -> Result<()> {
-    let yaml = read_manifest_file(file)?;
+    if let Some(bundle_path) = bundle {
+        let validated = validate_bundle_file(bundle_path)?;
+        let pool = connect_db(database_url).await?;
+        let inspect_config = inspect_config_for_bundle(&validated);
+        let sql_ctx = detect_sql_context_with_config(&pool, &inspect_config).await?;
+
+        // Detect cloud provider privilege level and warn about unsupported operations.
+        let privilege_level = pgroles_inspect::detect_privilege_level(&pool)
+            .await
+            .context("failed to detect privilege level")?;
+        info!(level = %privilege_level, "detected privilege level");
+
+        let current = inspect_current_with_config(&pool, &inspect_config).await?;
+
+        let resolved_passwords = resolve_passwords(&validated.composed.expanded)
+            .context("failed to resolve role passwords")?;
+        info!(%mode, "reconciliation mode");
+        let changes = inject_password_changes(
+            filter_changes(
+                apply_role_retirements(
+                    compute_plan(&current, &validated.composed.desired),
+                    &validated.composed.manifest.retirements,
+                ),
+                mode,
+            ),
+            &resolved_passwords,
+        );
+        validate_changes_against_managed_surface(
+            &changes,
+            &validated.composed.managed_change_surface,
+        )?;
+
+        // Validate changes against privilege level.
+        let priv_warnings = pgroles_inspect::cloud::validate_changes_for_privilege_level(
+            &changes,
+            &privilege_level,
+        );
+        if !priv_warnings.is_empty() {
+            for warning in &priv_warnings {
+                eprintln!("Warning: {warning}");
+            }
+        }
+
+        let drop_safety =
+            inspect_drop_safety(&pool, &changes, &validated.composed.manifest.retirements).await?;
+        let summary = PlanSummary::from_changes(&changes);
+
+        if summary.is_empty() {
+            println!("No changes needed. Database is in sync with manifest.");
+            return Ok(());
+        }
+
+        let sql_output = format_plan_sql_with_context(&changes, &sql_ctx);
+
+        if dry_run {
+            println!("-- DRY RUN: the following SQL would be executed:\n");
+            print!("{sql_output}");
+            eprintln!("\n{}", summary.format_plan());
+            if !drop_safety.is_empty() {
+                eprintln!("\n{drop_safety}");
+            }
+            return Ok(());
+        }
+
+        if drop_safety.has_blockers() {
+            anyhow::bail!("{}", drop_safety.blockers);
+        }
+
+        if !drop_safety.warnings.is_empty() {
+            eprintln!("\n{warnings}", warnings = drop_safety.warnings);
+        }
+
+        // Execute the entire plan in one transaction to avoid partial convergence.
+        info!(changes = summary.total(), "applying changes");
+        let mut transaction = pool.begin().await.context("failed to start transaction")?;
+        for change in &changes {
+            let is_sensitive = matches!(change, pgroles_core::diff::Change::SetPassword { .. });
+            for statement in pgroles_core::sql::render_statements_with_context(change, &sql_ctx) {
+                if is_sensitive {
+                    info!("executing: ALTER ROLE ... PASSWORD [REDACTED]");
+                } else {
+                    info!(sql = %statement, "executing");
+                }
+                sqlx::query(&statement)
+                    .execute(transaction.as_mut())
+                    .await
+                    .with_context(|| {
+                        if is_sensitive {
+                            "failed to execute: ALTER ROLE ... PASSWORD [REDACTED]".to_string()
+                        } else {
+                            format!("failed to execute: {statement}")
+                        }
+                    })?;
+            }
+        }
+        transaction
+            .commit()
+            .await
+            .context("failed to commit transaction")?;
+
+        println!(
+            "Applied {total} change(s) successfully.",
+            total = summary.total()
+        );
+        print!("{}", summary.format_applied());
+
+        return Ok(());
+    }
+
+    let file_path = file.unwrap_or_else(|| Path::new("pgroles.yaml"));
+    let yaml = read_manifest_file(file_path)?;
     let validated = validate_manifest(&yaml)?;
 
     let pool = connect_db(database_url).await?;
@@ -498,31 +727,46 @@ async fn cmd_apply(
     Ok(())
 }
 
-async fn cmd_inspect(file: Option<&Path>, database_url: &str) -> Result<()> {
-    // Validate manifest before connecting so YAML errors fail fast.
-    let validated = match file {
-        Some(path) => {
+async fn cmd_inspect(file: Option<&Path>, bundle: Option<&Path>, database_url: &str) -> Result<()> {
+    // Validate manifest or bundle before connecting so YAML errors fail fast.
+    let validated_manifest = match (file, bundle) {
+        (Some(path), None) => {
             let yaml = read_manifest_file(path)?;
             Some(validate_manifest(&yaml)?)
         }
-        None => None,
+        (None, Some(_)) | (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("clap enforces conflicts"),
+    };
+    let validated_bundle = match (file, bundle) {
+        (None, Some(path)) => Some(validate_bundle_file(path)?),
+        (Some(_), None) | (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("clap enforces conflicts"),
     };
 
     let pool = connect_db(database_url).await?;
 
-    let current = match validated {
-        Some(ref v) => inspect_current(&pool, v).await?,
-        None => {
-            info!("no manifest provided, inspecting all non-system roles");
-            pgroles_inspect::inspect_all(
-                &pool,
-                &pgroles_inspect::InspectAllConfig {
-                    exclude_system_roles: true,
-                },
-            )
-            .await
-            .context("failed to introspect database")?
-        }
+    let current = if let Some(ref validated) = validated_manifest {
+        inspect_current(&pool, validated).await?
+    } else if let Some(ref validated) = validated_bundle {
+        let inspect_config = inspect_config_for_bundle(validated);
+        inspect_current_with_config(&pool, &inspect_config).await?
+    } else {
+        info!("no manifest provided, inspecting all non-system roles");
+        pgroles_inspect::inspect_all(
+            &pool,
+            &pgroles_inspect::InspectAllConfig {
+                exclude_system_roles: true,
+            },
+        )
+        .await
+        .context("failed to introspect database")?
+    };
+
+    if let Some(ref validated) = validated_bundle {
+        print!(
+            "{}",
+            format_managed_scope_summary(&validated.composed.managed_scope)
+        );
     };
 
     print!("{}", format_role_graph_summary(&current));
@@ -568,26 +812,44 @@ async fn cmd_generate(database_url: &str, output: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-fn cmd_graph_desired(file: &Path, format: &GraphFormat, output: Option<&Path>) -> Result<()> {
-    let yaml = read_manifest_file(file)?;
-    let validated = validate_manifest(&yaml)?;
+fn cmd_graph_desired(
+    file: Option<&Path>,
+    bundle: Option<&Path>,
+    format: &GraphFormat,
+    output: Option<&Path>,
+) -> Result<()> {
+    let visual = if let Some(bundle_path) = bundle {
+        let validated = validate_bundle_file(bundle_path)?;
+        let mut visual =
+            visual::build_visual_graph(&validated.composed.desired, VisualSource::Desired);
+        if matches!(format, GraphFormat::Json) {
+            visual.meta.managed_scope =
+                Some(VisualManagedScope::from(&validated.composed.managed_scope));
+        }
+        visual
+    } else {
+        let file_path = file.unwrap_or_else(|| Path::new("pgroles.yaml"));
+        let yaml = read_manifest_file(file_path)?;
+        let validated = validate_manifest(&yaml)?;
+        visual::build_visual_graph(&validated.desired, VisualSource::Desired)
+    };
 
-    let visual = visual::build_visual_graph(&validated.desired, VisualSource::Desired);
     let rendered = render_graph(&visual, format);
     write_output(&rendered, output)
 }
 
 async fn cmd_graph_current(
     file: Option<&Path>,
+    bundle: Option<&Path>,
     database_url: &str,
     scope: &GraphScope,
     format: &GraphFormat,
     output: Option<&Path>,
 ) -> Result<()> {
     // Validate file requirement before connecting to the database.
-    if matches!(scope, GraphScope::Managed) && file.is_none() {
+    if matches!(scope, GraphScope::Managed) && file.is_none() && bundle.is_none() {
         anyhow::bail!(
-            "--file is required when --scope=managed (to determine which roles are managed)"
+            "--file or --bundle is required when --scope=managed (to determine which roles are managed)"
         );
     }
 
@@ -595,10 +857,23 @@ async fn cmd_graph_current(
 
     let graph = match scope {
         GraphScope::Managed => {
-            let file = file.expect("validated above");
-            let yaml = read_manifest_file(file)?;
-            let validated = validate_manifest(&yaml)?;
-            inspect_current(&pool, &validated).await?
+            if let Some(bundle_path) = bundle {
+                let validated = validate_bundle_file(bundle_path)?;
+                let inspect_config = inspect_config_for_bundle(&validated);
+                let graph = inspect_current_with_config(&pool, &inspect_config).await?;
+                let mut visual = visual::build_visual_graph(&graph, VisualSource::Current);
+                if matches!(format, GraphFormat::Json) {
+                    visual.meta.managed_scope =
+                        Some(VisualManagedScope::from(&validated.composed.managed_scope));
+                }
+                let rendered = render_graph(&visual, format);
+                return write_output(&rendered, output);
+            } else {
+                let file = file.expect("validated above");
+                let yaml = read_manifest_file(file)?;
+                let validated = validate_manifest(&yaml)?;
+                inspect_current(&pool, &validated).await?
+            }
         }
         GraphScope::All => {
             info!("introspecting all non-system roles");
@@ -654,16 +929,23 @@ async fn detect_sql_context(
     pool: &PgPool,
     expanded: &pgroles_core::manifest::ExpandedManifest,
 ) -> Result<pgroles_core::sql::SqlContext> {
+    let inspect_config = InspectConfig::from_expanded(expanded, false);
+    detect_sql_context_with_config(pool, &inspect_config).await
+}
+
+async fn detect_sql_context_with_config(
+    pool: &PgPool,
+    inspect_config: &InspectConfig,
+) -> Result<pgroles_core::sql::SqlContext> {
     let pg_version = pgroles_inspect::detect_pg_version(pool)
         .await
         .context("failed to detect PostgreSQL version")?;
-    let inspect_config = InspectConfig::from_expanded(expanded, false);
-    let managed_schemas: Vec<&str> = inspect_config
-        .managed_schemas
+    let privilege_schemas: Vec<&str> = inspect_config
+        .privilege_schemas
         .iter()
         .map(|schema| schema.as_str())
         .collect();
-    let relation_inventory = pgroles_inspect::fetch_relation_inventory(pool, &managed_schemas)
+    let relation_inventory = pgroles_inspect::fetch_relation_inventory(pool, &privilege_schemas)
         .await
         .context("failed to inspect relation inventory")?;
     info!(
@@ -696,13 +978,40 @@ async fn inspect_current(
                 .map(|retirement| retirement.role.clone()),
         );
 
+    inspect_current_with_config(pool, &config).await
+}
+
+fn inspect_config_for_bundle(validated: &pgroles_cli::ValidatedBundle) -> InspectConfig {
+    InspectConfig::from_managed_scope(
+        &validated.composed.managed_scope,
+        &validated.composed.expanded,
+        validated
+            .composed
+            .managed_change_surface
+            .needs_database_privilege_inspection(),
+    )
+    .with_additional_roles(
+        validated
+            .composed
+            .manifest
+            .retirements
+            .iter()
+            .map(|retirement| retirement.role.clone()),
+    )
+}
+
+async fn inspect_current_with_config(
+    pool: &PgPool,
+    config: &InspectConfig,
+) -> Result<pgroles_core::model::RoleGraph> {
     info!(
         managed_roles = config.managed_roles.len(),
         managed_schemas = config.managed_schemas.len(),
+        privilege_schemas = config.privilege_schemas.len(),
         "inspecting current database state"
     );
 
-    pgroles_inspect::inspect(pool, &config)
+    pgroles_inspect::inspect(pool, config)
         .await
         .context("failed to inspect database state")
 }
@@ -717,4 +1026,77 @@ async fn inspect_drop_safety(
         .await
         .context("failed to inspect role-drop safety")?;
     Ok(report.assess(retirements))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pgroles_core::model::{RoleGraph, RoleState};
+
+    fn sample_visual_graph() -> pgroles_core::visual::VisualGraph {
+        let mut graph = RoleGraph::default();
+        graph.roles.insert(
+            "analytics".to_string(),
+            RoleState {
+                login: true,
+                ..RoleState::default()
+            },
+        );
+        visual::build_visual_graph(&graph, VisualSource::Desired)
+    }
+
+    #[test]
+    fn render_graph_delegates_to_requested_format() {
+        let visual = sample_visual_graph();
+
+        assert_eq!(
+            render_graph(&visual, &GraphFormat::Tree),
+            visual::render_tree(&visual)
+        );
+        assert_eq!(
+            render_graph(&visual, &GraphFormat::Json),
+            visual::render_json(&visual)
+        );
+        assert_eq!(
+            render_graph(&visual, &GraphFormat::Dot),
+            visual::render_dot(&visual)
+        );
+        assert_eq!(
+            render_graph(&visual, &GraphFormat::Mermaid),
+            visual::render_mermaid(&visual)
+        );
+    }
+
+    #[test]
+    fn write_output_writes_file_when_path_provided() {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let path = dir.path().join("graph.txt");
+
+        write_output("graph output", Some(&path)).expect("write_output should succeed");
+
+        let written = std::fs::read_to_string(&path).expect("failed to read output file");
+        assert_eq!(written, "graph output");
+    }
+
+    #[test]
+    fn graph_current_managed_requires_file_before_connecting() {
+        let runtime = tokio::runtime::Runtime::new().expect("failed to create runtime");
+        let error = runtime
+            .block_on(cmd_graph_current(
+                None,
+                None,
+                "postgres://unused",
+                &GraphScope::Managed,
+                &GraphFormat::Tree,
+                None,
+            ))
+            .expect_err("managed graph without --file/--bundle should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("--file or --bundle is required when --scope=managed"),
+            "unexpected error: {error:#}"
+        );
+    }
 }

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -7,7 +7,7 @@
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 
 use std::io::Write;
 
@@ -23,6 +23,18 @@ fn write_temp_manifest(content: &str) -> NamedTempFile {
         .expect("failed to write temp manifest");
     file.flush().expect("failed to flush temp manifest");
     file
+}
+
+fn write_temp_bundle(bundle: &str, documents: &[(&str, &str)]) -> (TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("failed to create temp bundle dir");
+    let bundle_path = dir.path().join("bundle.yaml");
+    std::fs::write(&bundle_path, bundle).expect("failed to write bundle file");
+
+    for (name, content) in documents {
+        std::fs::write(dir.path().join(name), content).expect("failed to write policy document");
+    }
+
+    (dir, bundle_path)
 }
 
 fn pgroles_cmd() -> assert_cmd::Command {
@@ -191,6 +203,314 @@ schemas:
         .failure()
         .stderr(predicate::str::contains("duplicate schema name"))
         .stderr(predicate::str::contains("inventory"));
+}
+
+#[test]
+fn validate_bundle_with_split_schema_ownership() {
+    let (bundle_dir, bundle_path) = write_temp_bundle(
+        r#"
+shared:
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+"#,
+        &[
+            (
+                "platform.yaml",
+                r#"
+policy:
+  name: platform
+scope:
+  roles: [app_owner]
+  schemas:
+    - name: inventory
+      facets: [owner]
+roles:
+  - name: app_owner
+    login: false
+schemas:
+  - name: inventory
+    owner: app_owner
+"#,
+            ),
+            (
+                "app.yaml",
+                r#"
+policy:
+  name: app
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+schemas:
+  - name: inventory
+    profiles: [editor]
+"#,
+            ),
+        ],
+    );
+
+    let _keep_dir = bundle_dir;
+
+    pgroles_cmd()
+        .args([
+            "validate",
+            "--bundle",
+            bundle_path.to_str().expect("bundle path should be utf-8"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Policy bundle is valid"))
+        .stdout(predicate::str::contains("2 source document(s) loaded"))
+        .stdout(predicate::str::contains("2 role(s) defined"));
+}
+
+#[test]
+fn validate_bundle_rejects_role_outside_scope() {
+    let (bundle_dir, bundle_path) = write_temp_bundle(
+        r#"
+sources:
+  - file: app.yaml
+"#,
+        &[(
+            "app.yaml",
+            r#"
+roles:
+  - name: app
+    login: true
+"#,
+        )],
+    );
+
+    let _keep_dir = bundle_dir;
+
+    pgroles_cmd()
+        .args([
+            "validate",
+            "--bundle",
+            bundle_path.to_str().expect("bundle path should be utf-8"),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "defines role \"app\" outside its declared scope",
+        ));
+}
+
+// =========================================================================
+// graph subcommand
+// =========================================================================
+
+#[test]
+fn graph_desired_tree_renders_managed_roles() {
+    let manifest_file = write_temp_manifest(VALID_PROFILES);
+
+    pgroles_cmd()
+        .args([
+            "graph",
+            "desired",
+            "--file",
+            manifest_file.path().to_str().unwrap(),
+            "--format",
+            "tree",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("inventory-editor"))
+        .stdout(predicate::str::contains("catalog-viewer"))
+        .stdout(predicate::str::contains("app-service"));
+}
+
+#[test]
+fn graph_desired_bundle_tree_renders_composed_roles() {
+    let (bundle_dir, bundle_path) = write_temp_bundle(
+        r#"
+shared:
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+"#,
+        &[
+            (
+                "platform.yaml",
+                r#"
+policy:
+  name: platform
+scope:
+  roles: [app_owner]
+  schemas:
+    - name: inventory
+      facets: [owner]
+roles:
+  - name: app_owner
+    login: false
+schemas:
+  - name: inventory
+    owner: app_owner
+"#,
+            ),
+            (
+                "app.yaml",
+                r#"
+policy:
+  name: app
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+schemas:
+  - name: inventory
+    profiles: [editor]
+"#,
+            ),
+        ],
+    );
+    let _keep_dir = bundle_dir;
+
+    pgroles_cmd()
+        .args([
+            "graph",
+            "desired",
+            "--bundle",
+            bundle_path.to_str().expect("bundle path should be utf-8"),
+            "--format",
+            "tree",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("inventory-editor"))
+        .stdout(predicate::str::contains("app_owner"));
+}
+
+#[test]
+fn graph_desired_bundle_json_includes_managed_scope_metadata() {
+    let (bundle_dir, bundle_path) = write_temp_bundle(
+        r#"
+shared:
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+"#,
+        &[
+            (
+                "platform.yaml",
+                r#"
+policy:
+  name: platform
+scope:
+  roles: [app_owner]
+  schemas:
+    - name: inventory
+      facets: [owner]
+roles:
+  - name: app_owner
+    login: false
+schemas:
+  - name: inventory
+    owner: app_owner
+"#,
+            ),
+            (
+                "app.yaml",
+                r#"
+policy:
+  name: app
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+schemas:
+  - name: inventory
+    profiles: [editor]
+"#,
+            ),
+        ],
+    );
+    let _keep_dir = bundle_dir;
+
+    let output = pgroles_cmd()
+        .args([
+            "graph",
+            "desired",
+            "--bundle",
+            bundle_path.to_str().expect("bundle path should be utf-8"),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output).expect("graph json should parse");
+    assert_eq!(parsed["schema_version"], "pgroles.visual_graph.v1");
+    assert_eq!(parsed["meta"]["managed_scope"]["roles"][0], "app_owner");
+    assert_eq!(
+        parsed["meta"]["managed_scope"]["schemas"][0]["name"],
+        "inventory"
+    );
+    assert_eq!(parsed["meta"]["managed_scope"]["schemas"][0]["owner"], true);
+}
+
+#[test]
+fn graph_desired_output_file_writes_requested_format() {
+    let manifest_file = write_temp_manifest(VALID_PROFILES);
+    let output_dir = tempfile::tempdir().expect("failed to create temp output dir");
+    let output_path = output_dir.path().join("graph.json");
+
+    pgroles_cmd()
+        .args([
+            "graph",
+            "desired",
+            "--file",
+            manifest_file.path().to_str().unwrap(),
+            "--format",
+            "json",
+            "--output",
+            output_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let graph_json =
+        std::fs::read_to_string(&output_path).expect("failed to read rendered graph output");
+    assert!(graph_json.contains("\"inventory-editor\""));
+    assert!(graph_json.contains("\"catalog-viewer\""));
+}
+
+#[test]
+fn graph_current_managed_requires_file() {
+    pgroles_cmd()
+        .args([
+            "graph",
+            "current",
+            "--database-url",
+            "postgres://unused",
+            "--scope",
+            "managed",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--file or --bundle is required when --scope=managed",
+        ));
 }
 
 #[test]
@@ -628,6 +948,40 @@ fn diff_with_invalid_manifest_accepts_no_exit_code_flag() {
 }
 
 #[test]
+fn diff_with_invalid_bundle_fails_before_connecting() {
+    let (bundle_dir, bundle_path) = write_temp_bundle(
+        r#"
+sources:
+  - file: app.yaml
+"#,
+        &[(
+            "app.yaml",
+            r#"
+roles:
+  - name: app
+    login: true
+"#,
+        )],
+    );
+
+    let _keep_dir = bundle_dir;
+
+    pgroles_cmd()
+        .args([
+            "diff",
+            "--bundle",
+            bundle_path.to_str().expect("bundle path should be utf-8"),
+            "--database-url",
+            "postgres://localhost/test",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "defines role \"app\" outside its declared scope",
+        ));
+}
+
+#[test]
 fn apply_with_invalid_manifest() {
     let manifest_file = write_temp_manifest(INVALID_YAML);
 
@@ -642,6 +996,40 @@ fn apply_with_invalid_manifest() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("YAML parse error"));
+}
+
+#[test]
+fn apply_with_invalid_bundle_fails_before_connecting() {
+    let (bundle_dir, bundle_path) = write_temp_bundle(
+        r#"
+sources:
+  - file: app.yaml
+"#,
+        &[(
+            "app.yaml",
+            r#"
+roles:
+  - name: app
+    login: true
+"#,
+        )],
+    );
+
+    let _keep_dir = bundle_dir;
+
+    pgroles_cmd()
+        .args([
+            "apply",
+            "--bundle",
+            bundle_path.to_str().expect("bundle path should be utf-8"),
+            "--database-url",
+            "postgres://localhost/test",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "defines role \"app\" outside its declared scope",
+        ));
 }
 
 // =========================================================================
@@ -836,6 +1224,38 @@ mod live_db {
         })
     }
 
+    fn query_has_database_privilege(role: &str, database: &str, privilege: &str) -> bool {
+        with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            let row = sqlx::query("SELECT has_database_privilege($1, $2, $3) AS allowed")
+                .bind(role)
+                .bind(database)
+                .bind(privilege)
+                .fetch_one(&pool)
+                .await
+                .expect("failed to query database privilege");
+            row.get("allowed")
+        })
+    }
+
+    fn query_has_schema_privilege(role: &str, schema: &str, privilege: &str) -> bool {
+        with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            let row = sqlx::query("SELECT has_schema_privilege($1, $2, $3) AS allowed")
+                .bind(role)
+                .bind(schema)
+                .bind(privilege)
+                .fetch_one(&pool)
+                .await
+                .expect("failed to query schema privilege");
+            row.get("allowed")
+        })
+    }
+
     async fn open_role_connection(role: &str, password: &str) -> PgConnection {
         let options = PgConnectOptions::from_str(&database_url())
             .expect("failed to parse DATABASE_URL")
@@ -860,6 +1280,575 @@ mod live_db {
         fn drop(&mut self) {
             execute_sql(&self.sql);
         }
+    }
+
+    #[test]
+    #[ignore]
+    fn graph_current_all_renders_live_roles() {
+        let live_role = unique_name("graph_all_role");
+        let _cleanup = TestDbCleanup::new(format!(r#"DROP ROLE IF EXISTS "{live_role}";"#));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{live_role}";
+            CREATE ROLE "{live_role}" LOGIN;
+            "#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "graph",
+                "current",
+                "--database-url",
+                &database_url(),
+                "--scope",
+                "all",
+                "--format",
+                "tree",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(live_role.as_str()));
+    }
+
+    #[test]
+    #[ignore]
+    fn graph_current_managed_scopes_to_manifest_roles() {
+        let managed_role = unique_name("graph_managed_role");
+        let extra_role = unique_name("graph_extra_role");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP ROLE IF EXISTS "{extra_role}";
+            DROP ROLE IF EXISTS "{managed_role}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{extra_role}";
+            DROP ROLE IF EXISTS "{managed_role}";
+            CREATE ROLE "{managed_role}" LOGIN;
+            CREATE ROLE "{extra_role}" LOGIN;
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+roles:
+  - name: {managed_role}
+    login: true
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "graph",
+                "current",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--scope",
+                "managed",
+                "--format",
+                "tree",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(managed_role.as_str()))
+            .stdout(predicate::str::contains(extra_role.as_str()).not());
+    }
+
+    #[test]
+    #[ignore]
+    fn diff_bundle_owner_only_scope_ignores_unmanaged_schema_grants() {
+        let schema = unique_name("bundle_owner_schema");
+        let owner_role = unique_name("bundle_owner");
+        let extra_role = unique_name("bundle_extra");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{extra_role}";
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{extra_role}";
+            DROP ROLE IF EXISTS "{owner_role}";
+            CREATE ROLE "{owner_role}" NOLOGIN;
+            CREATE ROLE "{extra_role}" NOLOGIN;
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{owner_role}";
+            GRANT USAGE ON SCHEMA "{schema}" TO "{extra_role}";
+            "#
+        ));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+sources:
+  - file: platform.yaml
+"#,
+            &[(
+                "platform.yaml",
+                &format!(
+                    r#"
+policy:
+  name: platform
+scope:
+  roles: [{owner_role}]
+  schemas:
+    - name: {schema}
+      facets: [owner]
+roles:
+  - name: {owner_role}
+    login: false
+schemas:
+  - name: {schema}
+    owner: {owner_role}
+"#
+                ),
+            )],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "sql",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"))
+            .stdout(predicate::str::contains("REVOKE").not());
+    }
+
+    #[test]
+    #[ignore]
+    fn apply_bundle_owner_only_scope_ignores_unmanaged_schema_grants() {
+        let schema = unique_name("bundle_apply_owner_schema");
+        let owner_role = unique_name("bundle_apply_owner");
+        let extra_role = unique_name("bundle_apply_extra");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{extra_role}";
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{extra_role}";
+            DROP ROLE IF EXISTS "{owner_role}";
+            CREATE ROLE "{owner_role}" NOLOGIN;
+            CREATE ROLE "{extra_role}" NOLOGIN;
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{owner_role}";
+            GRANT USAGE ON SCHEMA "{schema}" TO "{extra_role}";
+            "#
+        ));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+sources:
+  - file: platform.yaml
+"#,
+            &[(
+                "platform.yaml",
+                &format!(
+                    r#"
+policy:
+  name: platform
+scope:
+  roles: [{owner_role}]
+  schemas:
+    - name: {schema}
+      facets: [owner]
+roles:
+  - name: {owner_role}
+    login: false
+schemas:
+  - name: {schema}
+    owner: {owner_role}
+"#
+                ),
+            )],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
+        assert!(
+            query_has_schema_privilege(&extra_role, &schema, "USAGE"),
+            "owner-only bundle scope should not revoke unmanaged schema grants"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    #[test]
+    #[ignore]
+    fn apply_bundle_revokes_removed_database_grants_for_managed_role() {
+        let managed_role = unique_name("bundle_db_role");
+        let _cleanup = TestDbCleanup::new(format!(r#"DROP ROLE IF EXISTS "{managed_role}";"#));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed_role}";
+            CREATE ROLE "{managed_role}" NOLOGIN;
+            GRANT CREATE ON DATABASE pgroles_test TO "{managed_role}";
+            "#
+        ));
+
+        assert!(
+            query_has_database_privilege(&managed_role, "pgroles_test", "CREATE"),
+            "test setup should grant database create privilege"
+        );
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+sources:
+  - file: app.yaml
+"#,
+            &[(
+                "app.yaml",
+                &format!(
+                    r#"
+policy:
+  name: app
+scope:
+  roles: [{managed_role}]
+roles:
+  - name: {managed_role}
+    login: false
+"#
+                ),
+            )],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1 grant(s) to revoke"));
+
+        assert!(
+            !query_has_database_privilege(&managed_role, "pgroles_test", "CREATE"),
+            "bundle apply should revoke removed database grants for managed roles"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    #[test]
+    #[ignore]
+    fn apply_bundle_with_split_schema_ownership_converges() {
+        let schema = unique_name("bundle_split_schema");
+        let owner_role = unique_name("bundle_split_owner");
+        let generated_role = format!("{schema}-editor");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{generated_role}";
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{generated_role}";
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+shared:
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+        - privileges: [SELECT]
+          object: { type: table, name: "*" }
+      default_privileges:
+        - privileges: [SELECT]
+          on_type: table
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+"#,
+            &[
+                (
+                    "platform.yaml",
+                    &format!(
+                        r#"
+policy:
+  name: platform
+scope:
+  roles: [{owner_role}]
+  schemas:
+    - name: {schema}
+      facets: [owner]
+roles:
+  - name: {owner_role}
+    login: false
+schemas:
+  - name: {schema}
+    owner: {owner_role}
+"#
+                    ),
+                ),
+                (
+                    "app.yaml",
+                    &format!(
+                        r#"
+policy:
+  name: app
+scope:
+  schemas:
+    - name: {schema}
+      facets: [bindings]
+schemas:
+  - name: {schema}
+    profiles: [editor]
+"#
+                    ),
+                ),
+            ],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Applied"))
+            .stdout(predicate::str::contains("No changes needed").not());
+
+        assert_eq!(
+            query_schema_owner(&schema).as_deref(),
+            Some(owner_role.as_str()),
+            "bundle apply should create the schema with the platform-owned owner"
+        );
+        assert!(
+            query_role_exists(&generated_role),
+            "bundle apply should create generated profile roles"
+        );
+        assert!(
+            query_has_schema_privilege(&generated_role, &schema, "USAGE"),
+            "bundle apply should grant schema usage from the binding profile"
+        );
+        assert_eq!(
+            query_default_acl_owner(&schema, &generated_role, "r").as_deref(),
+            Some(owner_role.as_str()),
+            "bundle apply should bind default privileges to the declared schema owner"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    #[test]
+    #[ignore]
+    fn additive_mode_bundle_skips_owner_bound_default_privileges_when_transfer_is_skipped() {
+        let schema = unique_name("bundle_additive_schema");
+        let old_owner = unique_name("bundle_old_owner");
+        let new_owner = unique_name("bundle_new_owner");
+        let generated_role = format!("{schema}-editor");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{generated_role}";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{generated_role}";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            CREATE ROLE "{old_owner}";
+            CREATE ROLE "{new_owner}";
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{old_owner}";
+            "#
+        ));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+shared:
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+      default_privileges:
+        - privileges: [SELECT]
+          on_type: table
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+"#,
+            &[
+                (
+                    "platform.yaml",
+                    &format!(
+                        r#"
+policy:
+  name: platform
+scope:
+  roles: [{new_owner}]
+  schemas:
+    - name: {schema}
+      facets: [owner]
+roles:
+  - name: {new_owner}
+schemas:
+  - name: {schema}
+    owner: {new_owner}
+"#
+                    ),
+                ),
+                (
+                    "app.yaml",
+                    &format!(
+                        r#"
+policy:
+  name: app
+scope:
+  schemas:
+    - name: {schema}
+      facets: [bindings]
+schemas:
+  - name: {schema}
+    profiles: [editor]
+"#
+                    ),
+                ),
+            ],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--mode",
+                "additive",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Applied: 2 change(s)"))
+            .stdout(predicate::str::contains("1 role(s) to create"))
+            .stdout(predicate::str::contains("1 grant(s) to add"))
+            .stdout(predicate::str::contains("No changes needed").not());
+
+        assert_eq!(
+            query_schema_owner(&schema).as_deref(),
+            Some(old_owner.as_str()),
+            "additive bundle apply should not transfer schema ownership"
+        );
+        assert!(
+            query_role_exists(&generated_role),
+            "additive bundle apply should still create generated binding roles"
+        );
+        assert!(
+            query_has_schema_privilege(&generated_role, &schema, "USAGE"),
+            "additive bundle apply should still grant non-owner-bound schema privileges"
+        );
+        assert_eq!(
+            query_default_acl_owner(&schema, &generated_role, "r"),
+            None,
+            "owner-bound default privileges should be skipped until ownership transfer is allowed"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--mode",
+                "additive",
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
     }
 
     #[test]
@@ -1004,6 +1993,100 @@ roles:
 
     #[test]
     #[ignore]
+    fn additive_mode_skips_owner_bound_default_privileges_when_transfer_is_skipped() {
+        let schema = unique_name("schema_owner_additive_defaults");
+        let old_owner = unique_name("old_owner");
+        let new_owner = unique_name("new_owner");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{schema}-editor";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{schema}-editor";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            CREATE ROLE "{old_owner}";
+            CREATE ROLE "{new_owner}";
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{old_owner}";
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+profiles:
+  editor:
+    grants:
+      - privileges: [USAGE]
+        object: {{ type: schema }}
+    default_privileges:
+      - privileges: [SELECT]
+        on_type: table
+
+schemas:
+  - name: {schema}
+    owner: {new_owner}
+    profiles: [editor]
+
+roles:
+  - name: {old_owner}
+  - name: {new_owner}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--mode",
+                "additive",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Applied: 2 change(s)"))
+            .stdout(predicate::str::contains("1 role(s) to create"))
+            .stdout(predicate::str::contains("1 grant(s) to add"))
+            .stdout(predicate::str::contains("No changes needed").not());
+
+        assert_eq!(
+            query_schema_owner(&schema).as_deref(),
+            Some(old_owner.as_str()),
+            "additive mode should not transfer schema ownership"
+        );
+        assert_eq!(
+            query_default_acl_owner(&schema, &format!("{schema}-editor"), "r"),
+            None,
+            "owner-bound default privileges should be skipped until ownership transfer is allowed"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--mode",
+                "additive",
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    #[test]
+    #[ignore]
     fn apply_converges_existing_schema_owner_and_uses_owner_for_default_privileges() {
         let schema = unique_name("schema_owner");
         let old_owner = unique_name("old_owner");
@@ -1073,6 +2156,85 @@ roles:
             query_default_acl_owner(&schema, &format!("{schema}-editor"), "r").as_deref(),
             Some(new_owner.as_str()),
             "default privileges should be attached to the schema owner"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    #[test]
+    #[ignore]
+    fn apply_restores_owner_schema_privileges_after_revoke_all() {
+        let schema = unique_name("schema_owner_acl");
+        let owner = unique_name("schema_owner");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{owner}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{owner}";
+            CREATE ROLE "{owner}";
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{owner}";
+            REVOKE ALL ON SCHEMA "{schema}" FROM "{owner}";
+            "#
+        ));
+
+        assert!(
+            !query_has_schema_privilege(&owner, &schema, "CREATE"),
+            "test setup should remove CREATE from schema owner"
+        );
+        assert!(
+            !query_has_schema_privilege(&owner, &schema, "USAGE"),
+            "test setup should remove USAGE from schema owner"
+        );
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+schemas:
+  - name: {schema}
+    owner: {owner}
+    profiles: []
+
+roles:
+  - name: {owner}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("1 grant(s) to add"));
+
+        assert!(
+            query_has_schema_privilege(&owner, &schema, "CREATE"),
+            "apply should restore CREATE to the schema owner"
+        );
+        assert!(
+            query_has_schema_privilege(&owner, &schema, "USAGE"),
+            "apply should restore USAGE to the schema owner"
         );
 
         pgroles_cmd()
@@ -1284,6 +2446,197 @@ schemas:
             .stdout(predicate::str::contains("Roles:"))
             .stdout(predicate::str::contains("Grants:"))
             .stdout(predicate::str::contains("PUBLIC grants"));
+    }
+
+    #[test]
+    #[ignore]
+    fn inspect_bundle_shows_managed_scope_summary() {
+        let managed_role = unique_name("inspect_bundle_managed");
+        let extra_role = unique_name("inspect_bundle_extra");
+        let schema = unique_name("inspect_bundle_schema");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{managed_role}";
+            DROP ROLE IF EXISTS "{extra_role}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{managed_role}";
+            DROP ROLE IF EXISTS "{extra_role}";
+            CREATE ROLE "{managed_role}" NOLOGIN;
+            CREATE ROLE "{extra_role}" NOLOGIN;
+            CREATE SCHEMA "{schema}";
+            "#
+        ));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+sources:
+  - file: platform.yaml
+"#,
+            &[(
+                "platform.yaml",
+                &format!(
+                    r#"
+policy:
+  name: platform
+scope:
+  roles: [{managed_role}]
+  schemas:
+    - name: {schema}
+      facets: [owner]
+roles:
+  - name: {managed_role}
+    login: false
+schemas:
+  - name: {schema}
+    owner: {managed_role}
+"#
+                ),
+            )],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "inspect",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Managed scope:"))
+            .stdout(predicate::str::contains("owner scope:"))
+            .stdout(predicate::str::contains(managed_role.as_str()))
+            .stdout(predicate::str::contains(extra_role.as_str()).not());
+    }
+
+    #[test]
+    #[ignore]
+    fn graph_current_managed_bundle_scopes_roles() {
+        let managed_role = unique_name("graph_bundle_managed");
+        let extra_role = unique_name("graph_bundle_extra");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed_role}";
+            DROP ROLE IF EXISTS "{extra_role}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed_role}";
+            DROP ROLE IF EXISTS "{extra_role}";
+            CREATE ROLE "{managed_role}" NOLOGIN;
+            CREATE ROLE "{extra_role}" NOLOGIN;
+            "#
+        ));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+sources:
+  - file: app.yaml
+"#,
+            &[(
+                "app.yaml",
+                &format!(
+                    r#"
+policy:
+  name: app
+scope:
+  roles: [{managed_role}]
+roles:
+  - name: {managed_role}
+    login: false
+"#
+                ),
+            )],
+        );
+        let _keep_dir = bundle_dir;
+
+        pgroles_cmd()
+            .args([
+                "graph",
+                "current",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--scope",
+                "managed",
+                "--format",
+                "json",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(managed_role.as_str()))
+            .stdout(predicate::str::contains(extra_role.as_str()).not())
+            .stdout(predicate::str::contains("\"managed_scope\""));
+    }
+
+    #[test]
+    #[ignore]
+    fn diff_bundle_format_json_includes_ownership_annotations() {
+        let managed_role = unique_name("bundle_json_role");
+        let _cleanup = TestDbCleanup::new(format!(r#"DROP ROLE IF EXISTS "{managed_role}";"#));
+
+        execute_sql(&format!(r#"DROP ROLE IF EXISTS "{managed_role}";"#));
+
+        let (bundle_dir, bundle_path) = write_temp_bundle(
+            r#"
+sources:
+  - file: app.yaml
+"#,
+            &[(
+                "app.yaml",
+                &format!(
+                    r#"
+policy:
+  name: app
+scope:
+  roles: [{managed_role}]
+roles:
+  - name: {managed_role}
+    login: false
+"#
+                ),
+            )],
+        );
+        let _keep_dir = bundle_dir;
+
+        let output = pgroles_cmd()
+            .args([
+                "diff",
+                "--bundle",
+                bundle_path.to_str().expect("bundle path should be utf-8"),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "json",
+                "--no-exit-code",
+            ])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&output).expect("diff json should parse");
+        assert_eq!(parsed["schema_version"], "pgroles.bundle_plan.v1");
+        assert_eq!(parsed["managed_scope"]["roles"][0], managed_role);
+        assert_eq!(parsed["changes"][0]["owner"]["document"], "app");
+        assert_eq!(parsed["changes"][0]["owner"]["managed_key"]["kind"], "role");
+        assert_eq!(
+            parsed["changes"][0]["owner"]["managed_key"]["name"],
+            managed_role
+        );
     }
 
     #[test]

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -825,11 +825,33 @@ mod live_db {
             .expect("failed to connect as retired role")
     }
 
+    struct TestDbCleanup {
+        sql: String,
+    }
+
+    impl TestDbCleanup {
+        fn new(sql: String) -> Self {
+            Self { sql }
+        }
+    }
+
+    impl Drop for TestDbCleanup {
+        fn drop(&mut self) {
+            execute_sql(&self.sql);
+        }
+    }
+
     #[test]
     #[ignore]
     fn apply_creates_declared_schema_with_owner() {
         let schema = unique_name("owned_schema");
         let owner_role = unique_name("owned_schema_owner");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
 
         execute_sql(&format!(
             r#"
@@ -882,13 +904,6 @@ roles:
             .assert()
             .success()
             .stdout(predicate::str::contains("No changes needed"));
-
-        execute_sql(&format!(
-            r#"
-            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
-            DROP ROLE IF EXISTS "{owner_role}";
-            "#
-        ));
     }
 
     #[test]
@@ -897,6 +912,14 @@ roles:
         let schema = unique_name("schema_owner");
         let old_owner = unique_name("old_owner");
         let new_owner = unique_name("new_owner");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{schema}-editor";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            "#
+        ));
 
         execute_sql(&format!(
             r#"
@@ -969,15 +992,6 @@ roles:
             .assert()
             .success()
             .stdout(predicate::str::contains("No changes needed"));
-
-        execute_sql(&format!(
-            r#"
-            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
-            DROP ROLE IF EXISTS "{schema}-editor";
-            DROP ROLE IF EXISTS "{new_owner}";
-            DROP ROLE IF EXISTS "{old_owner}";
-            "#
-        ));
     }
 
     #[test]

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -173,6 +173,27 @@ fn validate_undefined_profile() {
 }
 
 #[test]
+fn validate_duplicate_schema_name() {
+    let manifest_file = write_temp_manifest(
+        r#"
+schemas:
+  - name: inventory
+    profiles: []
+  - name: inventory
+    owner: inventory_owner
+    profiles: []
+"#,
+    );
+
+    pgroles_cmd()
+        .args(["validate", "--file", manifest_file.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("duplicate schema name"))
+        .stderr(predicate::str::contains("inventory"));
+}
+
+#[test]
 fn validate_nonexistent_file() {
     pgroles_cmd()
         .args([
@@ -908,6 +929,81 @@ roles:
 
     #[test]
     #[ignore]
+    fn additive_mode_does_not_transfer_schema_owner() {
+        let schema = unique_name("schema_owner_additive");
+        let old_owner = unique_name("old_owner");
+        let new_owner = unique_name("new_owner");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            CREATE ROLE "{old_owner}";
+            CREATE ROLE "{new_owner}";
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{old_owner}";
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+schemas:
+  - name: {schema}
+    owner: {new_owner}
+    profiles: []
+
+roles:
+  - name: {old_owner}
+  - name: {new_owner}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--mode",
+                "additive",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
+        assert_eq!(
+            query_schema_owner(&schema).as_deref(),
+            Some(old_owner.as_str()),
+            "additive mode should not transfer schema ownership"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--mode",
+                "additive",
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    #[test]
+    #[ignore]
     fn apply_converges_existing_schema_owner_and_uses_owner_for_default_privileges() {
         let schema = unique_name("schema_owner");
         let old_owner = unique_name("old_owner");
@@ -996,6 +1092,42 @@ roles:
 
     #[test]
     #[ignore]
+    fn apply_declared_schema_with_missing_owner_role_fails_clearly() {
+        let schema = unique_name("missing_owner_schema");
+        let missing_owner = unique_name("missing_owner_role");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{missing_owner}";
+            "#
+        ));
+
+        execute_sql(&format!(r#"DROP SCHEMA IF EXISTS "{schema}" CASCADE;"#));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+schemas:
+  - name: {schema}
+    owner: {missing_owner}
+    profiles: []
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains(missing_owner.as_str()));
+    }
+
+    #[test]
+    #[ignore]
     fn generate_output_to_stdout_has_no_nulls() {
         let output = pgroles_cmd()
             .args(["generate", "--database-url", &database_url()])
@@ -1011,6 +1143,46 @@ roles:
             "generated YAML should not contain null fields"
         );
         assert!(yaml.contains("roles:"), "expected roles section in output");
+    }
+
+    #[test]
+    #[ignore]
+    fn generate_includes_schema_owned_by_postgres_without_user_roles() {
+        let schema = unique_name("generate_schema_only");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            CREATE SCHEMA "{schema}" AUTHORIZATION postgres;
+            "#
+        ));
+
+        let output = pgroles_cmd()
+            .args(["generate", "--database-url", &database_url()])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let yaml = String::from_utf8(output).expect("output is not valid UTF-8");
+        assert!(
+            yaml.contains("schemas:"),
+            "expected schemas section in output"
+        );
+        assert!(
+            yaml.contains(&format!("- name: {schema}")),
+            "expected generated manifest to include schema {schema}: {yaml}"
+        );
+        assert!(
+            yaml.contains("owner: postgres"),
+            "expected generated manifest to include postgres schema owner: {yaml}"
+        );
     }
 
     #[test]

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -786,6 +786,35 @@ mod live_db {
         })
     }
 
+    fn query_default_acl_owner(schema: &str, grantee: &str, object_type: &str) -> Option<String> {
+        with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            let row = sqlx::query(
+                r#"
+                SELECT owner_role.rolname AS owner
+                FROM pg_default_acl da
+                JOIN pg_roles owner_role ON owner_role.oid = da.defaclrole
+                JOIN pg_namespace n ON n.oid = da.defaclnamespace
+                CROSS JOIN LATERAL aclexplode(da.defaclacl) AS acl
+                JOIN pg_roles grantee_role ON grantee_role.oid = acl.grantee
+                WHERE n.nspname = $1
+                  AND grantee_role.rolname = $2
+                  AND da.defaclobjtype::text = $3
+                LIMIT 1
+                "#,
+            )
+            .bind(schema)
+            .bind(grantee)
+            .bind(object_type)
+            .fetch_optional(&pool)
+            .await
+            .expect("failed to query default privilege owner");
+            row.map(|row| row.get("owner"))
+        })
+    }
+
     async fn open_role_connection(role: &str, password: &str) -> PgConnection {
         let options = PgConnectOptions::from_str(&database_url())
             .expect("failed to parse DATABASE_URL")
@@ -794,6 +823,161 @@ mod live_db {
         PgConnection::connect_with(&options)
             .await
             .expect("failed to connect as retired role")
+    }
+
+    #[test]
+    #[ignore]
+    fn apply_creates_declared_schema_with_owner() {
+        let schema = unique_name("owned_schema");
+        let owner_role = unique_name("owned_schema_owner");
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+default_owner: postgres
+
+schemas:
+  - name: {schema}
+    owner: {owner_role}
+    profiles: []
+
+roles:
+  - name: {owner_role}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success();
+
+        assert_eq!(
+            query_schema_owner(&schema).as_deref(),
+            Some(owner_role.as_str()),
+            "schema should be created with the declared owner"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{owner_role}";
+            "#
+        ));
+    }
+
+    #[test]
+    #[ignore]
+    fn apply_converges_existing_schema_owner_and_uses_owner_for_default_privileges() {
+        let schema = unique_name("schema_owner");
+        let old_owner = unique_name("old_owner");
+        let new_owner = unique_name("new_owner");
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{schema}-editor";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            CREATE ROLE "{old_owner}";
+            CREATE ROLE "{new_owner}";
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{old_owner}";
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+profiles:
+  editor:
+    grants:
+      - privileges: [USAGE]
+        object: {{ type: schema }}
+      - privileges: [SELECT]
+        object: {{ type: table, name: "*" }}
+    default_privileges:
+      - privileges: [SELECT]
+        on_type: table
+
+schemas:
+  - name: {schema}
+    owner: {new_owner}
+    profiles: [editor]
+
+roles:
+  - name: {old_owner}
+  - name: {new_owner}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success();
+
+        assert_eq!(
+            query_schema_owner(&schema).as_deref(),
+            Some(new_owner.as_str()),
+            "schema owner should be converged"
+        );
+        assert_eq!(
+            query_default_acl_owner(&schema, &format!("{schema}-editor"), "r").as_deref(),
+            Some(new_owner.as_str()),
+            "default privileges should be attached to the schema owner"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{schema}-editor";
+            DROP ROLE IF EXISTS "{new_owner}";
+            DROP ROLE IF EXISTS "{old_owner}";
+            "#
+        ));
     }
 
     #[test]

--- a/crates/pgroles-core/Cargo.toml
+++ b/crates/pgroles-core/Cargo.toml
@@ -19,9 +19,9 @@ schemars = { workspace = true }
 thiserror = { workspace = true }
 
 # SCRAM-SHA-256 verifier computation
-sha2 = "0.10"
-hmac = "0.12"
-pbkdf2 = "0.12"
-base64 = "0.22"
-rand = "0.9"
+sha2 = "0.11"
+hmac = "0.13"
+pbkdf2 = "0.13.0"
+base64 = "0.22.1"
+rand = "0.10.1"
 zeroize = "1"

--- a/crates/pgroles-core/src/composition.rs
+++ b/crates/pgroles-core/src/composition.rs
@@ -1,0 +1,944 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::manifest::{
+    AuthProvider, DefaultPrivilege, ExpandedManifest, Grant, ManifestError, Membership,
+    PolicyManifest, Profile, RoleDefinition, RoleRetirement, SchemaBinding, SchemaBindingFacet,
+    default_role_pattern, expand_manifest,
+};
+use crate::model::{DefaultPrivKey, GrantKey, RoleGraph};
+use crate::ownership::{
+    ManagedChangeSurface, ManagedScope, MembershipKey, OwnershipIndex, SchemaFacetKey,
+};
+use crate::report::BundleReportContext;
+
+#[derive(Debug, Error)]
+pub enum CompositionError {
+    #[error("YAML parse error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    #[error("policy bundle must declare at least one source")]
+    MissingSources,
+
+    #[error("policy document \"{document}\" defines role \"{role}\" outside its declared scope")]
+    RoleOutOfScope { document: String, role: String },
+
+    #[error(
+        "policy document \"{document}\" manages schema \"{schema}\" owner outside its declared scope"
+    )]
+    SchemaOwnerOutOfScope { document: String, schema: String },
+
+    #[error(
+        "policy document \"{document}\" manages schema \"{schema}\" bindings outside its declared scope"
+    )]
+    SchemaBindingsOutOfScope { document: String, schema: String },
+
+    #[error("policy documents \"{first}\" and \"{second}\" both manage role \"{role}\"")]
+    DuplicateManagedRole {
+        role: String,
+        first: String,
+        second: String,
+    },
+
+    #[error(
+        "policy documents \"{first}\" and \"{second}\" both manage schema facet \"{schema}.{facet}\""
+    )]
+    DuplicateManagedSchemaFacet {
+        schema: String,
+        facet: String,
+        first: String,
+        second: String,
+    },
+
+    #[error("policy documents \"{first}\" and \"{second}\" both manage grant {target}")]
+    DuplicateManagedGrant {
+        target: String,
+        first: String,
+        second: String,
+    },
+
+    #[error("policy documents \"{first}\" and \"{second}\" both manage default privilege {target}")]
+    DuplicateManagedDefaultPrivilege {
+        target: String,
+        first: String,
+        second: String,
+    },
+
+    #[error(
+        "policy documents \"{first}\" and \"{second}\" both manage membership \"{role}\" -> \"{member}\""
+    )]
+    DuplicateManagedMembership {
+        role: String,
+        member: String,
+        first: String,
+        second: String,
+    },
+
+    #[error("policy document \"{document}\" failed validation: {error}")]
+    InvalidDocument {
+        document: String,
+        error: ManifestError,
+    },
+
+    #[error("composed policy failed validation: {0}")]
+    InvalidComposedManifest(ManifestError),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PolicyBundle {
+    #[serde(default)]
+    pub shared: SharedPolicy,
+
+    #[serde(default)]
+    pub sources: Vec<BundleSource>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SharedPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_owner: Option<String>,
+
+    #[serde(default)]
+    pub auth_providers: Vec<AuthProvider>,
+
+    #[serde(default)]
+    pub profiles: HashMap<String, Profile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleSource {
+    pub file: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyDocument {
+    pub source: String,
+    pub fragment: PolicyFragment,
+}
+
+impl PolicyDocument {
+    pub fn label(&self) -> &str {
+        self.fragment
+            .policy
+            .name
+            .as_deref()
+            .unwrap_or(self.source.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PolicyFragment {
+    #[serde(default)]
+    pub policy: FragmentMetadata,
+
+    #[serde(default)]
+    pub scope: FragmentScope,
+
+    #[serde(default)]
+    pub schemas: Vec<SchemaBinding>,
+
+    #[serde(default)]
+    pub roles: Vec<RoleDefinition>,
+
+    #[serde(default)]
+    pub grants: Vec<Grant>,
+
+    #[serde(default)]
+    pub default_privileges: Vec<DefaultPrivilege>,
+
+    #[serde(default)]
+    pub memberships: Vec<Membership>,
+
+    #[serde(default)]
+    pub retirements: Vec<RoleRetirement>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FragmentMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FragmentScope {
+    #[serde(default)]
+    pub roles: Vec<String>,
+
+    #[serde(default)]
+    pub schemas: Vec<ScopedSchema>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScopedSchema {
+    pub name: String,
+
+    #[serde(default)]
+    pub facets: Vec<SchemaBindingFacet>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComposedPolicy {
+    pub manifest: PolicyManifest,
+    pub expanded: ExpandedManifest,
+    pub desired: RoleGraph,
+    pub ownership: OwnershipIndex,
+    pub managed_scope: ManagedScope,
+    pub managed_change_surface: ManagedChangeSurface,
+}
+
+impl ComposedPolicy {
+    pub fn report_context(&self) -> BundleReportContext<'_> {
+        BundleReportContext {
+            ownership: &self.ownership,
+            managed_scope: &self.managed_scope,
+        }
+    }
+}
+
+pub fn parse_policy_bundle(yaml: &str) -> Result<PolicyBundle, CompositionError> {
+    Ok(serde_yaml::from_str(yaml)?)
+}
+
+pub fn parse_policy_fragment(yaml: &str) -> Result<PolicyFragment, CompositionError> {
+    Ok(serde_yaml::from_str(yaml)?)
+}
+
+pub fn compose_bundle(
+    bundle: &PolicyBundle,
+    documents: &[PolicyDocument],
+) -> Result<ComposedPolicy, CompositionError> {
+    if bundle.sources.is_empty() || documents.is_empty() {
+        return Err(CompositionError::MissingSources);
+    }
+
+    let mut ownership = OwnershipIndex::default();
+    let mut merged_schemas: BTreeMap<String, SchemaBinding> = BTreeMap::new();
+    let mut manifest = PolicyManifest {
+        default_owner: bundle.shared.default_owner.clone(),
+        auth_providers: bundle.shared.auth_providers.clone(),
+        profiles: bundle.shared.profiles.clone(),
+        schemas: Vec::new(),
+        roles: Vec::new(),
+        grants: Vec::new(),
+        default_privileges: Vec::new(),
+        memberships: Vec::new(),
+        retirements: Vec::new(),
+    };
+
+    for document in documents {
+        validate_document_scope(bundle, document)?;
+
+        let document_manifest = document_manifest(bundle, &document.fragment);
+        let expanded = expand_manifest(&document_manifest).map_err(|error| {
+            CompositionError::InvalidDocument {
+                document: document.label().to_string(),
+                error,
+            }
+        })?;
+        let desired =
+            RoleGraph::from_expanded(&expanded, document_manifest.default_owner.as_deref())
+                .map_err(|error| CompositionError::InvalidDocument {
+                    document: document.label().to_string(),
+                    error,
+                })?;
+
+        register_document_ownership(&mut ownership, document, &expanded, &desired)?;
+        merge_document_manifest(&mut manifest, &mut merged_schemas, &document.fragment);
+    }
+
+    manifest.schemas = merged_schemas.into_values().collect();
+
+    let expanded = expand_manifest(&manifest).map_err(CompositionError::InvalidComposedManifest)?;
+    let desired = RoleGraph::from_expanded(&expanded, manifest.default_owner.as_deref())
+        .map_err(CompositionError::InvalidComposedManifest)?;
+    let managed_scope = ownership.managed_scope();
+    let managed_change_surface = ownership.managed_change_surface();
+
+    Ok(ComposedPolicy {
+        manifest,
+        expanded,
+        desired,
+        ownership,
+        managed_scope,
+        managed_change_surface,
+    })
+}
+
+fn document_manifest(bundle: &PolicyBundle, fragment: &PolicyFragment) -> PolicyManifest {
+    PolicyManifest {
+        default_owner: bundle.shared.default_owner.clone(),
+        auth_providers: bundle.shared.auth_providers.clone(),
+        profiles: bundle.shared.profiles.clone(),
+        schemas: fragment.schemas.clone(),
+        roles: fragment.roles.clone(),
+        grants: fragment.grants.clone(),
+        default_privileges: fragment.default_privileges.clone(),
+        memberships: fragment.memberships.clone(),
+        retirements: fragment.retirements.clone(),
+    }
+}
+
+fn validate_document_scope(
+    bundle: &PolicyBundle,
+    document: &PolicyDocument,
+) -> Result<(), CompositionError> {
+    let owned_roles: BTreeSet<&str> = document
+        .fragment
+        .scope
+        .roles
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let schema_scope = schema_scope_map(&document.fragment.scope);
+    let document_name = document.label().to_string();
+
+    for role in &document.fragment.roles {
+        if !owned_roles.contains(role.name.as_str()) {
+            return Err(CompositionError::RoleOutOfScope {
+                document: document_name.clone(),
+                role: role.name.clone(),
+            });
+        }
+    }
+
+    for retirement in &document.fragment.retirements {
+        if !owned_roles.contains(retirement.role.as_str()) {
+            return Err(CompositionError::RoleOutOfScope {
+                document: document_name.clone(),
+                role: retirement.role.clone(),
+            });
+        }
+    }
+
+    for schema in &document.fragment.schemas {
+        let manages_bindings =
+            !schema.profiles.is_empty() || schema.role_pattern != default_role_pattern();
+        if manages_bindings
+            && !has_schema_facet(&schema_scope, &schema.name, SchemaBindingFacet::Bindings)
+        {
+            return Err(CompositionError::SchemaBindingsOutOfScope {
+                document: document_name.clone(),
+                schema: schema.name.clone(),
+            });
+        }
+
+        let manages_owner = schema.owner.is_some() || bundle.shared.default_owner.is_some();
+        if manages_owner
+            && !has_schema_facet(&schema_scope, &schema.name, SchemaBindingFacet::Owner)
+        {
+            return Err(CompositionError::SchemaOwnerOutOfScope {
+                document: document_name.clone(),
+                schema: schema.name.clone(),
+            });
+        }
+    }
+
+    for grant in &document.fragment.grants {
+        if let Some(schema) = schema_name_for_grant(grant)
+            && !has_schema_facet(&schema_scope, schema, SchemaBindingFacet::Bindings)
+        {
+            return Err(CompositionError::SchemaBindingsOutOfScope {
+                document: document_name.clone(),
+                schema: schema.to_string(),
+            });
+        }
+    }
+
+    for default_privilege in &document.fragment.default_privileges {
+        if !has_schema_facet(
+            &schema_scope,
+            &default_privilege.schema,
+            SchemaBindingFacet::Bindings,
+        ) {
+            return Err(CompositionError::SchemaBindingsOutOfScope {
+                document: document_name.clone(),
+                schema: default_privilege.schema.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn schema_scope_map(scope: &FragmentScope) -> BTreeMap<String, BTreeSet<SchemaBindingFacet>> {
+    let mut result = BTreeMap::new();
+
+    for schema in &scope.schemas {
+        let entry = result
+            .entry(schema.name.clone())
+            .or_insert_with(BTreeSet::new);
+        for facet in &schema.facets {
+            entry.insert(*facet);
+        }
+    }
+
+    result
+}
+
+fn has_schema_facet(
+    scope: &BTreeMap<String, BTreeSet<SchemaBindingFacet>>,
+    schema: &str,
+    facet: SchemaBindingFacet,
+) -> bool {
+    scope
+        .get(schema)
+        .is_some_and(|facets| facets.contains(&facet))
+}
+
+fn schema_name_for_grant(grant: &Grant) -> Option<&str> {
+    match grant.object.object_type {
+        crate::manifest::ObjectType::Database => None,
+        crate::manifest::ObjectType::Schema => grant.object.name.as_deref(),
+        _ => grant.object.schema.as_deref(),
+    }
+}
+
+fn register_document_ownership(
+    ownership: &mut OwnershipIndex,
+    document: &PolicyDocument,
+    expanded: &ExpandedManifest,
+    desired: &RoleGraph,
+) -> Result<(), CompositionError> {
+    let label = document.label().to_string();
+
+    for role in &expanded.roles {
+        register_role_owner(ownership, &role.name, &label)?;
+    }
+
+    for retirement in &document.fragment.retirements {
+        register_role_owner(ownership, &retirement.role, &label)?;
+    }
+
+    for schema in &document.fragment.scope.schemas {
+        for facet in &schema.facets {
+            register_schema_facet_owner(ownership, &schema.name, *facet, &label)?;
+        }
+    }
+
+    for grant in desired.grants.keys() {
+        register_grant_owner(ownership, grant, &label)?;
+    }
+
+    for default_privilege in desired.default_privileges.keys() {
+        register_default_privilege_owner(ownership, default_privilege, &label)?;
+    }
+
+    for membership in &desired.memberships {
+        register_membership_owner(
+            ownership,
+            &MembershipKey {
+                role: membership.role.clone(),
+                member: membership.member.clone(),
+            },
+            &label,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn register_role_owner(
+    ownership: &mut OwnershipIndex,
+    role: &str,
+    owner: &str,
+) -> Result<(), CompositionError> {
+    if let Some(existing) = ownership.roles.insert(role.to_string(), owner.to_string()) {
+        return Err(CompositionError::DuplicateManagedRole {
+            role: role.to_string(),
+            first: existing,
+            second: owner.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn register_schema_facet_owner(
+    ownership: &mut OwnershipIndex,
+    schema: &str,
+    facet: SchemaBindingFacet,
+    owner: &str,
+) -> Result<(), CompositionError> {
+    let key = SchemaFacetKey {
+        schema: schema.to_string(),
+        facet,
+    };
+
+    if let Some(existing) = ownership
+        .schema_facets
+        .insert(key.clone(), owner.to_string())
+    {
+        return Err(CompositionError::DuplicateManagedSchemaFacet {
+            schema: schema.to_string(),
+            facet: facet.to_string(),
+            first: existing,
+            second: owner.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn register_grant_owner(
+    ownership: &mut OwnershipIndex,
+    key: &GrantKey,
+    owner: &str,
+) -> Result<(), CompositionError> {
+    if let Some(existing) = ownership.grants.insert(key.clone(), owner.to_string()) {
+        return Err(CompositionError::DuplicateManagedGrant {
+            target: format_grant_key(key),
+            first: existing,
+            second: owner.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn register_default_privilege_owner(
+    ownership: &mut OwnershipIndex,
+    key: &DefaultPrivKey,
+    owner: &str,
+) -> Result<(), CompositionError> {
+    if let Some(existing) = ownership
+        .default_privileges
+        .insert(key.clone(), owner.to_string())
+    {
+        return Err(CompositionError::DuplicateManagedDefaultPrivilege {
+            target: format_default_privilege_key(key),
+            first: existing,
+            second: owner.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn register_membership_owner(
+    ownership: &mut OwnershipIndex,
+    key: &MembershipKey,
+    owner: &str,
+) -> Result<(), CompositionError> {
+    if let Some(existing) = ownership.memberships.insert(key.clone(), owner.to_string()) {
+        return Err(CompositionError::DuplicateManagedMembership {
+            role: key.role.clone(),
+            member: key.member.clone(),
+            first: existing,
+            second: owner.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn format_grant_key(key: &GrantKey) -> String {
+    let target = match (&key.schema, &key.name) {
+        (Some(schema), Some(name)) => format!("{schema}.{name}"),
+        (Some(schema), None) => schema.clone(),
+        (None, Some(name)) => name.clone(),
+        (None, None) => "<unnamed>".to_string(),
+    };
+
+    format!(
+        "for role \"{}\" on {} \"{}\"",
+        key.role, key.object_type, target
+    )
+}
+
+fn format_default_privilege_key(key: &DefaultPrivKey) -> String {
+    format!(
+        "owner \"{}\" schema \"{}\" on {} to \"{}\"",
+        key.owner, key.schema, key.on_type, key.grantee
+    )
+}
+
+fn merge_document_manifest(
+    manifest: &mut PolicyManifest,
+    merged_schemas: &mut BTreeMap<String, SchemaBinding>,
+    fragment: &PolicyFragment,
+) {
+    manifest.roles.extend(fragment.roles.clone());
+    manifest.grants.extend(fragment.grants.clone());
+    manifest
+        .default_privileges
+        .extend(fragment.default_privileges.clone());
+    manifest.memberships.extend(fragment.memberships.clone());
+    manifest.retirements.extend(fragment.retirements.clone());
+
+    for schema in &fragment.schemas {
+        let entry = merged_schemas
+            .entry(schema.name.clone())
+            .or_insert_with(|| SchemaBinding {
+                name: schema.name.clone(),
+                profiles: Vec::new(),
+                role_pattern: default_role_pattern(),
+                owner: None,
+            });
+
+        if schema.owner.is_some() {
+            entry.owner = schema.owner.clone();
+        }
+
+        if !schema.profiles.is_empty() {
+            entry.profiles = schema.profiles.clone();
+        }
+
+        if schema.role_pattern != default_role_pattern() {
+            entry.role_pattern = schema.role_pattern.clone();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::Change;
+    use crate::manifest::{ObjectType, Privilege};
+    use crate::ownership::{
+        ManagedChangeError, ManagedChangeSurface, ManagedSchemaScope, OwnershipIndex,
+        validate_changes_against_managed_surface,
+    };
+
+    fn bundle_with_editor_profile() -> PolicyBundle {
+        let bundle = r#"
+shared:
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+"#;
+        parse_policy_bundle(bundle).expect("bundle should parse")
+    }
+
+    #[test]
+    fn compose_bundle_merges_schema_owner_and_bindings() {
+        let bundle = bundle_with_editor_profile();
+        let platform = PolicyDocument {
+            source: "platform.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: platform
+scope:
+  roles: [app_owner]
+  schemas:
+    - name: inventory
+      facets: [owner]
+roles:
+  - name: app_owner
+    login: false
+schemas:
+  - name: inventory
+    owner: app_owner
+"#,
+            )
+            .expect("platform fragment should parse"),
+        };
+        let app = PolicyDocument {
+            source: "app.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: app
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+schemas:
+  - name: inventory
+    profiles: [editor]
+"#,
+            )
+            .expect("app fragment should parse"),
+        };
+
+        let composed = compose_bundle(&bundle, &[platform, app]).expect("bundle should compose");
+
+        assert_eq!(composed.expanded.schemas.len(), 1);
+        assert_eq!(
+            composed.expanded.schemas[0].owner.as_deref(),
+            Some("app_owner")
+        );
+        assert!(composed.desired.roles.contains_key("inventory-editor"));
+        assert!(composed.ownership.roles.contains_key("inventory-editor"));
+        assert_eq!(
+            composed.managed_scope.schemas.get("inventory"),
+            Some(&ManagedSchemaScope {
+                owner: true,
+                bindings: true
+            })
+        );
+    }
+
+    #[test]
+    fn compose_bundle_rejects_role_outside_scope() {
+        let bundle = PolicyBundle {
+            shared: SharedPolicy::default(),
+            sources: vec![BundleSource {
+                file: "app.yaml".to_string(),
+            }],
+        };
+        let document = PolicyDocument {
+            source: "app.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+roles:
+  - name: app
+    login: true
+"#,
+            )
+            .expect("fragment should parse"),
+        };
+
+        let error = compose_bundle(&bundle, &[document]).expect_err("scope validation should fail");
+        assert!(matches!(
+            error,
+            CompositionError::RoleOutOfScope { role, .. } if role == "app"
+        ));
+    }
+
+    #[test]
+    fn compose_bundle_rejects_duplicate_generated_roles() {
+        let bundle = PolicyBundle {
+            shared: SharedPolicy {
+                profiles: HashMap::from([(
+                    "viewer".to_string(),
+                    Profile {
+                        login: None,
+                        grants: vec![],
+                        default_privileges: vec![],
+                    },
+                )]),
+                ..SharedPolicy::default()
+            },
+            sources: vec![
+                BundleSource {
+                    file: "a.yaml".to_string(),
+                },
+                BundleSource {
+                    file: "b.yaml".to_string(),
+                },
+            ],
+        };
+        let first = PolicyDocument {
+            source: "a.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: first
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+schemas:
+  - name: inventory
+    profiles: [viewer]
+"#,
+            )
+            .expect("first fragment should parse"),
+        };
+        let second = PolicyDocument {
+            source: "b.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: second
+scope:
+  roles: [inventory-viewer]
+roles:
+  - name: inventory-viewer
+    login: true
+"#,
+            )
+            .expect("second fragment should parse"),
+        };
+
+        let error =
+            compose_bundle(&bundle, &[first, second]).expect_err("generated role should conflict");
+        assert!(matches!(
+            error,
+            CompositionError::DuplicateManagedRole { role, .. } if role == "inventory-viewer"
+        ));
+    }
+
+    #[test]
+    fn compose_bundle_rejects_duplicate_grants() {
+        let bundle = PolicyBundle {
+            shared: SharedPolicy::default(),
+            sources: vec![
+                BundleSource {
+                    file: "a.yaml".to_string(),
+                },
+                BundleSource {
+                    file: "b.yaml".to_string(),
+                },
+            ],
+        };
+        let first = PolicyDocument {
+            source: "a.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: first
+scope:
+  roles: [app]
+roles:
+  - name: app
+grants:
+  - role: app
+    privileges: [CONNECT]
+    object: { type: database, name: appdb }
+"#,
+            )
+            .expect("first fragment should parse"),
+        };
+        let second = PolicyDocument {
+            source: "b.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: second
+grants:
+  - role: app
+    privileges: [CREATE]
+    object: { type: database, name: appdb }
+"#,
+            )
+            .expect("second fragment should parse"),
+        };
+
+        let error =
+            compose_bundle(&bundle, &[first, second]).expect_err("grant ownership should conflict");
+        assert!(matches!(
+            error,
+            CompositionError::DuplicateManagedGrant { first, second, .. }
+                if first == "first" && second == "second"
+        ));
+    }
+
+    #[test]
+    fn register_default_privilege_owner_rejects_duplicates() {
+        let mut ownership = OwnershipIndex::default();
+        let key = DefaultPrivKey {
+            owner: "app_owner".to_string(),
+            schema: "inventory".to_string(),
+            on_type: crate::manifest::ObjectType::Table,
+            grantee: "app".to_string(),
+        };
+
+        register_default_privilege_owner(&mut ownership, &key, "first")
+            .expect("first owner should register");
+        let error = register_default_privilege_owner(&mut ownership, &key, "second")
+            .expect_err("default privilege ownership should conflict");
+        assert!(matches!(
+            error,
+            CompositionError::DuplicateManagedDefaultPrivilege { first, second, .. }
+                if first == "first" && second == "second"
+        ));
+    }
+
+    #[test]
+    fn compose_bundle_rejects_duplicate_membership_selectors() {
+        let bundle = PolicyBundle {
+            shared: SharedPolicy::default(),
+            sources: vec![
+                BundleSource {
+                    file: "a.yaml".to_string(),
+                },
+                BundleSource {
+                    file: "b.yaml".to_string(),
+                },
+            ],
+        };
+        let first = PolicyDocument {
+            source: "a.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: first
+memberships:
+  - role: editor
+    members:
+      - name: app
+"#,
+            )
+            .expect("first fragment should parse"),
+        };
+        let second = PolicyDocument {
+            source: "b.yaml".to_string(),
+            fragment: parse_policy_fragment(
+                r#"
+policy:
+  name: second
+memberships:
+  - role: editor
+    members:
+      - name: app
+        admin: true
+"#,
+            )
+            .expect("second fragment should parse"),
+        };
+
+        let error = compose_bundle(&bundle, &[first, second])
+            .expect_err("membership ownership should conflict");
+        assert!(matches!(
+            error,
+            CompositionError::DuplicateManagedMembership { role, member, .. }
+                if role == "editor" && member == "app"
+        ));
+    }
+
+    #[test]
+    fn managed_surface_allows_revoke_of_removed_database_grant_for_managed_role() {
+        let surface = ManagedChangeSurface {
+            roles: BTreeSet::from(["app".to_string()]),
+            ..ManagedChangeSurface::default()
+        };
+
+        let result = validate_changes_against_managed_surface(
+            &[Change::Revoke {
+                role: "app".to_string(),
+                privileges: BTreeSet::from([Privilege::Connect]),
+                object_type: ObjectType::Database,
+                schema: None,
+                name: Some("appdb".to_string()),
+            }],
+            &surface,
+        );
+
+        assert!(result.is_ok(), "managed role should own database revokes");
+    }
+
+    #[test]
+    fn managed_surface_rejects_unmanaged_membership_removal() {
+        let surface = ManagedChangeSurface::default();
+
+        let error = validate_changes_against_managed_surface(
+            &[Change::RemoveMember {
+                role: "editor".to_string(),
+                member: "app".to_string(),
+            }],
+            &surface,
+        )
+        .expect_err("unmanaged membership removal should be rejected");
+
+        assert!(matches!(
+            error,
+            ManagedChangeError::OutOfScope { change } if change.contains("remove membership")
+        ));
+    }
+
+    #[test]
+    fn schema_scope_facet_display_matches_yaml_values() {
+        assert_eq!(SchemaBindingFacet::Owner.to_string(), "owner");
+        assert_eq!(SchemaBindingFacet::Bindings.to_string(), "bindings");
+        assert_eq!(Privilege::Usage.to_string(), "USAGE");
+    }
+}

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -34,6 +34,12 @@ pub enum Change {
     /// Create a new role with the given attributes.
     CreateRole { name: String, state: RoleState },
 
+    /// Create a schema, optionally assigning an owner up front.
+    CreateSchema { name: String, owner: Option<String> },
+
+    /// Change an existing schema's owner.
+    AlterSchemaOwner { name: String, owner: String },
+
     /// Alter an existing role's attributes.
     AlterRole {
         name: String,
@@ -228,6 +234,7 @@ fn is_role_drop_or_retirement(change: &Change) -> bool {
 pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
     let mut creates = Vec::new();
     let mut alters = Vec::new();
+    let mut schema_changes = Vec::new();
     let mut grants = Vec::new();
     let mut set_defaults = Vec::new();
     let mut add_members = Vec::new();
@@ -274,6 +281,10 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
         }
     }
 
+    // ----- Schemas -----
+
+    diff_schemas(current, desired, &mut schema_changes);
+
     // ----- Grants -----
 
     diff_grants(current, desired, &mut grants, &mut revokes);
@@ -290,6 +301,7 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
     let mut changes = Vec::new();
     changes.extend(creates);
     changes.extend(alters);
+    changes.extend(schema_changes);
     changes.extend(grants);
     changes.extend(set_defaults);
     changes.extend(remove_members);
@@ -298,6 +310,27 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
     changes.extend(revokes);
     changes.extend(drops);
     changes
+}
+
+fn diff_schemas(current: &RoleGraph, desired: &RoleGraph, out: &mut Vec<Change>) {
+    for (name, desired_state) in &desired.schemas {
+        match current.schemas.get(name) {
+            None => out.push(Change::CreateSchema {
+                name: name.clone(),
+                owner: desired_state.owner.clone(),
+            }),
+            Some(current_state) => {
+                if current_state.owner != desired_state.owner
+                    && let Some(owner) = &desired_state.owner
+                {
+                    out.push(Change::AlterSchemaOwner {
+                        name: name.clone(),
+                        owner: owner.clone(),
+                    });
+                }
+            }
+        }
+    }
 }
 
 /// Augment a diff plan with explicit role-retirement actions.
@@ -654,7 +687,7 @@ fn diff_memberships(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{DefaultPrivState, GrantState};
+    use crate::model::{DefaultPrivState, GrantState, SchemaState};
 
     /// Helper: build an empty graph.
     fn empty_graph() -> RoleGraph {
@@ -718,6 +751,72 @@ mod tests {
             }
             other => panic!("expected AlterRole, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn diff_creates_missing_schema() {
+        let current = empty_graph();
+        let mut desired = empty_graph();
+        desired.schemas.insert(
+            "inventory".to_string(),
+            SchemaState {
+                owner: Some("inventory_owner".to_string()),
+            },
+        );
+
+        let changes = diff(&current, &desired);
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(
+            &changes[0],
+            Change::CreateSchema { name, owner }
+                if name == "inventory" && owner.as_deref() == Some("inventory_owner")
+        ));
+    }
+
+    #[test]
+    fn diff_alters_schema_owner_when_different() {
+        let mut current = empty_graph();
+        current.schemas.insert(
+            "inventory".to_string(),
+            SchemaState {
+                owner: Some("old_owner".to_string()),
+            },
+        );
+
+        let mut desired = empty_graph();
+        desired.schemas.insert(
+            "inventory".to_string(),
+            SchemaState {
+                owner: Some("new_owner".to_string()),
+            },
+        );
+
+        let changes = diff(&current, &desired);
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(
+            &changes[0],
+            Change::AlterSchemaOwner { name, owner }
+                if name == "inventory" && owner == "new_owner"
+        ));
+    }
+
+    #[test]
+    fn diff_does_not_alter_schema_owner_when_unmanaged() {
+        let mut current = empty_graph();
+        current.schemas.insert(
+            "inventory".to_string(),
+            SchemaState {
+                owner: Some("old_owner".to_string()),
+            },
+        );
+
+        let mut desired = empty_graph();
+        desired
+            .schemas
+            .insert("inventory".to_string(), SchemaState { owner: None });
+
+        let changes = diff(&current, &desired);
+        assert!(changes.is_empty());
     }
 
     #[test]
@@ -952,11 +1051,16 @@ mod tests {
             .iter()
             .position(|c| matches!(c, Change::CreateRole { .. }))
             .unwrap();
+        let schema_idx = changes
+            .iter()
+            .position(|c| matches!(c, Change::CreateSchema { .. }))
+            .unwrap_or(create_idx);
         let drop_idx = changes
             .iter()
             .position(|c| matches!(c, Change::DropRole { .. }))
             .unwrap();
-        assert!(create_idx < drop_idx);
+        assert!(create_idx <= schema_idx);
+        assert!(schema_idx < drop_idx);
     }
 
     #[test]
@@ -1012,6 +1116,7 @@ profiles:
 
 schemas:
   - name: inventory
+    owner: inventory_owner
     profiles: [editor]
 
 memberships:
@@ -1028,10 +1133,14 @@ memberships:
         let current = RoleGraph::default();
         let changes = diff(&current, &desired);
 
-        // Should have: 1 CreateRole, 2 Grants, 1 SetDefaultPrivilege, 1 AddMember
+        // Should have: 1 CreateRole, 1 CreateSchema, 2 Grants, 1 SetDefaultPrivilege, 1 AddMember
         let create_count = changes
             .iter()
             .filter(|c| matches!(c, Change::CreateRole { .. }))
+            .count();
+        let create_schema_count = changes
+            .iter()
+            .filter(|c| matches!(c, Change::CreateSchema { .. }))
             .count();
         let grant_count = changes
             .iter()
@@ -1047,6 +1156,7 @@ memberships:
             .count();
 
         assert_eq!(create_count, 1);
+        assert_eq!(create_schema_count, 1);
         assert_eq!(grant_count, 2); // schema USAGE + table *
         assert_eq!(dp_count, 1);
         assert_eq!(member_count, 1);
@@ -1066,6 +1176,14 @@ memberships:
             Change::CreateRole {
                 name: "new-role".to_string(),
                 state: RoleState::default(),
+            },
+            Change::CreateSchema {
+                name: "inventory".to_string(),
+                owner: Some("inventory_owner".to_string()),
+            },
+            Change::AlterSchemaOwner {
+                name: "catalog".to_string(),
+                owner: "catalog_owner".to_string(),
             },
             Change::AlterRole {
                 name: "altered-role".to_string(),
@@ -1141,8 +1259,8 @@ memberships:
     fn filter_additive_keeps_only_constructive_changes() {
         let filtered = filter_changes(all_change_variants(), ReconciliationMode::Additive);
 
-        // Should keep: CreateRole, AlterRole, SetComment, Grant, SetDefaultPrivilege, AddMember
-        assert_eq!(filtered.len(), 6);
+        // Should keep: CreateRole, CreateSchema, AlterSchemaOwner, AlterRole, SetComment, Grant, SetDefaultPrivilege, AddMember
+        assert_eq!(filtered.len(), 8);
 
         // Verify no destructive changes remain
         for change in &filtered {
@@ -1166,6 +1284,16 @@ memberships:
             filtered
                 .iter()
                 .any(|c| matches!(c, Change::CreateRole { .. }))
+        );
+        assert!(
+            filtered
+                .iter()
+                .any(|c| matches!(c, Change::CreateSchema { .. }))
+        );
+        assert!(
+            filtered
+                .iter()
+                .any(|c| matches!(c, Change::AlterSchemaOwner { .. }))
         );
         assert!(
             filtered
@@ -1195,7 +1323,7 @@ memberships:
         let filtered = filter_changes(all_change_variants(), ReconciliationMode::Adopt);
 
         // Should keep everything except: DropRole, DropOwned, ReassignOwned, TerminateSessions
-        assert_eq!(filtered.len(), 9);
+        assert_eq!(filtered.len(), 11);
 
         // Verify no role-drop/retirement changes remain
         for change in &filtered {

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -11,7 +11,10 @@
 use std::collections::BTreeSet;
 
 use crate::manifest::{ObjectType, Privilege, RoleRetirement};
-use crate::model::{DefaultPrivKey, GrantKey, MembershipEdge, RoleAttribute, RoleGraph, RoleState};
+use crate::model::{
+    DefaultPrivKey, GrantKey, MembershipEdge, RoleAttribute, RoleGraph, RoleState,
+    default_schema_owner_privileges,
+};
 
 // ---------------------------------------------------------------------------
 // Change enum
@@ -39,6 +42,13 @@ pub enum Change {
 
     /// Change an existing schema's owner.
     AlterSchemaOwner { name: String, owner: String },
+
+    /// Restore the schema owner's ordinary CREATE/USAGE privileges.
+    EnsureSchemaOwnerPrivileges {
+        name: String,
+        owner: String,
+        privileges: BTreeSet<Privilege>,
+    },
 
     /// Alter an existing role's attributes.
     AlterRole {
@@ -187,15 +197,35 @@ impl std::fmt::Display for ReconciliationMode {
 pub fn filter_changes(changes: Vec<Change>, mode: ReconciliationMode) -> Vec<Change> {
     match mode {
         ReconciliationMode::Authoritative => changes,
-        ReconciliationMode::Additive => changes
-            .into_iter()
-            .filter(|change| !is_destructive(change))
-            .collect(),
+        ReconciliationMode::Additive => filter_additive_changes(changes),
         ReconciliationMode::Adopt => changes
             .into_iter()
             .filter(|change| !is_role_drop_or_retirement(change))
             .collect(),
     }
+}
+
+fn filter_additive_changes(changes: Vec<Change>) -> Vec<Change> {
+    let skipped_owner_transfers: BTreeSet<(String, String)> = changes
+        .iter()
+        .filter_map(|change| match change {
+            Change::AlterSchemaOwner { name, owner } => Some((name.clone(), owner.clone())),
+            _ => None,
+        })
+        .collect();
+
+    changes
+        .into_iter()
+        .filter(|change| match change {
+            Change::EnsureSchemaOwnerPrivileges { name, owner, .. } => {
+                !skipped_owner_transfers.contains(&(name.clone(), owner.clone()))
+            }
+            Change::SetDefaultPrivilege { schema, owner, .. } => {
+                !skipped_owner_transfers.contains(&(schema.clone(), owner.clone()))
+            }
+            _ => !is_destructive(change),
+        })
+        .collect()
 }
 
 /// Returns `true` for any change that removes access or drops a role.
@@ -236,6 +266,7 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
     let mut creates = Vec::new();
     let mut alters = Vec::new();
     let mut schema_changes = Vec::new();
+    let mut schema_grants = Vec::new();
     let mut grants = Vec::new();
     let mut set_defaults = Vec::new();
     let mut add_members = Vec::new();
@@ -284,7 +315,7 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
 
     // ----- Schemas -----
 
-    diff_schemas(current, desired, &mut schema_changes);
+    diff_schemas(current, desired, &mut schema_changes, &mut schema_grants);
 
     // ----- Grants -----
 
@@ -303,6 +334,7 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
     changes.extend(creates);
     changes.extend(alters);
     changes.extend(schema_changes);
+    changes.extend(schema_grants);
     changes.extend(grants);
     changes.extend(set_defaults);
     changes.extend(remove_members);
@@ -313,10 +345,15 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
     changes
 }
 
-fn diff_schemas(current: &RoleGraph, desired: &RoleGraph, out: &mut Vec<Change>) {
+fn diff_schemas(
+    current: &RoleGraph,
+    desired: &RoleGraph,
+    schema_out: &mut Vec<Change>,
+    grant_out: &mut Vec<Change>,
+) {
     for (name, desired_state) in &desired.schemas {
         match current.schemas.get(name) {
-            None => out.push(Change::CreateSchema {
+            None => schema_out.push(Change::CreateSchema {
                 name: name.clone(),
                 owner: desired_state.owner.clone(),
             }),
@@ -324,12 +361,39 @@ fn diff_schemas(current: &RoleGraph, desired: &RoleGraph, out: &mut Vec<Change>)
                 if current_state.owner != desired_state.owner
                     && let Some(owner) = &desired_state.owner
                 {
-                    out.push(Change::AlterSchemaOwner {
+                    schema_out.push(Change::AlterSchemaOwner {
                         name: name.clone(),
                         owner: owner.clone(),
                     });
                 }
             }
+        }
+
+        let Some(owner) = desired_state.owner.as_deref() else {
+            continue;
+        };
+
+        if !current.schemas.contains_key(name) {
+            continue;
+        }
+
+        let expected_privileges = default_schema_owner_privileges(owner);
+        let current_privileges = current
+            .schemas
+            .get(name)
+            .map(|state| state.owner_privileges.clone())
+            .unwrap_or_default();
+        let missing_privileges: BTreeSet<Privilege> = expected_privileges
+            .difference(&current_privileges)
+            .copied()
+            .collect();
+
+        if !missing_privileges.is_empty() {
+            grant_out.push(Change::EnsureSchemaOwnerPrivileges {
+                name: name.clone(),
+                owner: owner.to_string(),
+                privileges: missing_privileges,
+            });
         }
     }
 }
@@ -688,11 +752,20 @@ fn diff_memberships(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{DefaultPrivState, GrantState, SchemaState};
+    use crate::model::{
+        DefaultPrivState, GrantState, SchemaState, default_schema_owner_privileges,
+    };
 
     /// Helper: build an empty graph.
     fn empty_graph() -> RoleGraph {
         RoleGraph::default()
+    }
+
+    fn managed_schema(owner: &str) -> SchemaState {
+        SchemaState {
+            owner: Some(owner.to_string()),
+            owner_privileges: default_schema_owner_privileges(owner),
+        }
     }
 
     #[test]
@@ -758,12 +831,9 @@ mod tests {
     fn diff_creates_missing_schema() {
         let current = empty_graph();
         let mut desired = empty_graph();
-        desired.schemas.insert(
-            "inventory".to_string(),
-            SchemaState {
-                owner: Some("inventory_owner".to_string()),
-            },
-        );
+        desired
+            .schemas
+            .insert("inventory".to_string(), managed_schema("inventory_owner"));
 
         let changes = diff(&current, &desired);
         assert_eq!(changes.len(), 1);
@@ -777,20 +847,14 @@ mod tests {
     #[test]
     fn diff_alters_schema_owner_when_different() {
         let mut current = empty_graph();
-        current.schemas.insert(
-            "inventory".to_string(),
-            SchemaState {
-                owner: Some("old_owner".to_string()),
-            },
-        );
+        current
+            .schemas
+            .insert("inventory".to_string(), managed_schema("old_owner"));
 
         let mut desired = empty_graph();
-        desired.schemas.insert(
-            "inventory".to_string(),
-            SchemaState {
-                owner: Some("new_owner".to_string()),
-            },
-        );
+        desired
+            .schemas
+            .insert("inventory".to_string(), managed_schema("new_owner"));
 
         let changes = diff(&current, &desired);
         assert_eq!(changes.len(), 1);
@@ -804,20 +868,86 @@ mod tests {
     #[test]
     fn diff_does_not_alter_schema_owner_when_unmanaged() {
         let mut current = empty_graph();
+        current
+            .schemas
+            .insert("inventory".to_string(), managed_schema("old_owner"));
+
+        let mut desired = empty_graph();
+        desired.schemas.insert(
+            "inventory".to_string(),
+            SchemaState {
+                owner: None,
+                owner_privileges: BTreeSet::new(),
+            },
+        );
+
+        let changes = diff(&current, &desired);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn diff_restores_missing_owner_schema_privileges() {
+        let mut current = empty_graph();
         current.schemas.insert(
             "inventory".to_string(),
             SchemaState {
-                owner: Some("old_owner".to_string()),
+                owner: Some("inventory_owner".to_string()),
+                owner_privileges: BTreeSet::from([Privilege::Usage]),
             },
         );
 
         let mut desired = empty_graph();
         desired
             .schemas
-            .insert("inventory".to_string(), SchemaState { owner: None });
+            .insert("inventory".to_string(), managed_schema("inventory_owner"));
 
         let changes = diff(&current, &desired);
-        assert!(changes.is_empty());
+        assert_eq!(changes.len(), 1);
+        assert!(matches!(
+            &changes[0],
+            Change::EnsureSchemaOwnerPrivileges {
+                name,
+                owner,
+                privileges,
+            } if name == "inventory"
+                && owner == "inventory_owner"
+                && privileges == &BTreeSet::from([Privilege::Create])
+        ));
+    }
+
+    #[test]
+    fn diff_restores_owner_schema_privileges_after_transfer() {
+        let mut current = empty_graph();
+        current.schemas.insert(
+            "inventory".to_string(),
+            SchemaState {
+                owner: Some("old_owner".to_string()),
+                owner_privileges: BTreeSet::from([Privilege::Usage]),
+            },
+        );
+
+        let mut desired = empty_graph();
+        desired
+            .schemas
+            .insert("inventory".to_string(), managed_schema("new_owner"));
+
+        let changes = diff(&current, &desired);
+        assert_eq!(changes.len(), 2);
+        assert!(matches!(
+            &changes[0],
+            Change::AlterSchemaOwner { name, owner }
+                if name == "inventory" && owner == "new_owner"
+        ));
+        assert!(matches!(
+            &changes[1],
+            Change::EnsureSchemaOwnerPrivileges {
+                name,
+                owner,
+                privileges,
+            } if name == "inventory"
+                && owner == "new_owner"
+                && privileges == &BTreeSet::from([Privilege::Create])
+        ));
     }
 
     #[test]
@@ -1186,6 +1316,11 @@ memberships:
                 name: "catalog".to_string(),
                 owner: "catalog_owner".to_string(),
             },
+            Change::EnsureSchemaOwnerPrivileges {
+                name: "catalog".to_string(),
+                owner: "catalog_owner".to_string(),
+                privileges: BTreeSet::from([Privilege::Create, Privilege::Usage]),
+            },
             Change::AlterRole {
                 name: "altered-role".to_string(),
                 attributes: vec![RoleAttribute::Login(true)],
@@ -1269,6 +1404,7 @@ memberships:
                 !matches!(
                     change,
                     Change::AlterSchemaOwner { .. }
+                        | Change::EnsureSchemaOwnerPrivileges { .. }
                         | Change::Revoke { .. }
                         | Change::RevokeDefaultPrivilege { .. }
                         | Change::RemoveMember { .. }
@@ -1316,11 +1452,44 @@ memberships:
     }
 
     #[test]
+    fn filter_additive_skips_owner_bound_follow_ups_when_transfer_is_skipped() {
+        let changes = vec![
+            Change::AlterSchemaOwner {
+                name: "inventory".to_string(),
+                owner: "new_owner".to_string(),
+            },
+            Change::EnsureSchemaOwnerPrivileges {
+                name: "inventory".to_string(),
+                owner: "new_owner".to_string(),
+                privileges: BTreeSet::from([Privilege::Create, Privilege::Usage]),
+            },
+            Change::SetDefaultPrivilege {
+                owner: "new_owner".to_string(),
+                schema: "inventory".to_string(),
+                on_type: ObjectType::Table,
+                grantee: "inventory-editor".to_string(),
+                privileges: BTreeSet::from([Privilege::Select]),
+            },
+            Change::Grant {
+                role: "inventory-editor".to_string(),
+                privileges: BTreeSet::from([Privilege::Usage]),
+                object_type: ObjectType::Schema,
+                schema: None,
+                name: Some("inventory".to_string()),
+            },
+        ];
+
+        let filtered = filter_changes(changes, ReconciliationMode::Additive);
+        assert_eq!(filtered.len(), 1);
+        assert!(matches!(&filtered[0], Change::Grant { role, .. } if role == "inventory-editor"));
+    }
+
+    #[test]
     fn filter_adopt_keeps_revokes_but_not_drops() {
         let filtered = filter_changes(all_change_variants(), ReconciliationMode::Adopt);
 
         // Should keep everything except: DropRole, DropOwned, ReassignOwned, TerminateSessions
-        assert_eq!(filtered.len(), 11);
+        assert_eq!(filtered.len(), 12);
 
         // Verify no role-drop/retirement changes remain
         for change in &filtered {

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -202,7 +202,8 @@ pub fn filter_changes(changes: Vec<Change>, mode: ReconciliationMode) -> Vec<Cha
 fn is_destructive(change: &Change) -> bool {
     matches!(
         change,
-        Change::Revoke { .. }
+        Change::AlterSchemaOwner { .. }
+            | Change::Revoke { .. }
             | Change::RevokeDefaultPrivilege { .. }
             | Change::RemoveMember { .. }
             | Change::DropRole { .. }
@@ -1259,15 +1260,16 @@ memberships:
     fn filter_additive_keeps_only_constructive_changes() {
         let filtered = filter_changes(all_change_variants(), ReconciliationMode::Additive);
 
-        // Should keep: CreateRole, CreateSchema, AlterSchemaOwner, AlterRole, SetComment, Grant, SetDefaultPrivilege, AddMember
-        assert_eq!(filtered.len(), 8);
+        // Should keep: CreateRole, CreateSchema, AlterRole, SetComment, Grant, SetDefaultPrivilege, AddMember
+        assert_eq!(filtered.len(), 7);
 
         // Verify no destructive changes remain
         for change in &filtered {
             assert!(
                 !matches!(
                     change,
-                    Change::Revoke { .. }
+                    Change::AlterSchemaOwner { .. }
+                        | Change::Revoke { .. }
                         | Change::RevokeDefaultPrivilege { .. }
                         | Change::RemoveMember { .. }
                         | Change::DropRole { .. }
@@ -1289,11 +1291,6 @@ memberships:
             filtered
                 .iter()
                 .any(|c| matches!(c, Change::CreateSchema { .. }))
-        );
-        assert!(
-            filtered
-                .iter()
-                .any(|c| matches!(c, Change::AlterSchemaOwner { .. }))
         );
         assert!(
             filtered

--- a/crates/pgroles-core/src/export.rs
+++ b/crates/pgroles-core/src/export.rs
@@ -261,6 +261,7 @@ roles:
             "cdc".to_string(),
             crate::model::SchemaState {
                 owner: Some("cdc_owner".to_string()),
+                owner_privileges: crate::model::default_schema_owner_privileges("cdc_owner"),
             },
         );
 

--- a/crates/pgroles-core/src/export.rs
+++ b/crates/pgroles-core/src/export.rs
@@ -8,7 +8,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use crate::manifest::{
     DefaultPrivilege, DefaultPrivilegeGrant, Grant, MemberSpec, Membership, ObjectTarget,
-    PolicyManifest, RoleDefinition,
+    PolicyManifest, RoleDefinition, SchemaBinding,
 };
 use crate::model::RoleGraph;
 
@@ -88,6 +88,18 @@ pub fn role_graph_to_manifest(graph: &RoleGraph) -> PolicyManifest {
         })
         .collect();
 
+    // --- Schemas ---
+    let schemas: Vec<SchemaBinding> = graph
+        .schemas
+        .iter()
+        .map(|(name, state)| SchemaBinding {
+            name: name.clone(),
+            profiles: Vec::new(),
+            role_pattern: "{schema}-{profile}".to_string(),
+            owner: state.owner.clone(),
+        })
+        .collect();
+
     // --- Default privileges ---
     // Group by (owner, schema) to produce compact default_privileges entries.
     let mut dp_groups: BTreeMap<(String, String), Vec<DefaultPrivilegeGrant>> = BTreeMap::new();
@@ -132,7 +144,7 @@ pub fn role_graph_to_manifest(graph: &RoleGraph) -> PolicyManifest {
         default_owner: None,
         auth_providers: Vec::new(),
         profiles: HashMap::new(),
-        schemas: Vec::new(),
+        schemas,
         roles,
         grants,
         default_privileges,
@@ -171,6 +183,7 @@ profiles:
 
 schemas:
   - name: inventory
+    owner: inventory_owner
     profiles: [editor]
 
 roles:
@@ -204,6 +217,9 @@ memberships:
             changes.is_empty(),
             "round-trip produced unexpected changes: {changes:?}"
         );
+
+        assert_eq!(exported_manifest.schemas.len(), 1);
+        assert_eq!(exported_manifest.schemas[0].name, "inventory");
     }
 
     #[test]
@@ -236,6 +252,23 @@ roles:
             .unwrap();
         assert_eq!(login.login, Some(true));
         assert_eq!(login.connection_limit, Some(5));
+    }
+
+    #[test]
+    fn export_includes_managed_schemas() {
+        let mut graph = RoleGraph::default();
+        graph.schemas.insert(
+            "cdc".to_string(),
+            crate::model::SchemaState {
+                owner: Some("cdc_owner".to_string()),
+            },
+        );
+
+        let exported = role_graph_to_manifest(&graph);
+        assert_eq!(exported.schemas.len(), 1);
+        assert_eq!(exported.schemas[0].name, "cdc");
+        assert_eq!(exported.schemas[0].owner.as_deref(), Some("cdc_owner"));
+        assert!(exported.schemas[0].profiles.is_empty());
     }
 
     #[test]

--- a/crates/pgroles-core/src/lib.rs
+++ b/crates/pgroles-core/src/lib.rs
@@ -1,7 +1,10 @@
+pub mod composition;
 pub mod diff;
 pub mod export;
 pub mod manifest;
 pub mod model;
+pub mod ownership;
+pub mod report;
 pub mod scram;
 pub mod sql;
 pub mod visual;

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -430,10 +430,17 @@ pub struct RoleRetirement {
 /// default privileges, and memberships. Ready to be converted into a `RoleGraph`.
 #[derive(Debug, Clone)]
 pub struct ExpandedManifest {
+    pub schemas: Vec<ExpandedSchema>,
     pub roles: Vec<RoleDefinition>,
     pub grants: Vec<Grant>,
     pub default_privileges: Vec<DefaultPrivilege>,
     pub memberships: Vec<Membership>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpandedSchema {
+    pub name: String,
+    pub owner: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -467,6 +474,17 @@ pub fn parse_manifest(yaml: &str) -> Result<PolicyManifest, ManifestError> {
 /// roles, grants, and default privileges. Merges with one-off definitions.
 /// Validates no duplicate role names.
 pub fn expand_manifest(manifest: &PolicyManifest) -> Result<ExpandedManifest, ManifestError> {
+    let schemas: Vec<ExpandedSchema> = manifest
+        .schemas
+        .iter()
+        .map(|schema_binding| ExpandedSchema {
+            name: schema_binding.name.clone(),
+            owner: schema_binding
+                .owner
+                .clone()
+                .or(manifest.default_owner.clone()),
+        })
+        .collect();
     let mut roles: Vec<RoleDefinition> = Vec::new();
     let mut grants: Vec<Grant> = Vec::new();
     let mut default_privileges: Vec<DefaultPrivilege> = Vec::new();
@@ -627,6 +645,7 @@ pub fn expand_manifest(manifest: &PolicyManifest) -> Result<ExpandedManifest, Ma
     }
 
     Ok(ExpandedManifest {
+        schemas,
         roles,
         grants,
         default_privileges,
@@ -849,6 +868,63 @@ schemas:
             Some("myschema".to_string())
         );
         assert_eq!(expanded.grants[1].object.name, Some("*".to_string()));
+    }
+
+    #[test]
+    fn expand_schema_owner_overrides_default_owner() {
+        let yaml = r#"
+default_owner: app_owner
+
+profiles:
+  editor:
+    default_privileges:
+      - privileges: [SELECT]
+        on_type: table
+
+schemas:
+  - name: inventory
+    owner: inventory_owner
+    profiles: [editor]
+  - name: catalog
+    profiles: [editor]
+"#;
+
+        let manifest = parse_manifest(yaml).unwrap();
+        let expanded = expand_manifest(&manifest).unwrap();
+
+        assert_eq!(
+            expanded.schemas,
+            vec![
+                ExpandedSchema {
+                    name: "inventory".to_string(),
+                    owner: Some("inventory_owner".to_string()),
+                },
+                ExpandedSchema {
+                    name: "catalog".to_string(),
+                    owner: Some("app_owner".to_string()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn expand_declared_schema_with_no_profiles() {
+        let yaml = r#"
+schemas:
+  - name: cdc
+    owner: cdc_owner
+    profiles: []
+"#;
+
+        let manifest = parse_manifest(yaml).unwrap();
+        let expanded = expand_manifest(&manifest).unwrap();
+
+        assert_eq!(expanded.schemas.len(), 1);
+        assert_eq!(expanded.schemas[0].name, "cdc");
+        assert_eq!(expanded.schemas[0].owner.as_deref(), Some("cdc_owner"));
+        assert!(expanded.roles.is_empty());
+        assert!(expanded.grants.is_empty());
+        assert!(expanded.default_privileges.is_empty());
     }
 
     #[test]

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -15,6 +15,9 @@ pub enum ManifestError {
     #[error("duplicate role name: \"{0}\"")]
     DuplicateRole(String),
 
+    #[error("duplicate schema name: \"{0}\"")]
+    DuplicateSchema(String),
+
     #[error("profile \"{0}\" referenced by schema \"{1}\" is not defined")]
     UndefinedProfile(String, String),
 
@@ -474,6 +477,13 @@ pub fn parse_manifest(yaml: &str) -> Result<PolicyManifest, ManifestError> {
 /// roles, grants, and default privileges. Merges with one-off definitions.
 /// Validates no duplicate role names.
 pub fn expand_manifest(manifest: &PolicyManifest) -> Result<ExpandedManifest, ManifestError> {
+    let mut seen_schemas: HashSet<String> = HashSet::new();
+    for schema_binding in &manifest.schemas {
+        if !seen_schemas.insert(schema_binding.name.clone()) {
+            return Err(ManifestError::DuplicateSchema(schema_binding.name.clone()));
+        }
+    }
+
     let schemas: Vec<ExpandedSchema> = manifest
         .schemas
         .iter()
@@ -1005,6 +1015,22 @@ roles:
                 .to_string()
                 .contains("duplicate role name")
         );
+    }
+
+    #[test]
+    fn expand_rejects_duplicate_schema_name() {
+        let yaml = r#"
+schemas:
+  - name: inventory
+    profiles: []
+  - name: inventory
+    owner: inventory_owner
+    profiles: []
+"#;
+
+        let manifest = parse_manifest(yaml).unwrap();
+        let error = expand_manifest(&manifest).unwrap_err();
+        assert!(error.to_string().contains("duplicate schema name"));
     }
 
     #[test]

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -250,6 +250,7 @@ pub struct ProfileObjectTarget {
 pub struct SchemaBinding {
     pub name: String,
 
+    #[serde(default)]
     pub profiles: Vec<String>,
 
     /// Role naming pattern. Supports `{schema}` and `{profile}` placeholders.
@@ -262,7 +263,25 @@ pub struct SchemaBinding {
     pub owner: Option<String>,
 }
 
-fn default_role_pattern() -> String {
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaBindingFacet {
+    Owner,
+    Bindings,
+}
+
+impl std::fmt::Display for SchemaBindingFacet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaBindingFacet::Owner => write!(f, "owner"),
+            SchemaBindingFacet::Bindings => write!(f, "bindings"),
+        }
+    }
+}
+
+pub(crate) fn default_role_pattern() -> String {
     "{schema}-{profile}".to_string()
 }
 

--- a/crates/pgroles-core/src/model.rs
+++ b/crates/pgroles-core/src/model.rs
@@ -121,6 +121,18 @@ pub enum RoleAttribute {
 }
 
 // ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+/// The schema state managed by pgroles.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct SchemaState {
+    /// Desired owner for the schema. `None` means ensure existence only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
 // Grants
 // ---------------------------------------------------------------------------
 
@@ -197,6 +209,8 @@ pub struct MembershipEdge {
 pub struct RoleGraph {
     /// Managed roles, keyed by role name.
     pub roles: BTreeMap<String, RoleState>,
+    /// Managed schemas, keyed by schema name.
+    pub schemas: BTreeMap<String, SchemaState>,
     /// Object privilege grants, keyed by grant target.
     pub grants: BTreeMap<GrantKey, GrantState>,
     /// Default privilege rules, keyed by (owner, schema, type, grantee).
@@ -220,6 +234,16 @@ impl RoleGraph {
         for role_def in &expanded.roles {
             let state = RoleState::from_definition(role_def);
             graph.roles.insert(role_def.name.clone(), state);
+        }
+
+        // --- Schemas ---
+        for schema in &expanded.schemas {
+            graph.schemas.insert(
+                schema.name.clone(),
+                SchemaState {
+                    owner: schema.owner.clone(),
+                },
+            );
         }
 
         // --- Grants ---
@@ -436,6 +460,13 @@ memberships:
         assert_eq!(graph.roles.len(), 2);
         assert!(graph.roles.contains_key("inventory-editor"));
         assert!(graph.roles.contains_key("analytics"));
+
+        // Managed schema state includes the declared schema and resolved owner.
+        assert_eq!(graph.schemas.len(), 1);
+        assert_eq!(
+            graph.schemas["inventory"].owner.as_deref(),
+            Some("app_owner")
+        );
 
         // inventory-editor is NOLOGIN, analytics is LOGIN
         assert!(!graph.roles["inventory-editor"].login);

--- a/crates/pgroles-core/src/model.rs
+++ b/crates/pgroles-core/src/model.rs
@@ -130,6 +130,12 @@ pub struct SchemaState {
     /// Desired owner for the schema. `None` means ensure existence only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
+    /// The schema owner's ordinary privileges on the schema itself.
+    ///
+    /// PostgreSQL lets owners revoke their own CREATE/USAGE privileges, so we
+    /// track the effective state separately from grant rows.
+    #[serde(skip_serializing_if = "BTreeSet::is_empty", default)]
+    pub owner_privileges: BTreeSet<Privilege>,
 }
 
 // ---------------------------------------------------------------------------
@@ -238,10 +244,15 @@ impl RoleGraph {
 
         // --- Schemas ---
         for schema in &expanded.schemas {
+            let owner = schema.owner.clone();
             graph.schemas.insert(
                 schema.name.clone(),
                 SchemaState {
-                    owner: schema.owner.clone(),
+                    owner_privileges: owner
+                        .as_deref()
+                        .map(default_schema_owner_privileges)
+                        .unwrap_or_default(),
+                    owner,
                 },
             );
         }
@@ -320,6 +331,10 @@ fn grant_key_from_manifest(grant: &Grant) -> GrantKey {
         schema: grant.object.schema.clone(),
         name: grant.object.name.clone(),
     }
+}
+
+pub fn default_schema_owner_privileges(_owner: &str) -> BTreeSet<Privilege> {
+    [Privilege::Create, Privilege::Usage].into_iter().collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pgroles-core/src/ownership.rs
+++ b/crates/pgroles-core/src/ownership.rs
@@ -1,0 +1,309 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+use crate::diff::Change;
+use crate::manifest::{ObjectType, SchemaBindingFacet};
+use crate::model::{DefaultPrivKey, GrantKey};
+
+#[derive(Debug, Clone, Default)]
+pub struct OwnershipIndex {
+    pub roles: BTreeMap<String, String>,
+    pub schema_facets: BTreeMap<SchemaFacetKey, String>,
+    pub grants: BTreeMap<GrantKey, String>,
+    pub default_privileges: BTreeMap<DefaultPrivKey, String>,
+    pub memberships: BTreeMap<MembershipKey, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchemaFacetKey {
+    pub schema: String,
+    pub facet: SchemaBindingFacet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MembershipKey {
+    pub role: String,
+    pub member: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ManagedScope {
+    pub roles: BTreeSet<String>,
+    pub schemas: BTreeMap<String, ManagedSchemaScope>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ManagedSchemaScope {
+    pub owner: bool,
+    pub bindings: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ManagedChangeSurface {
+    pub roles: BTreeSet<String>,
+    pub owner_schemas: BTreeSet<String>,
+    pub binding_schemas: BTreeSet<String>,
+    pub explicit_grants: BTreeSet<GrantKey>,
+    pub explicit_default_privileges: BTreeSet<DefaultPrivKey>,
+    pub explicit_memberships: BTreeSet<MembershipKey>,
+}
+
+#[derive(Debug, Error)]
+pub enum ManagedChangeError {
+    #[error("change falls outside managed bundle scope: {change}")]
+    OutOfScope { change: String },
+}
+
+impl OwnershipIndex {
+    pub fn managed_scope(&self) -> ManagedScope {
+        let mut scope = ManagedScope {
+            roles: self.roles.keys().cloned().collect(),
+            schemas: BTreeMap::new(),
+        };
+
+        for key in self.schema_facets.keys() {
+            let entry = scope.schemas.entry(key.schema.clone()).or_default();
+            match key.facet {
+                SchemaBindingFacet::Owner => entry.owner = true,
+                SchemaBindingFacet::Bindings => entry.bindings = true,
+            }
+        }
+
+        scope
+    }
+
+    pub fn managed_change_surface(&self) -> ManagedChangeSurface {
+        let mut surface = ManagedChangeSurface {
+            roles: self.roles.keys().cloned().collect(),
+            explicit_grants: self.grants.keys().cloned().collect(),
+            explicit_default_privileges: self.default_privileges.keys().cloned().collect(),
+            explicit_memberships: self.memberships.keys().cloned().collect(),
+            ..ManagedChangeSurface::default()
+        };
+
+        for key in self.schema_facets.keys() {
+            match key.facet {
+                SchemaBindingFacet::Owner => {
+                    surface.owner_schemas.insert(key.schema.clone());
+                }
+                SchemaBindingFacet::Bindings => {
+                    surface.binding_schemas.insert(key.schema.clone());
+                }
+            }
+        }
+
+        surface
+    }
+}
+
+pub fn validate_changes_against_managed_surface(
+    changes: &[Change],
+    surface: &ManagedChangeSurface,
+) -> Result<(), ManagedChangeError> {
+    for change in changes {
+        if !surface.allows_change(change) {
+            return Err(ManagedChangeError::OutOfScope {
+                change: describe_change(change),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+impl ManagedChangeSurface {
+    pub fn needs_database_privilege_inspection(&self) -> bool {
+        !self.roles.is_empty()
+    }
+
+    fn allows_change(&self, change: &Change) -> bool {
+        match change {
+            Change::CreateRole { name, .. }
+            | Change::AlterRole { name, .. }
+            | Change::SetComment { name, .. }
+            | Change::SetPassword { name, .. }
+            | Change::DropRole { name } => self.roles.contains(name),
+            Change::TerminateSessions { role } | Change::DropOwned { role } => {
+                self.roles.contains(role)
+            }
+            Change::ReassignOwned { from_role, to_role } => {
+                self.roles.contains(from_role) && !to_role.is_empty()
+            }
+            Change::CreateSchema { name, .. } => {
+                self.owner_schemas.contains(name) || self.binding_schemas.contains(name)
+            }
+            Change::AlterSchemaOwner { name, owner } => {
+                self.owner_schemas.contains(name) && !owner.is_empty()
+            }
+            Change::EnsureSchemaOwnerPrivileges { name, owner, .. } => {
+                self.owner_schemas.contains(name) && !owner.is_empty()
+            }
+            Change::Grant {
+                role,
+                object_type,
+                schema,
+                name,
+                ..
+            }
+            | Change::Revoke {
+                role,
+                object_type,
+                schema,
+                name,
+                ..
+            } => self.allows_grant_change(&GrantKey {
+                role: role.clone(),
+                object_type: *object_type,
+                schema: schema.clone(),
+                name: name.clone(),
+            }),
+            Change::SetDefaultPrivilege {
+                owner,
+                schema,
+                on_type,
+                grantee,
+                ..
+            }
+            | Change::RevokeDefaultPrivilege {
+                owner,
+                schema,
+                on_type,
+                grantee,
+                ..
+            } => self.allows_default_privilege_change(&DefaultPrivKey {
+                owner: owner.clone(),
+                schema: schema.clone(),
+                on_type: *on_type,
+                grantee: grantee.clone(),
+            }),
+            Change::AddMember { role, member, .. } | Change::RemoveMember { role, member } => {
+                self.roles.contains(role)
+                    || self.explicit_memberships.contains(&MembershipKey {
+                        role: role.clone(),
+                        member: member.clone(),
+                    })
+            }
+        }
+    }
+
+    fn allows_grant_change(&self, key: &GrantKey) -> bool {
+        if self.explicit_grants.contains(key) {
+            return true;
+        }
+
+        if is_binding_schema_object(key.object_type)
+            && grant_schema_name(key)
+                .as_deref()
+                .is_some_and(|schema| self.binding_schemas.contains(schema))
+        {
+            return true;
+        }
+
+        key.object_type == ObjectType::Database && self.roles.contains(&key.role)
+    }
+
+    fn allows_default_privilege_change(&self, key: &DefaultPrivKey) -> bool {
+        self.explicit_default_privileges.contains(key) || self.binding_schemas.contains(&key.schema)
+    }
+}
+
+fn is_binding_schema_object(object_type: ObjectType) -> bool {
+    !matches!(object_type, ObjectType::Database)
+}
+
+pub(crate) fn grant_schema_name(key: &GrantKey) -> Option<String> {
+    match key.object_type {
+        ObjectType::Schema => key.name.clone(),
+        ObjectType::Database => None,
+        _ => key.schema.clone(),
+    }
+}
+
+pub(crate) fn describe_change(change: &Change) -> String {
+    match change {
+        Change::CreateRole { name, .. } => format!("create role \"{name}\""),
+        Change::AlterRole { name, .. } => format!("alter role \"{name}\""),
+        Change::SetComment { name, .. } => format!("set comment on role \"{name}\""),
+        Change::SetPassword { name, .. } => format!("set password for role \"{name}\""),
+        Change::DropRole { name } => format!("drop role \"{name}\""),
+        Change::CreateSchema { name, .. } => format!("create schema \"{name}\""),
+        Change::AlterSchemaOwner { name, owner } => {
+            format!("alter schema \"{name}\" owner to \"{owner}\"")
+        }
+        Change::EnsureSchemaOwnerPrivileges { name, owner, .. } => {
+            format!("ensure owner privileges on schema \"{name}\" for \"{owner}\"")
+        }
+        Change::Grant {
+            role,
+            object_type,
+            schema,
+            name,
+            ..
+        } => format_grant_action(
+            "grant",
+            role,
+            *object_type,
+            schema.as_deref(),
+            name.as_deref(),
+        ),
+        Change::Revoke {
+            role,
+            object_type,
+            schema,
+            name,
+            ..
+        } => format_grant_action(
+            "revoke",
+            role,
+            *object_type,
+            schema.as_deref(),
+            name.as_deref(),
+        ),
+        Change::SetDefaultPrivilege {
+            owner,
+            schema,
+            on_type,
+            grantee,
+            ..
+        } => format!(
+            "set default privilege for owner \"{owner}\" schema \"{schema}\" on {on_type} to \"{grantee}\""
+        ),
+        Change::RevokeDefaultPrivilege {
+            owner,
+            schema,
+            on_type,
+            grantee,
+            ..
+        } => format!(
+            "revoke default privilege for owner \"{owner}\" schema \"{schema}\" on {on_type} from \"{grantee}\""
+        ),
+        Change::AddMember { role, member, .. } => {
+            format!("add membership \"{role}\" -> \"{member}\"")
+        }
+        Change::RemoveMember { role, member } => {
+            format!("remove membership \"{role}\" -> \"{member}\"")
+        }
+        Change::TerminateSessions { role } => format!("terminate sessions for role \"{role}\""),
+        Change::ReassignOwned { from_role, to_role } => {
+            format!("reassign owned from \"{from_role}\" to \"{to_role}\"")
+        }
+        Change::DropOwned { role } => format!("drop owned by role \"{role}\""),
+    }
+}
+
+fn format_grant_action(
+    action: &str,
+    role: &str,
+    object_type: ObjectType,
+    schema: Option<&str>,
+    name: Option<&str>,
+) -> String {
+    let target = match (schema, name) {
+        (Some(schema), Some(name)) => format!("{schema}.{name}"),
+        (Some(schema), None) => schema.to_string(),
+        (None, Some(name)) => name.to_string(),
+        (None, None) => "<unnamed>".to_string(),
+    };
+    format!("{action} for role \"{role}\" on {object_type} \"{target}\"")
+}

--- a/crates/pgroles-core/src/report.rs
+++ b/crates/pgroles-core/src/report.rs
@@ -1,0 +1,520 @@
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::diff::Change;
+use crate::manifest::{ObjectType, SchemaBindingFacet};
+use crate::model::{DefaultPrivKey, GrantKey};
+use crate::ownership::{
+    ManagedScope, MembershipKey, OwnershipIndex, SchemaFacetKey, describe_change, grant_schema_name,
+};
+use crate::visual::VisualManagedScope;
+
+pub const BUNDLE_PLAN_SCHEMA_VERSION: &str = "pgroles.bundle_plan.v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanOutputMode {
+    Full,
+    Redacted,
+}
+
+#[derive(Debug, Clone)]
+pub struct BundleReportContext<'a> {
+    pub ownership: &'a OwnershipIndex,
+    pub managed_scope: &'a ManagedScope,
+}
+
+#[derive(Debug, Error)]
+pub enum BundlePlanError {
+    #[error("missing managed owner for change: {change}")]
+    MissingOwner { change: String },
+
+    #[error("bundle change is missing required scope details: {change}")]
+    InvalidChange { change: String },
+}
+
+#[derive(Debug, Error)]
+pub enum BundlePlanRenderError {
+    #[error(transparent)]
+    Plan(#[from] BundlePlanError),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundlePlanJson {
+    pub schema_version: String,
+    pub managed_scope: VisualManagedScope,
+    pub changes: Vec<AnnotatedPlanChange>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AnnotatedPlanChange {
+    pub category: BundleChangeCategory,
+    pub owner: BundleChangeOwner,
+    pub change: Change,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleChangeOwner {
+    pub document: String,
+    pub managed_key: ManagedOwnershipKey,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BundleChangeCategory {
+    Role,
+    Schema,
+    Grant,
+    DefaultPrivilege,
+    Membership,
+    Retirement,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ManagedOwnershipKey {
+    Role {
+        name: String,
+    },
+    SchemaFacet {
+        schema: String,
+        facet: SchemaBindingFacet,
+    },
+    Grant {
+        role: String,
+        object_type: ObjectType,
+        schema: Option<String>,
+        name: Option<String>,
+    },
+    DefaultPrivilege {
+        owner: String,
+        schema: String,
+        on_type: ObjectType,
+        grantee: String,
+    },
+    Membership {
+        role: String,
+        member: String,
+    },
+}
+
+pub fn shape_plan_changes(changes: &[Change], mode: PlanOutputMode) -> Vec<Change> {
+    match mode {
+        PlanOutputMode::Full => changes.to_vec(),
+        PlanOutputMode::Redacted => changes
+            .iter()
+            .map(|change| match change {
+                Change::SetPassword { name, .. } => Change::SetPassword {
+                    name: name.clone(),
+                    password: "[REDACTED]".to_string(),
+                },
+                other => other.clone(),
+            })
+            .collect(),
+    }
+}
+
+pub fn render_plan_json(
+    changes: &[Change],
+    mode: PlanOutputMode,
+) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(&shape_plan_changes(changes, mode))
+}
+
+pub fn build_bundle_plan(
+    changes: &[Change],
+    context: &BundleReportContext<'_>,
+    mode: PlanOutputMode,
+) -> Result<BundlePlanJson, BundlePlanError> {
+    let shaped_changes = shape_plan_changes(changes, mode);
+    let annotated_changes = shaped_changes
+        .iter()
+        .map(|change| {
+            Ok(AnnotatedPlanChange {
+                category: bundle_change_category(change),
+                owner: lookup_bundle_change_owner(change, context.ownership)?,
+                change: change.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>, BundlePlanError>>()?;
+
+    Ok(BundlePlanJson {
+        schema_version: BUNDLE_PLAN_SCHEMA_VERSION.to_string(),
+        managed_scope: VisualManagedScope::from(context.managed_scope),
+        changes: annotated_changes,
+    })
+}
+
+pub fn render_bundle_plan_json(
+    changes: &[Change],
+    context: &BundleReportContext<'_>,
+    mode: PlanOutputMode,
+) -> Result<String, BundlePlanRenderError> {
+    let plan = build_bundle_plan(changes, context, mode)?;
+    Ok(serde_json::to_string_pretty(&plan)?)
+}
+
+fn lookup_bundle_change_owner(
+    change: &Change,
+    ownership: &OwnershipIndex,
+) -> Result<BundleChangeOwner, BundlePlanError> {
+    match change {
+        Change::CreateRole { name, .. }
+        | Change::AlterRole { name, .. }
+        | Change::SetComment { name, .. }
+        | Change::SetPassword { name, .. }
+        | Change::DropRole { name } => ownership
+            .roles
+            .get(name)
+            .cloned()
+            .map(|document| BundleChangeOwner {
+                document,
+                managed_key: ManagedOwnershipKey::Role { name: name.clone() },
+            })
+            .ok_or_else(|| BundlePlanError::MissingOwner {
+                change: describe_change(change),
+            }),
+        Change::TerminateSessions { role } | Change::DropOwned { role } => ownership
+            .roles
+            .get(role)
+            .cloned()
+            .map(|document| BundleChangeOwner {
+                document,
+                managed_key: ManagedOwnershipKey::Role { name: role.clone() },
+            })
+            .ok_or_else(|| BundlePlanError::MissingOwner {
+                change: describe_change(change),
+            }),
+        Change::ReassignOwned { from_role, .. } => ownership
+            .roles
+            .get(from_role)
+            .cloned()
+            .map(|document| BundleChangeOwner {
+                document,
+                managed_key: ManagedOwnershipKey::Role {
+                    name: from_role.clone(),
+                },
+            })
+            .ok_or_else(|| BundlePlanError::MissingOwner {
+                change: describe_change(change),
+            }),
+        Change::CreateSchema { name, .. } => {
+            lookup_bundle_schema_owner_or_bindings(name, ownership, change)
+        }
+        Change::AlterSchemaOwner { name, .. }
+        | Change::EnsureSchemaOwnerPrivileges { name, .. } => {
+            lookup_bundle_schema_facet(name, SchemaBindingFacet::Owner, ownership, change)
+        }
+        Change::Grant {
+            role,
+            object_type,
+            schema,
+            name,
+            ..
+        }
+        | Change::Revoke {
+            role,
+            object_type,
+            schema,
+            name,
+            ..
+        } => {
+            let grant_key = GrantKey {
+                role: role.clone(),
+                object_type: *object_type,
+                schema: schema.clone(),
+                name: name.clone(),
+            };
+
+            if let Some(document) = ownership.grants.get(&grant_key) {
+                return Ok(BundleChangeOwner {
+                    document: document.clone(),
+                    managed_key: ManagedOwnershipKey::Grant {
+                        role: grant_key.role.clone(),
+                        object_type: grant_key.object_type,
+                        schema: grant_key.schema.clone(),
+                        name: grant_key.name.clone(),
+                    },
+                });
+            }
+
+            if *object_type == ObjectType::Database {
+                return ownership
+                    .roles
+                    .get(role)
+                    .cloned()
+                    .map(|document| BundleChangeOwner {
+                        document,
+                        managed_key: ManagedOwnershipKey::Role { name: role.clone() },
+                    })
+                    .ok_or_else(|| BundlePlanError::MissingOwner {
+                        change: describe_change(change),
+                    });
+            }
+
+            let schema_name =
+                grant_schema_name(&grant_key).ok_or_else(|| BundlePlanError::InvalidChange {
+                    change: describe_change(change),
+                })?;
+            lookup_bundle_schema_facet(
+                &schema_name,
+                SchemaBindingFacet::Bindings,
+                ownership,
+                change,
+            )
+        }
+        Change::SetDefaultPrivilege {
+            owner,
+            schema,
+            on_type,
+            grantee,
+            ..
+        }
+        | Change::RevokeDefaultPrivilege {
+            owner,
+            schema,
+            on_type,
+            grantee,
+            ..
+        } => {
+            let key = DefaultPrivKey {
+                owner: owner.clone(),
+                schema: schema.clone(),
+                on_type: *on_type,
+                grantee: grantee.clone(),
+            };
+
+            if let Some(document) = ownership.default_privileges.get(&key) {
+                return Ok(BundleChangeOwner {
+                    document: document.clone(),
+                    managed_key: ManagedOwnershipKey::DefaultPrivilege {
+                        owner: key.owner.clone(),
+                        schema: key.schema.clone(),
+                        on_type: key.on_type,
+                        grantee: key.grantee.clone(),
+                    },
+                });
+            }
+
+            lookup_bundle_schema_facet(schema, SchemaBindingFacet::Bindings, ownership, change)
+        }
+        Change::AddMember { role, member, .. } | Change::RemoveMember { role, member } => {
+            let key = MembershipKey {
+                role: role.clone(),
+                member: member.clone(),
+            };
+
+            if let Some(document) = ownership.memberships.get(&key) {
+                return Ok(BundleChangeOwner {
+                    document: document.clone(),
+                    managed_key: ManagedOwnershipKey::Membership {
+                        role: role.clone(),
+                        member: member.clone(),
+                    },
+                });
+            }
+
+            ownership
+                .roles
+                .get(role)
+                .cloned()
+                .map(|document| BundleChangeOwner {
+                    document,
+                    managed_key: ManagedOwnershipKey::Role { name: role.clone() },
+                })
+                .ok_or_else(|| BundlePlanError::MissingOwner {
+                    change: describe_change(change),
+                })
+        }
+    }
+}
+
+fn lookup_bundle_schema_owner_or_bindings(
+    schema: &str,
+    ownership: &OwnershipIndex,
+    change: &Change,
+) -> Result<BundleChangeOwner, BundlePlanError> {
+    lookup_bundle_schema_facet(schema, SchemaBindingFacet::Owner, ownership, change).or_else(|_| {
+        lookup_bundle_schema_facet(schema, SchemaBindingFacet::Bindings, ownership, change)
+    })
+}
+
+fn lookup_bundle_schema_facet(
+    schema: &str,
+    facet: SchemaBindingFacet,
+    ownership: &OwnershipIndex,
+    change: &Change,
+) -> Result<BundleChangeOwner, BundlePlanError> {
+    let facet_key = SchemaFacetKey {
+        schema: schema.to_string(),
+        facet,
+    };
+
+    ownership
+        .schema_facets
+        .get(&facet_key)
+        .cloned()
+        .map(|document| BundleChangeOwner {
+            document,
+            managed_key: ManagedOwnershipKey::SchemaFacet {
+                schema: schema.to_string(),
+                facet,
+            },
+        })
+        .ok_or_else(|| BundlePlanError::MissingOwner {
+            change: describe_change(change),
+        })
+}
+
+fn bundle_change_category(change: &Change) -> BundleChangeCategory {
+    match change {
+        Change::CreateRole { .. }
+        | Change::AlterRole { .. }
+        | Change::SetComment { .. }
+        | Change::SetPassword { .. }
+        | Change::DropRole { .. } => BundleChangeCategory::Role,
+        Change::CreateSchema { .. }
+        | Change::AlterSchemaOwner { .. }
+        | Change::EnsureSchemaOwnerPrivileges { .. } => BundleChangeCategory::Schema,
+        Change::Grant { .. } | Change::Revoke { .. } => BundleChangeCategory::Grant,
+        Change::SetDefaultPrivilege { .. } | Change::RevokeDefaultPrivilege { .. } => {
+            BundleChangeCategory::DefaultPrivilege
+        }
+        Change::AddMember { .. } | Change::RemoveMember { .. } => BundleChangeCategory::Membership,
+        Change::ReassignOwned { .. }
+        | Change::DropOwned { .. }
+        | Change::TerminateSessions { .. } => BundleChangeCategory::Retirement,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::composition::{self, PolicyDocument};
+    use crate::diff::diff;
+    use crate::model::RoleGraph;
+
+    #[test]
+    fn render_plan_json_redacts_passwords_in_redacted_mode() {
+        let changes = vec![Change::SetPassword {
+            name: "app".to_string(),
+            password: "super-secret".to_string(),
+        }];
+
+        let redacted = shape_plan_changes(&changes, PlanOutputMode::Redacted);
+        assert_eq!(
+            redacted[0],
+            Change::SetPassword {
+                name: "app".to_string(),
+                password: "[REDACTED]".to_string(),
+            }
+        );
+
+        let json =
+            render_plan_json(&changes, PlanOutputMode::Redacted).expect("json should render");
+        assert!(json.contains("[REDACTED]"));
+        assert!(!json.contains("super-secret"));
+    }
+
+    #[test]
+    fn bundle_plan_json_contract_is_versioned_and_typed() {
+        let bundle = composition::parse_policy_bundle(
+            r#"
+sources:
+  - file: app.yaml
+"#,
+        )
+        .expect("bundle should parse");
+        let documents = vec![PolicyDocument {
+            source: "app.yaml".to_string(),
+            fragment: composition::parse_policy_fragment(
+                r#"
+policy:
+  name: app
+scope:
+  roles: [app]
+roles:
+  - name: app
+    login: false
+"#,
+            )
+            .expect("fragment should parse"),
+        }];
+        let composed =
+            composition::compose_bundle(&bundle, &documents).expect("bundle should compose");
+        let changes = diff(&RoleGraph::default(), &composed.desired);
+
+        let plan = build_bundle_plan(
+            &changes,
+            &composed.report_context(),
+            PlanOutputMode::Redacted,
+        )
+        .expect("bundle plan should annotate");
+        let json = serde_json::to_value(&plan).expect("bundle plan should serialize");
+
+        assert_eq!(json["schema_version"], BUNDLE_PLAN_SCHEMA_VERSION);
+        assert_eq!(json["managed_scope"]["roles"][0], "app");
+        assert_eq!(json["changes"][0]["category"], "role");
+        assert_eq!(json["changes"][0]["owner"]["document"], "app");
+        assert_eq!(json["changes"][0]["owner"]["managed_key"]["kind"], "role");
+        assert_eq!(json["changes"][0]["owner"]["managed_key"]["name"], "app");
+    }
+
+    #[test]
+    fn bundle_plan_full_mode_preserves_password_values() {
+        let bundle = composition::parse_policy_bundle(
+            r#"
+sources:
+  - file: app.yaml
+"#,
+        )
+        .expect("bundle should parse");
+        let documents = vec![PolicyDocument {
+            source: "app.yaml".to_string(),
+            fragment: composition::parse_policy_fragment(
+                r#"
+policy:
+  name: app
+scope:
+  roles: [app]
+roles:
+  - name: app
+    login: true
+"#,
+            )
+            .expect("fragment should parse"),
+        }];
+        let composed =
+            composition::compose_bundle(&bundle, &documents).expect("bundle should compose");
+        let changes = vec![Change::SetPassword {
+            name: "app".to_string(),
+            password: "super-secret".to_string(),
+        }];
+
+        let redacted = build_bundle_plan(
+            &changes,
+            &composed.report_context(),
+            PlanOutputMode::Redacted,
+        )
+        .expect("redacted plan should build");
+        let full = build_bundle_plan(&changes, &composed.report_context(), PlanOutputMode::Full)
+            .expect("full plan should build");
+
+        assert_eq!(
+            redacted.changes[0].change,
+            Change::SetPassword {
+                name: "app".to_string(),
+                password: "[REDACTED]".to_string(),
+            }
+        );
+        assert_eq!(
+            full.changes[0].change,
+            Change::SetPassword {
+                name: "app".to_string(),
+                password: "super-secret".to_string(),
+            }
+        );
+    }
+}

--- a/crates/pgroles-core/src/scram.rs
+++ b/crates/pgroles-core/src/scram.rs
@@ -12,8 +12,8 @@
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use hmac::{Hmac, Mac};
-use rand::Rng;
+use hmac::{Hmac, KeyInit, Mac};
+use rand::RngExt;
 use sha2::{Digest, Sha256};
 use zeroize::Zeroize;
 

--- a/crates/pgroles-core/src/sql.rs
+++ b/crates/pgroles-core/src/sql.rs
@@ -96,6 +96,8 @@ pub fn render_statements(change: &Change) -> Vec<String> {
 pub fn render_statements_with_context(change: &Change, ctx: &SqlContext) -> Vec<String> {
     match change {
         Change::CreateRole { name, state } => render_create_role(name, state),
+        Change::CreateSchema { name, owner } => render_create_schema(name, owner.as_deref()),
+        Change::AlterSchemaOwner { name, owner } => render_alter_schema_owner(name, owner),
         Change::AlterRole { name, attributes } => render_alter_role(name, attributes),
         Change::SetComment { name, comment } => render_set_comment(name, comment),
         Change::Grant {
@@ -167,6 +169,30 @@ pub fn render_all_with_context(changes: &[Change], ctx: &SqlContext) -> String {
         .flat_map(|c| render_statements_with_context(c, ctx))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// CREATE / ALTER SCHEMA
+// ---------------------------------------------------------------------------
+
+fn render_create_schema(name: &str, owner: Option<&str>) -> Vec<String> {
+    let sql = match owner {
+        Some(owner) => format!(
+            "CREATE SCHEMA {} AUTHORIZATION {};",
+            quote_ident(name),
+            quote_ident(owner)
+        ),
+        None => format!("CREATE SCHEMA {};", quote_ident(name)),
+    };
+    vec![sql]
+}
+
+fn render_alter_schema_owner(name: &str, owner: &str) -> Vec<String> {
+    vec![format!(
+        "ALTER SCHEMA {} OWNER TO {};",
+        quote_ident(name),
+        quote_ident(owner)
+    )]
 }
 
 // ---------------------------------------------------------------------------
@@ -709,6 +735,39 @@ mod tests {
     }
 
     #[test]
+    fn render_create_schema_with_owner() {
+        let change = Change::CreateSchema {
+            name: "inventory".to_string(),
+            owner: Some("inventory_owner".to_string()),
+        };
+        assert_eq!(
+            render(&change),
+            "CREATE SCHEMA \"inventory\" AUTHORIZATION \"inventory_owner\";"
+        );
+    }
+
+    #[test]
+    fn render_create_schema_without_owner() {
+        let change = Change::CreateSchema {
+            name: "inventory".to_string(),
+            owner: None,
+        };
+        assert_eq!(render(&change), "CREATE SCHEMA \"inventory\";");
+    }
+
+    #[test]
+    fn render_alter_schema_owner() {
+        let change = Change::AlterSchemaOwner {
+            name: "inventory".to_string(),
+            owner: "inventory_owner".to_string(),
+        };
+        assert_eq!(
+            render(&change),
+            "ALTER SCHEMA \"inventory\" OWNER TO \"inventory_owner\";"
+        );
+    }
+
+    #[test]
     fn render_create_role_with_login_and_comment() {
         let change = Change::CreateRole {
             name: "analytics".to_string(),
@@ -1102,6 +1161,7 @@ profiles:
 
 schemas:
   - name: inventory
+    owner: inventory_owner
     profiles: [editor]
 
 memberships:
@@ -1120,6 +1180,7 @@ memberships:
 
         // Smoke test: the output should contain key SQL statements
         assert!(sql.contains("CREATE ROLE \"inventory-editor\""));
+        assert!(sql.contains("CREATE SCHEMA \"inventory\" AUTHORIZATION \"inventory_owner\";"));
         assert!(sql.contains("GRANT USAGE ON SCHEMA \"inventory\" TO \"inventory-editor\""));
         assert!(sql.contains("GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE"));
         assert!(sql.contains("ALTER DEFAULT PRIVILEGES"));

--- a/crates/pgroles-core/src/sql.rs
+++ b/crates/pgroles-core/src/sql.rs
@@ -98,6 +98,18 @@ pub fn render_statements_with_context(change: &Change, ctx: &SqlContext) -> Vec<
         Change::CreateRole { name, state } => render_create_role(name, state),
         Change::CreateSchema { name, owner } => render_create_schema(name, owner.as_deref()),
         Change::AlterSchemaOwner { name, owner } => render_alter_schema_owner(name, owner),
+        Change::EnsureSchemaOwnerPrivileges {
+            name,
+            owner,
+            privileges,
+        } => render_grant(
+            owner,
+            privileges,
+            ObjectType::Schema,
+            None,
+            Some(name.as_str()),
+            ctx,
+        ),
         Change::AlterRole { name, attributes } => render_alter_role(name, attributes),
         Change::SetComment { name, comment } => render_set_comment(name, comment),
         Change::Grant {
@@ -764,6 +776,19 @@ mod tests {
         assert_eq!(
             render(&change),
             "ALTER SCHEMA \"inventory\" OWNER TO \"inventory_owner\";"
+        );
+    }
+
+    #[test]
+    fn render_ensure_schema_owner_privileges() {
+        let change = Change::EnsureSchemaOwnerPrivileges {
+            name: "inventory".to_string(),
+            owner: "inventory_owner".to_string(),
+            privileges: BTreeSet::from([Privilege::Create, Privilege::Usage]),
+        };
+        assert_eq!(
+            render(&change),
+            "GRANT CREATE, USAGE ON SCHEMA \"inventory\" TO \"inventory_owner\";"
         );
     }
 

--- a/crates/pgroles-core/src/visual.rs
+++ b/crates/pgroles-core/src/visual.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::manifest::{ObjectType, Privilege};
 use crate::model::{DefaultPrivKey, GrantKey, RoleGraph};
+use crate::ownership::ManagedScope;
+
+pub const VISUAL_GRAPH_SCHEMA_VERSION: &str = "pgroles.visual_graph.v1";
 
 // ---------------------------------------------------------------------------
 // DTO types
@@ -18,6 +21,7 @@ use crate::model::{DefaultPrivKey, GrantKey, RoleGraph};
 /// Top-level visualization graph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VisualGraph {
+    pub schema_version: String,
     pub meta: VisualMeta,
     pub nodes: Vec<VisualNode>,
     pub edges: Vec<VisualEdge>,
@@ -32,6 +36,40 @@ pub struct VisualMeta {
     pub default_privilege_count: usize,
     pub membership_count: usize,
     pub collapsed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub managed_scope: Option<VisualManagedScope>,
+}
+
+/// Optional managed-scope metadata for bundle-aware graph output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VisualManagedScope {
+    pub roles: Vec<String>,
+    pub schemas: Vec<VisualManagedSchema>,
+}
+
+/// A schema plus the managed facets owned within that schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VisualManagedSchema {
+    pub name: String,
+    pub owner: bool,
+    pub bindings: bool,
+}
+
+impl From<&ManagedScope> for VisualManagedScope {
+    fn from(scope: &ManagedScope) -> Self {
+        Self {
+            roles: scope.roles.iter().cloned().collect(),
+            schemas: scope
+                .schemas
+                .iter()
+                .map(|(name, managed)| VisualManagedSchema {
+                    name: name.clone(),
+                    owner: managed.owner,
+                    bindings: managed.bindings,
+                })
+                .collect(),
+        }
+    }
 }
 
 /// Where the graph data came from.
@@ -229,6 +267,7 @@ pub fn build_visual_graph(graph: &RoleGraph, source: VisualSource) -> VisualGrap
     edges.sort_by(|a, b| (&a.source, &a.target, &a.kind).cmp(&(&b.source, &b.target, &b.kind)));
 
     VisualGraph {
+        schema_version: VISUAL_GRAPH_SCHEMA_VERSION.to_string(),
         meta: VisualMeta {
             source,
             role_count: graph.roles.len(),
@@ -236,6 +275,7 @@ pub fn build_visual_graph(graph: &RoleGraph, source: VisualSource) -> VisualGrap
             default_privilege_count: graph.default_privileges.len(),
             membership_count: graph.memberships.len(),
             collapsed: true,
+            managed_scope: None,
         },
         nodes,
         edges,
@@ -694,6 +734,7 @@ mod tests {
     use super::*;
     use crate::manifest::{expand_manifest, parse_manifest};
     use crate::model::RoleGraph;
+    use crate::ownership::{ManagedSchemaScope, ManagedScope};
 
     fn build_test_graph() -> RoleGraph {
         let yaml = r#"
@@ -840,6 +881,39 @@ memberships:
         let deserialized: VisualGraph = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.nodes.len(), visual.nodes.len());
         assert_eq!(deserialized.edges.len(), visual.edges.len());
+    }
+
+    #[test]
+    fn json_contract_includes_schema_version_and_managed_scope() {
+        let graph = build_test_graph();
+        let mut visual = build_visual_graph(&graph, VisualSource::Desired);
+        visual.meta.managed_scope = Some(VisualManagedScope::from(&ManagedScope {
+            roles: ["analytics".to_string()].into_iter().collect(),
+            schemas: [(
+                "orders".to_string(),
+                ManagedSchemaScope {
+                    owner: true,
+                    bindings: true,
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }));
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&render_json(&visual)).expect("json should parse");
+
+        assert_eq!(parsed["schema_version"], VISUAL_GRAPH_SCHEMA_VERSION);
+        assert_eq!(parsed["meta"]["managed_scope"]["roles"][0], "analytics");
+        assert_eq!(
+            parsed["meta"]["managed_scope"]["schemas"][0]["name"],
+            "orders"
+        );
+        assert_eq!(parsed["meta"]["managed_scope"]["schemas"][0]["owner"], true);
+        assert_eq!(
+            parsed["meta"]["managed_scope"]["schemas"][0]["bindings"],
+            true
+        );
     }
 
     #[test]

--- a/crates/pgroles-inspect/Cargo.toml
+++ b/crates/pgroles-inspect/Cargo.toml
@@ -16,3 +16,6 @@ pgroles-core = { workspace = true }
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/pgroles-inspect/src/cloud.rs
+++ b/crates/pgroles-inspect/src/cloud.rs
@@ -184,6 +184,7 @@ pub fn validate_changes_for_privilege_level(
                     ));
                 }
             }
+            Change::CreateSchema { .. } | Change::AlterSchemaOwner { .. } => {}
             Change::AlterRole { name, attributes } => {
                 for attr in attributes {
                     let attr_name = match attr {

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -19,7 +19,9 @@ use sqlx::PgPool;
 use thiserror::Error;
 use tracing::debug;
 
+use pgroles_core::manifest::Privilege;
 use pgroles_core::model::RoleGraph;
+use pgroles_core::ownership::ManagedScope;
 
 // Re-export the sub-modules' public items for testing / advanced use.
 pub use cloud::{CloudProvider, PrivilegeLevel, detect_privilege_level};
@@ -68,9 +70,11 @@ pub struct InspectConfig {
     /// Privileges and memberships are filtered to only include these roles.
     pub managed_roles: Vec<String>,
 
-    /// The schema names that the manifest manages.
-    /// Privileges and default privileges are scoped to these schemas.
+    /// The schema names that the manifest manages for schema-owner inspection.
     pub managed_schemas: Vec<String>,
+
+    /// The schema names whose grants/default privileges are managed.
+    pub privilege_schemas: Vec<String>,
 
     /// Whether to also inspect database-level privileges (CONNECT, CREATE, TEMPORARY).
     /// Usually only needed if the manifest includes database-level grants.
@@ -137,7 +141,8 @@ impl InspectConfig {
 
         Self {
             managed_roles: managed_roles.into_iter().collect(),
-            managed_schemas: managed_schemas.into_iter().collect(),
+            managed_schemas: managed_schemas.clone().into_iter().collect(),
+            privilege_schemas: managed_schemas.into_iter().collect(),
             include_database_privileges,
             wildcard_grants: wildcard_map
                 .into_iter()
@@ -149,6 +154,38 @@ impl InspectConfig {
                         privileges,
                     },
                 )
+                .collect(),
+        }
+    }
+
+    /// Create an `InspectConfig` from a managed scope plus an expanded desired
+    /// manifest so current-state inspection can be restricted to composed policy
+    /// boundaries.
+    pub fn from_managed_scope(
+        scope: &ManagedScope,
+        expanded: &pgroles_core::manifest::ExpandedManifest,
+        include_database_privileges: bool,
+    ) -> Self {
+        let base = Self::from_expanded(expanded, include_database_privileges);
+
+        Self {
+            managed_roles: scope.roles.iter().cloned().collect(),
+            managed_schemas: scope.schemas.keys().cloned().collect(),
+            privilege_schemas: scope
+                .schemas
+                .iter()
+                .filter_map(|(schema, managed)| managed.bindings.then_some(schema.clone()))
+                .collect(),
+            include_database_privileges,
+            wildcard_grants: base
+                .wildcard_grants
+                .into_iter()
+                .filter(|pattern| {
+                    scope
+                        .schemas
+                        .get(&pattern.schema)
+                        .is_some_and(|managed| managed.bindings)
+                })
                 .collect(),
         }
     }
@@ -227,6 +264,7 @@ pub async fn inspect_all(
             row.schema_name.clone(),
             pgroles_core::model::SchemaState {
                 owner: Some(row.owner_name.clone()),
+                owner_privileges: row.owner_privileges(),
             },
         );
     }
@@ -277,6 +315,11 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
     // Build &str slices for the query functions
     let role_refs: Vec<&str> = config.managed_roles.iter().map(|s| s.as_str()).collect();
     let schema_refs: Vec<&str> = config.managed_schemas.iter().map(|s| s.as_str()).collect();
+    let privilege_schema_refs: Vec<&str> = config
+        .privilege_schemas
+        .iter()
+        .map(|s| s.as_str())
+        .collect();
 
     // --- Roles ---
     debug!(
@@ -310,6 +353,7 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
                 row.schema_name.clone(),
                 pgroles_core::model::SchemaState {
                     owner: Some(row.owner_name.clone()),
+                    owner_privileges: row.owner_privileges(),
                 },
             );
         }
@@ -317,14 +361,14 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
     }
 
     // --- Object privileges ---
-    if !schema_refs.is_empty() {
+    if !privilege_schema_refs.is_empty() {
         debug!(
-            schemas = ?schema_refs,
+            schemas = ?privilege_schema_refs,
             "inspecting object privileges via aclexplode"
         );
         let privilege_grants = privileges::fetch_privileges_with_wildcards(
             pool,
-            &schema_refs,
+            &privilege_schema_refs,
             &role_refs,
             &config.wildcard_grants,
         )
@@ -350,9 +394,10 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
     }
 
     // --- Default privileges ---
-    if !schema_refs.is_empty() {
+    if !privilege_schema_refs.is_empty() {
         debug!("inspecting default privileges from pg_default_acl");
-        let default_privs = fetch_default_privileges(pool, &schema_refs, &role_refs).await?;
+        let default_privs =
+            fetch_default_privileges(pool, &privilege_schema_refs, &role_refs).await?;
         for (key, state) in default_privs {
             graph.default_privileges.insert(key, state);
         }
@@ -392,6 +437,21 @@ pub async fn fetch_existing_schemas(
 pub struct SchemaRow {
     pub schema_name: String,
     pub owner_name: String,
+    pub owner_has_create: bool,
+    pub owner_has_usage: bool,
+}
+
+impl SchemaRow {
+    fn owner_privileges(&self) -> BTreeSet<Privilege> {
+        let mut privileges = BTreeSet::new();
+        if self.owner_has_create {
+            privileges.insert(Privilege::Create);
+        }
+        if self.owner_has_usage {
+            privileges.insert(Privilege::Usage);
+        }
+        privileges
+    }
 }
 
 pub async fn fetch_schemas(
@@ -400,7 +460,11 @@ pub async fn fetch_schemas(
 ) -> Result<Vec<SchemaRow>, InspectError> {
     let rows = sqlx::query_as::<_, SchemaRow>(
         r#"
-        SELECT n.nspname AS schema_name, owner_role.rolname AS owner_name
+        SELECT
+            n.nspname AS schema_name,
+            owner_role.rolname AS owner_name,
+            has_schema_privilege(owner_role.rolname, n.nspname, 'CREATE') AS owner_has_create,
+            has_schema_privilege(owner_role.rolname, n.nspname, 'USAGE') AS owner_has_usage
         FROM pg_namespace n
         JOIN pg_roles owner_role ON owner_role.oid = n.nspowner
         WHERE n.nspname = ANY($1)
@@ -414,10 +478,9 @@ pub async fn fetch_schemas(
 }
 
 fn remove_redundant_schema_owner_grants(graph: &mut RoleGraph) {
-    // PostgreSQL records the schema owner's inherent CREATE/USAGE privileges in
-    // the schema ACL. Those are part of ownership, not user-declared grants.
-    // Filtering them here keeps `diff` from trying to revoke owner self-grants
-    // after a schema is created or its ownership changes.
+    // Keep ordinary owner CREATE/USAGE management in SchemaState instead of the
+    // grants map. This avoids noisy self-grants while still preserving drift
+    // when the owner's ordinary privileges have been revoked.
     graph.grants.retain(|key, _| {
         if key.object_type != pgroles_core::manifest::ObjectType::Schema {
             return true;
@@ -443,6 +506,7 @@ fn remove_redundant_schema_owner_grants(graph: &mut RoleGraph) {
 mod tests {
     use super::*;
     use pgroles_core::manifest::{expand_manifest, parse_manifest};
+    use pgroles_core::ownership::ManagedSchemaScope;
 
     #[test]
     fn inspect_config_from_expanded_manifest() {
@@ -495,6 +559,7 @@ grants:
         assert!(config.managed_schemas.contains(&"catalog".to_string()));
 
         assert!(config.include_database_privileges);
+        assert_eq!(config.privilege_schemas.len(), 2);
         assert_eq!(config.wildcard_grants.len(), 2);
     }
 
@@ -515,12 +580,55 @@ roles:
     }
 
     #[test]
+    fn inspect_config_from_managed_scope_limits_privileges_to_binding_schemas() {
+        let yaml = r#"
+default_owner: app_owner
+
+profiles:
+  editor:
+    grants:
+      - privileges: [USAGE]
+        object: { type: schema }
+
+schemas:
+  - name: inventory
+    owner: app_owner
+    profiles: [editor]
+
+roles:
+  - name: app_owner
+    login: false
+"#;
+        let manifest = parse_manifest(yaml).unwrap();
+        let expanded = expand_manifest(&manifest).unwrap();
+        let scope = ManagedScope {
+            roles: BTreeSet::from(["app_owner".to_string(), "inventory-editor".to_string()]),
+            schemas: BTreeMap::from([(
+                "inventory".to_string(),
+                ManagedSchemaScope {
+                    owner: true,
+                    bindings: false,
+                },
+            )]),
+        };
+
+        let config = InspectConfig::from_managed_scope(&scope, &expanded, false);
+
+        assert_eq!(config.managed_schemas, vec!["inventory".to_string()]);
+        assert!(config.privilege_schemas.is_empty());
+        assert!(config.wildcard_grants.is_empty());
+    }
+
+    #[test]
     fn remove_redundant_schema_owner_grants_keeps_only_non_owner_schema_grants() {
         let mut graph = RoleGraph::default();
         graph.schemas.insert(
             "inventory".to_string(),
             pgroles_core::model::SchemaState {
                 owner: Some("inventory_owner".to_string()),
+                owner_privileges: [pgroles_core::manifest::Privilege::Create]
+                    .into_iter()
+                    .collect(),
             },
         );
         graph.grants.insert(

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -131,6 +131,10 @@ impl InspectConfig {
             managed_schemas.insert(dp.schema.clone());
         }
 
+        for schema in &expanded.schemas {
+            managed_schemas.insert(schema.name.clone());
+        }
+
         Self {
             managed_roles: managed_roles.into_iter().collect(),
             managed_schemas: managed_schemas.into_iter().collect(),
@@ -220,6 +224,17 @@ pub async fn inspect_all(
         graph.memberships.insert(row.to_membership_edge());
     }
 
+    // Schemas
+    let schema_rows = fetch_schemas(pool, &schema_refs).await?;
+    for row in &schema_rows {
+        graph.schemas.insert(
+            row.schema_name.clone(),
+            pgroles_core::model::SchemaState {
+                owner: Some(row.owner_name.clone()),
+            },
+        );
+    }
+
     // Object privileges (no wildcard patterns for unscoped inspection)
     if !schema_refs.is_empty() {
         let privilege_grants = privileges::fetch_privileges_with_wildcards(
@@ -232,6 +247,7 @@ pub async fn inspect_all(
         for (key, state) in privilege_grants {
             graph.grants.insert(key, state);
         }
+        remove_redundant_schema_owner_grants(&mut graph);
     }
 
     // Database privileges
@@ -285,6 +301,21 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
     // The fetch above already handles this (filters on group role = managed).
     debug!(found = graph.memberships.len(), "memberships inspected");
 
+    // --- Schemas ---
+    if !schema_refs.is_empty() {
+        debug!(schemas = ?schema_refs, "inspecting schemas from pg_namespace");
+        let schema_rows = fetch_schemas(pool, &schema_refs).await?;
+        for row in &schema_rows {
+            graph.schemas.insert(
+                row.schema_name.clone(),
+                pgroles_core::model::SchemaState {
+                    owner: Some(row.owner_name.clone()),
+                },
+            );
+        }
+        debug!(found = graph.schemas.len(), "schemas inspected");
+    }
+
     // --- Object privileges ---
     if !schema_refs.is_empty() {
         debug!(
@@ -301,6 +332,7 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
         for (key, state) in privilege_grants {
             graph.grants.insert(key, state);
         }
+        remove_redundant_schema_owner_grants(&mut graph);
         debug!(found = graph.grants.len(), "privilege grants inspected");
     }
 
@@ -354,6 +386,49 @@ pub async fn fetch_existing_schemas(
     .fetch_all(pool)
     .await?;
     Ok(rows.into_iter().map(|r| r.0).collect())
+}
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct SchemaRow {
+    pub schema_name: String,
+    pub owner_name: String,
+}
+
+pub async fn fetch_schemas(
+    pool: &PgPool,
+    managed_schemas: &[&str],
+) -> Result<Vec<SchemaRow>, InspectError> {
+    let rows = sqlx::query_as::<_, SchemaRow>(
+        r#"
+        SELECT n.nspname AS schema_name, owner_role.rolname AS owner_name
+        FROM pg_namespace n
+        JOIN pg_roles owner_role ON owner_role.oid = n.nspowner
+        WHERE n.nspname = ANY($1)
+        ORDER BY n.nspname
+        "#,
+    )
+    .bind(managed_schemas)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+fn remove_redundant_schema_owner_grants(graph: &mut RoleGraph) {
+    graph.grants.retain(|key, _| {
+        if key.object_type != pgroles_core::manifest::ObjectType::Schema {
+            return true;
+        }
+
+        let Some(schema_name) = key.name.as_deref() else {
+            return true;
+        };
+
+        let Some(schema_state) = graph.schemas.get(schema_name) else {
+            return true;
+        };
+
+        schema_state.owner.as_deref() != Some(key.role.as_str())
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -197,10 +197,6 @@ pub async fn inspect_all(
     }
     debug!(found = graph.roles.len(), "roles discovered for generation");
 
-    if graph.roles.is_empty() {
-        return Ok(graph);
-    }
-
     let role_names: Vec<String> = graph.roles.keys().cloned().collect();
     let role_refs: Vec<&str> = role_names.iter().map(|s| s.as_str()).collect();
 
@@ -233,6 +229,10 @@ pub async fn inspect_all(
                 owner: Some(row.owner_name.clone()),
             },
         );
+    }
+
+    if graph.roles.is_empty() && graph.schemas.is_empty() {
+        return Ok(graph);
     }
 
     // Object privileges (no wildcard patterns for unscoped inspection)

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -414,6 +414,10 @@ pub async fn fetch_schemas(
 }
 
 fn remove_redundant_schema_owner_grants(graph: &mut RoleGraph) {
+    // PostgreSQL records the schema owner's inherent CREATE/USAGE privileges in
+    // the schema ACL. Those are part of ownership, not user-declared grants.
+    // Filtering them here keeps `diff` from trying to revoke owner self-grants
+    // after a schema is created or its ownership changes.
     graph.grants.retain(|key, _| {
         if key.object_type != pgroles_core::manifest::ObjectType::Schema {
             return true;
@@ -508,5 +512,52 @@ roles:
         assert_eq!(config.managed_roles.len(), 2);
         assert!(config.managed_roles.contains(&"analytics".to_string()));
         assert!(config.managed_roles.contains(&"legacy-app".to_string()));
+    }
+
+    #[test]
+    fn remove_redundant_schema_owner_grants_keeps_only_non_owner_schema_grants() {
+        let mut graph = RoleGraph::default();
+        graph.schemas.insert(
+            "inventory".to_string(),
+            pgroles_core::model::SchemaState {
+                owner: Some("inventory_owner".to_string()),
+            },
+        );
+        graph.grants.insert(
+            pgroles_core::model::GrantKey {
+                role: "inventory_owner".to_string(),
+                object_type: pgroles_core::manifest::ObjectType::Schema,
+                schema: None,
+                name: Some("inventory".to_string()),
+            },
+            pgroles_core::model::GrantState {
+                privileges: [pgroles_core::manifest::Privilege::Usage]
+                    .into_iter()
+                    .collect(),
+            },
+        );
+        graph.grants.insert(
+            pgroles_core::model::GrantKey {
+                role: "inventory_reader".to_string(),
+                object_type: pgroles_core::manifest::ObjectType::Schema,
+                schema: None,
+                name: Some("inventory".to_string()),
+            },
+            pgroles_core::model::GrantState {
+                privileges: [pgroles_core::manifest::Privilege::Usage]
+                    .into_iter()
+                    .collect(),
+            },
+        );
+
+        remove_redundant_schema_owner_grants(&mut graph);
+
+        assert_eq!(graph.grants.len(), 1);
+        assert!(
+            graph
+                .grants
+                .keys()
+                .all(|key| key.role == "inventory_reader")
+        );
     }
 }

--- a/crates/pgroles-inspect/src/memberships.rs
+++ b/crates/pgroles-inspect/src/memberships.rs
@@ -162,3 +162,28 @@ async fn fetch_memberships_legacy(
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn membership_row_maps_to_membership_edge() {
+        let row = MembershipRow {
+            role_name: "editors".to_string(),
+            member_name: "alice@example.com".to_string(),
+            admin_option: true,
+            inherit_option: false,
+        };
+
+        let edge = row.to_membership_edge();
+        assert_eq!(edge.role, "editors");
+        assert_eq!(edge.member, "alice@example.com");
+        assert!(!edge.inherit);
+        assert!(edge.admin);
+    }
+}

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -1,8 +1,13 @@
 //! Query object privileges from PostgreSQL catalog tables.
 //!
-//! Uses `aclexplode()` to decompose ACL arrays from `pg_class`, `pg_namespace`,
-//! `pg_proc`, `pg_type`, and `pg_database`. NULL ACLs (meaning system defaults)
-//! are handled via `COALESCE(acl_col, acldefault(type_char, owner_oid))`.
+//! Uses `aclexplode()` to decompose explicit ACL arrays from `pg_class`,
+//! `pg_namespace`, `pg_proc`, `pg_type`, and `pg_database`.
+//!
+//! Managed-state inspection intentionally does not synthesize owner/default ACLs
+//! from `acldefault(...)`. Doing so would make implicit owner privileges appear
+//! as explicit managed grants, causing drift where the manifest never declared
+//! those self-grants. PUBLIC/default visibility is handled separately by the
+//! `public_grants` module for informational output.
 //!
 //! The privilege character mapping:
 //!   r = SELECT, a = INSERT, w = UPDATE, d = DELETE, D = TRUNCATE,
@@ -135,6 +140,15 @@ pub(crate) async fn fetch_privileges_with_wildcards(
 ) -> Result<BTreeMap<GrantKey, GrantState>, sqlx::Error> {
     let mut grants: BTreeMap<GrantKey, GrantState> = BTreeMap::new();
     let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
+
+    for ((object_type, schema_name), object_names) in
+        fetch_relation_inventory(pool, managed_schemas).await?
+    {
+        inventory.insert(
+            (object_type, schema_name),
+            object_names.into_iter().collect(),
+        );
+    }
 
     // Run all the independent queries and collect results.
     // We use separate queries per object type rather than one giant UNION
@@ -344,8 +358,7 @@ fn all_privileges() -> BTreeSet<Privilege> {
 /// the object type:
 ///   'r' = table, 'v' = view, 'm' = materialized view, 'S' = sequence, 'p' = partitioned table
 ///
-/// NULL ACLs are handled with `acldefault('r', c.relowner)` for relations and
-/// `acldefault('S', c.relowner)` for sequences.
+/// Only explicit ACLs are inspected. NULL ACLs produce no rows.
 async fn fetch_relation_privileges(
     pool: &PgPool,
     managed_schemas: &[&str],
@@ -366,15 +379,7 @@ async fn fetch_relation_privileges(
             END AS obj_type
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        CROSS JOIN LATERAL aclexplode(
-            COALESCE(
-                c.relacl,
-                acldefault(
-                    CASE WHEN c.relkind = 'S' THEN 'S'::"char" ELSE 'r'::"char" END,
-                    c.relowner
-                )
-            )
-        ) AS acl
+        CROSS JOIN LATERAL aclexplode(c.relacl) AS acl
         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE n.nspname = ANY($1)
           AND c.relkind IN ('r', 'p', 'v', 'm', 'S')
@@ -388,8 +393,8 @@ async fn fetch_relation_privileges(
 
 /// Fetch privileges on schemas.
 ///
-/// Uses `pg_namespace`. The ACL default type is 'n' (namespace).
-/// For schema grants, the object_name is the schema name itself.
+/// Uses `pg_namespace`. For schema grants, the object_name is the schema name itself.
+/// Only explicit ACLs are inspected. NULL ACLs produce no rows.
 async fn fetch_schema_privileges(
     pool: &PgPool,
     managed_schemas: &[&str],
@@ -403,12 +408,7 @@ async fn fetch_schema_privileges(
             n.nspname AS object_name,
             'schema' AS obj_type
         FROM pg_namespace n
-        CROSS JOIN LATERAL aclexplode(
-            COALESCE(
-                n.nspacl,
-                acldefault('n'::"char", n.nspowner)
-            )
-        ) AS acl
+        CROSS JOIN LATERAL aclexplode(n.nspacl) AS acl
         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE n.nspname = ANY($1)
         ORDER BY n.nspname
@@ -421,9 +421,10 @@ async fn fetch_schema_privileges(
 
 /// Fetch privileges on functions/procedures.
 ///
-/// Uses `pg_proc` joined with `pg_namespace`. The ACL default type is 'f'.
+/// Uses `pg_proc` joined with `pg_namespace`.
 /// Function names can be overloaded, so we include the OID-derived
 /// identity signature via `pg_catalog.pg_get_function_identity_arguments()`.
+/// Only explicit ACLs are inspected. NULL ACLs produce no rows.
 async fn fetch_function_privileges(
     pool: &PgPool,
     managed_schemas: &[&str],
@@ -438,12 +439,7 @@ async fn fetch_function_privileges(
             'function' AS obj_type
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
-        CROSS JOIN LATERAL aclexplode(
-            COALESCE(
-                p.proacl,
-                acldefault('f'::"char", p.proowner)
-            )
-        ) AS acl
+        CROSS JOIN LATERAL aclexplode(p.proacl) AS acl
         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE n.nspname = ANY($1)
         ORDER BY n.nspname, p.proname
@@ -456,9 +452,10 @@ async fn fetch_function_privileges(
 
 /// Fetch privileges on types/domains.
 ///
-/// Uses `pg_type` joined with `pg_namespace`. The ACL default type is 'T'.
+/// Uses `pg_type` joined with `pg_namespace`.
 /// We filter out internal/array types (typname not starting with '_',
 /// typtype not 'p' for pseudo-types).
+/// Only explicit ACLs are inspected. NULL ACLs produce no rows.
 async fn fetch_type_privileges(
     pool: &PgPool,
     managed_schemas: &[&str],
@@ -473,12 +470,7 @@ async fn fetch_type_privileges(
             'type' AS obj_type
         FROM pg_type t
         JOIN pg_namespace n ON n.oid = t.typnamespace
-        CROSS JOIN LATERAL aclexplode(
-            COALESCE(
-                t.typacl,
-                acldefault('T'::"char", t.typowner)
-            )
-        ) AS acl
+        CROSS JOIN LATERAL aclexplode(t.typacl) AS acl
         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE n.nspname = ANY($1)
           AND t.typname NOT LIKE '\_%'
@@ -493,9 +485,8 @@ async fn fetch_type_privileges(
 
 /// Fetch database-level privileges on the current database.
 ///
-/// Uses `pg_database`. The ACL default type is 'd'.
-/// This is separate because it's not schema-scoped; we always query the
-/// current database.
+/// Uses `pg_database`. This is separate because it's not schema-scoped; we
+/// always query the current database. Only explicit ACLs are inspected.
 pub async fn fetch_database_privileges(
     pool: &PgPool,
     managed_roles: &[&str],
@@ -509,12 +500,7 @@ pub async fn fetch_database_privileges(
             db.datname AS object_name,
             'database' AS obj_type
         FROM pg_database db
-        CROSS JOIN LATERAL aclexplode(
-            COALESCE(
-                db.datacl,
-                acldefault('d'::"char", db.datdba)
-            )
-        ) AS acl
+        CROSS JOIN LATERAL aclexplode(db.datacl) AS acl
         LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
         WHERE db.datname = current_database()
         ORDER BY db.datname

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -86,8 +86,8 @@ pub async fn fetch_privileges(
     fetch_privileges_with_wildcards(pool, managed_schemas, managed_roles, &[]).await
 }
 
-/// Fetch schema-scoped relation names grouped by object type.
-pub async fn fetch_relation_inventory(
+/// Fetch schema-scoped object names grouped by object type.
+pub async fn fetch_object_inventory(
     pool: &PgPool,
     managed_schemas: &[&str],
 ) -> Result<BTreeMap<(ObjectType, String), Vec<String>>, sqlx::Error> {
@@ -108,7 +108,47 @@ pub async fn fetch_relation_inventory(
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = ANY($1)
           AND c.relkind IN ('r', 'p', 'v', 'm')
-        ORDER BY n.nspname, c.relkind, c.relname
+
+        UNION ALL
+
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            c.relname AS object_name,
+            'sequence' AS obj_type
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ANY($1)
+          AND c.relkind = 'S'
+
+        UNION ALL
+
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            p.proname || '(' || pg_catalog.pg_get_function_identity_arguments(p.oid) || ')' AS object_name,
+            'function' AS obj_type
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = ANY($1)
+
+        UNION ALL
+
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            t.typname AS object_name,
+            'type' AS obj_type
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = ANY($1)
+          AND t.typname NOT LIKE '\_%'
+          AND t.typtype <> 'p'
+
+        ORDER BY schema_name, obj_type, object_name
         "#,
     )
     .bind(managed_schemas)
@@ -132,6 +172,24 @@ pub async fn fetch_relation_inventory(
     Ok(inventory)
 }
 
+/// Fetch only relation names (tables, views, materialized views) for callers
+/// that specifically need relation inventory.
+pub async fn fetch_relation_inventory(
+    pool: &PgPool,
+    managed_schemas: &[&str],
+) -> Result<BTreeMap<(ObjectType, String), Vec<String>>, sqlx::Error> {
+    Ok(fetch_object_inventory(pool, managed_schemas)
+        .await?
+        .into_iter()
+        .filter(|((object_type, _), _)| {
+            matches!(
+                object_type,
+                ObjectType::Table | ObjectType::View | ObjectType::MaterializedView
+            )
+        })
+        .collect())
+}
+
 pub(crate) async fn fetch_privileges_with_wildcards(
     pool: &PgPool,
     managed_schemas: &[&str],
@@ -142,7 +200,7 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
 
     for ((object_type, schema_name), object_names) in
-        fetch_relation_inventory(pool, managed_schemas).await?
+        fetch_object_inventory(pool, managed_schemas).await?
     {
         inventory.insert(
             (object_type, schema_name),
@@ -798,6 +856,74 @@ mod tests {
         assert!(
             !entry.privileges.contains(&Privilege::Update),
             "Update is not shared across all sequences"
+        );
+    }
+
+    #[test]
+    fn object_inventory_supports_non_relation_wildcards() {
+        let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
+        inventory.insert(
+            (ObjectType::Function, "public".to_string()),
+            BTreeSet::from(["refresh_widgets()".to_string()]),
+        );
+        inventory.insert(
+            (ObjectType::Type, "public".to_string()),
+            BTreeSet::from(["widget_status".to_string()]),
+        );
+        inventory.insert(
+            (ObjectType::Sequence, "public".to_string()),
+            BTreeSet::from(["widgets_id_seq".to_string()]),
+        );
+
+        let wildcards = vec![
+            WildcardGrantPattern {
+                role: "app".to_string(),
+                object_type: ObjectType::Function,
+                schema: "public".to_string(),
+                privileges: BTreeSet::from([Privilege::Execute]),
+            },
+            WildcardGrantPattern {
+                role: "app".to_string(),
+                object_type: ObjectType::Type,
+                schema: "public".to_string(),
+                privileges: BTreeSet::from([Privilege::Usage]),
+            },
+            WildcardGrantPattern {
+                role: "app".to_string(),
+                object_type: ObjectType::Sequence,
+                schema: "public".to_string(),
+                privileges: BTreeSet::from([Privilege::Usage]),
+            },
+        ];
+
+        let result = normalize_wildcard_grants(BTreeMap::new(), &inventory, &wildcards);
+
+        assert!(
+            !result.contains_key(&GrantKey {
+                role: "app".to_string(),
+                object_type: ObjectType::Function,
+                schema: Some("public".to_string()),
+                name: Some("*".to_string()),
+            }),
+            "existing function inventory should prevent vacuous wildcard synthesis"
+        );
+        assert!(
+            !result.contains_key(&GrantKey {
+                role: "app".to_string(),
+                object_type: ObjectType::Type,
+                schema: Some("public".to_string()),
+                name: Some("*".to_string()),
+            }),
+            "existing type inventory should prevent vacuous wildcard synthesis"
+        );
+        assert!(
+            !result.contains_key(&GrantKey {
+                role: "app".to_string(),
+                object_type: ObjectType::Sequence,
+                schema: Some("public".to_string()),
+                name: Some("*".to_string()),
+            }),
+            "existing sequence inventory should prevent vacuous wildcard synthesis"
         );
     }
 }

--- a/crates/pgroles-inspect/src/roles.rs
+++ b/crates/pgroles-inspect/src/roles.rs
@@ -117,3 +117,157 @@ pub async fn fetch_roles(
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_row_maps_to_role_state() {
+        let row = RoleRow {
+            rolname: "analytics".to_string(),
+            rolsuper: false,
+            rolinherit: false,
+            rolcreaterole: true,
+            rolcreatedb: false,
+            rolcanlogin: true,
+            rolreplication: false,
+            rolbypassrls: true,
+            rolconnlimit: 12,
+            comment: Some("analytics login".to_string()),
+            rolvaliduntil: Some("2026-12-31T00:00:00Z".to_string()),
+        };
+
+        let state = row.to_role_state();
+        assert!(state.login);
+        assert!(!state.superuser);
+        assert!(!state.inherit);
+        assert!(state.createrole);
+        assert!(!state.createdb);
+        assert!(!state.replication);
+        assert!(state.bypassrls);
+        assert_eq!(state.connection_limit, 12);
+        assert_eq!(state.comment.as_deref(), Some("analytics login"));
+        assert_eq!(
+            state.password_valid_until.as_deref(),
+            Some("2026-12-31T00:00:00Z")
+        );
+    }
+
+    fn with_runtime<T>(future: impl std::future::Future<Output = T>) -> T {
+        tokio::runtime::Runtime::new()
+            .expect("failed to create tokio runtime")
+            .block_on(future)
+    }
+
+    fn database_url() -> String {
+        std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for live DB tests")
+    }
+
+    fn unique_name(prefix: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        format!("{prefix}_{nanos}")
+    }
+
+    fn execute_sql(sql: &str) {
+        use sqlx::Executor;
+
+        with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            pool.execute(sql)
+                .await
+                .expect("failed to execute setup SQL");
+        });
+    }
+
+    struct TestDbCleanup {
+        sql: String,
+    }
+
+    impl TestDbCleanup {
+        fn new(sql: String) -> Self {
+            Self { sql }
+        }
+    }
+
+    impl Drop for TestDbCleanup {
+        fn drop(&mut self) {
+            execute_sql(&self.sql);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn fetch_roles_scopes_to_managed_names() {
+        let managed = unique_name("managed_role");
+        let extra = unique_name("extra_role");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed}";
+            DROP ROLE IF EXISTS "{extra}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed}";
+            DROP ROLE IF EXISTS "{extra}";
+            CREATE ROLE "{managed}" LOGIN;
+            CREATE ROLE "{extra}" NOLOGIN;
+            "#
+        ));
+
+        let roles = with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            fetch_roles(&pool, Some(&[managed.as_str()]))
+                .await
+                .expect("failed to fetch scoped roles")
+        });
+
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].rolname, managed);
+    }
+
+    #[test]
+    #[ignore]
+    fn fetch_roles_unscoped_excludes_postgres_but_includes_user_roles() {
+        let user_role = unique_name("role_inventory");
+        let _cleanup = TestDbCleanup::new(format!(r#"DROP ROLE IF EXISTS "{user_role}";"#));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{user_role}";
+            CREATE ROLE "{user_role}" LOGIN;
+            "#
+        ));
+
+        let roles = with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            fetch_roles(&pool, None)
+                .await
+                .expect("failed to fetch unscoped roles")
+        });
+
+        assert!(
+            roles.iter().any(|row| row.rolname == user_role),
+            "expected unscoped fetch to include the test user role"
+        );
+        assert!(
+            roles.iter().all(|row| row.rolname != "postgres"),
+            "expected unscoped fetch to exclude postgres"
+        );
+    }
+}

--- a/crates/pgroles-operator/Cargo.toml
+++ b/crates/pgroles-operator/Cargo.toml
@@ -35,11 +35,11 @@ axum = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
-rand = "0.9"
-jiff = "0.2"
-base64 = "0.22"
-sha2 = "0.10"
-percent-encoding = "2"
+rand = "0.10.1"
+jiff = "0.2.23"
+base64 = "0.22.1"
+sha2 = "0.11"
+percent-encoding = "2.3.2"
 
 [[bin]]
 name = "pgroles-operator"

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -745,19 +745,33 @@ pub struct PlanReference {
 /// Summary of changes applied during reconciliation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ChangeSummary {
+    #[serde(default)]
     pub roles_created: i32,
+    #[serde(default)]
     pub roles_altered: i32,
+    #[serde(default)]
     pub schemas_created: i32,
+    #[serde(default)]
     pub schema_owners_altered: i32,
+    #[serde(default)]
     pub roles_dropped: i32,
+    #[serde(default)]
     pub sessions_terminated: i32,
+    #[serde(default)]
     pub grants_added: i32,
+    #[serde(default)]
     pub grants_revoked: i32,
+    #[serde(default)]
     pub default_privileges_set: i32,
+    #[serde(default)]
     pub default_privileges_revoked: i32,
+    #[serde(default)]
     pub members_added: i32,
+    #[serde(default)]
     pub members_removed: i32,
+    #[serde(default)]
     pub passwords_set: i32,
+    #[serde(default)]
     pub total: i32,
 }
 

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -747,6 +747,8 @@ pub struct PlanReference {
 pub struct ChangeSummary {
     pub roles_created: i32,
     pub roles_altered: i32,
+    pub schemas_created: i32,
+    pub schema_owners_altered: i32,
     pub roles_dropped: i32,
     pub sessions_terminated: i32,
     pub grants_added: i32,

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -744,6 +744,7 @@ pub struct PlanReference {
 
 /// Summary of changes applied during reconciliation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct ChangeSummary {
     #[serde(default)]
     pub roles_created: i32,

--- a/crates/pgroles-operator/src/password.rs
+++ b/crates/pgroles-operator/src/password.rs
@@ -5,7 +5,7 @@ use k8s_openapi::api::core::v1::Secret;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::ResourceExt;
 use kube::api::{Api, ObjectMeta, PostParams};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::BTreeMap;
 
 use crate::crd::{GeneratePasswordSpec, PostgresPolicy};

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -595,9 +595,16 @@ fn render_redacted_sql(
 
 /// Compute SHA-256 hash of the SQL string as a hex digest.
 pub(crate) fn compute_sql_hash(sql: &str) -> String {
+    use std::fmt::Write as _;
+
     let mut hasher = Sha256::new();
     hasher.update(sql.as_bytes());
-    format!("{:x}", hasher.finalize())
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut hex, "{byte:02x}").expect("writing to a string should succeed");
+    }
+    hex
 }
 
 /// Generate a plan name from policy name and current timestamp.

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -450,7 +450,11 @@ fn slow_retry_delay(resource: &PostgresPolicy) -> Duration {
 fn referenced_schema_names(
     expanded: &pgroles_core::manifest::ExpandedManifest,
 ) -> std::collections::BTreeSet<String> {
-    let mut names = std::collections::BTreeSet::new();
+    let mut names: std::collections::BTreeSet<String> = expanded
+        .schemas
+        .iter()
+        .map(|schema| schema.name.clone())
+        .collect();
     for grant in &expanded.grants {
         if grant.object.object_type == pgroles_core::manifest::ObjectType::Schema
             && let Some(name) = &grant.object.name
@@ -465,6 +469,16 @@ fn referenced_schema_names(
         names.insert(dp.schema.clone());
     }
     names
+}
+
+fn declared_schema_names(
+    expanded: &pgroles_core::manifest::ExpandedManifest,
+) -> std::collections::BTreeSet<String> {
+    expanded
+        .schemas
+        .iter()
+        .map(|schema| schema.name.clone())
+        .collect()
 }
 
 /// Pre-flight check: ensure every schema referenced by the policy exists in
@@ -486,9 +500,10 @@ async fn validate_referenced_schemas_exist(
     pool: &sqlx::PgPool,
     expanded: &pgroles_core::manifest::ExpandedManifest,
 ) -> Result<(), ReconcileError> {
+    let declared = declared_schema_names(expanded);
     let referenced: std::collections::BTreeSet<String> = referenced_schema_names(expanded)
         .into_iter()
-        .filter(|name| !is_system_schema(name))
+        .filter(|name| !is_system_schema(name) && !declared.contains(name))
         .collect();
     if referenced.is_empty() {
         return Ok(());
@@ -1749,6 +1764,8 @@ fn accumulate_summary(summary: &mut ChangeSummary, change: &pgroles_core::diff::
     use pgroles_core::diff::Change;
     match change {
         Change::CreateRole { .. } => summary.roles_created += 1,
+        Change::CreateSchema { .. } => summary.grants_added += 1,
+        Change::AlterSchemaOwner { .. } => summary.grants_added += 1,
         Change::AlterRole { .. } => summary.roles_altered += 1,
         Change::SetComment { .. } => summary.roles_altered += 1,
         Change::DropRole { .. } => summary.roles_dropped += 1,
@@ -2657,6 +2674,7 @@ mod tests {
             ExpandedManifest, Grant, ObjectTarget, ObjectType, Privilege,
         };
         let expanded = ExpandedManifest {
+            schemas: Vec::new(),
             roles: Vec::new(),
             grants: vec![Grant {
                 role: "app".into(),
@@ -2680,6 +2698,7 @@ mod tests {
             ExpandedManifest, Grant, ObjectTarget, ObjectType, Privilege,
         };
         let expanded = ExpandedManifest {
+            schemas: Vec::new(),
             roles: Vec::new(),
             grants: vec![Grant {
                 role: "app".into(),
@@ -2703,6 +2722,7 @@ mod tests {
             DefaultPrivilege, DefaultPrivilegeGrant, ExpandedManifest, ObjectType, Privilege,
         };
         let expanded = ExpandedManifest {
+            schemas: Vec::new(),
             roles: Vec::new(),
             grants: Vec::new(),
             default_privileges: vec![DefaultPrivilege {
@@ -2727,6 +2747,7 @@ mod tests {
             ObjectType, Privilege,
         };
         let expanded = ExpandedManifest {
+            schemas: Vec::new(),
             roles: Vec::new(),
             grants: vec![
                 Grant {
@@ -2771,6 +2792,7 @@ mod tests {
             ExpandedManifest, Grant, ObjectTarget, ObjectType, Privilege,
         };
         let expanded = ExpandedManifest {
+            schemas: Vec::new(),
             roles: Vec::new(),
             grants: vec![Grant {
                 role: "app".into(),
@@ -2800,6 +2822,45 @@ mod tests {
         assert!(!is_system_schema("public"));
         assert!(!is_system_schema("etl"));
         assert!(!is_system_schema("analytics"));
+    }
+
+    #[test]
+    fn referenced_schema_names_include_declared_schemas() {
+        use pgroles_core::manifest::{ExpandedManifest, ExpandedSchema};
+
+        let expanded = ExpandedManifest {
+            schemas: vec![ExpandedSchema {
+                name: "cdc".into(),
+                owner: Some("cdc_owner".into()),
+            }],
+            roles: Vec::new(),
+            grants: Vec::new(),
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+        };
+
+        let names = referenced_schema_names(&expanded);
+        assert!(names.contains("cdc"));
+    }
+
+    #[test]
+    fn declared_schema_names_returns_declared_only() {
+        use pgroles_core::manifest::{ExpandedManifest, ExpandedSchema};
+
+        let expanded = ExpandedManifest {
+            schemas: vec![ExpandedSchema {
+                name: "cdc".into(),
+                owner: Some("cdc_owner".into()),
+            }],
+            roles: Vec::new(),
+            grants: Vec::new(),
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+        };
+
+        let names = declared_schema_names(&expanded);
+        assert_eq!(names.len(), 1);
+        assert!(names.contains("cdc"));
     }
 
     #[test]

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -1764,8 +1764,8 @@ fn accumulate_summary(summary: &mut ChangeSummary, change: &pgroles_core::diff::
     use pgroles_core::diff::Change;
     match change {
         Change::CreateRole { .. } => summary.roles_created += 1,
-        Change::CreateSchema { .. } => summary.grants_added += 1,
-        Change::AlterSchemaOwner { .. } => summary.grants_added += 1,
+        Change::CreateSchema { .. } => summary.schemas_created += 1,
+        Change::AlterSchemaOwner { .. } => summary.schema_owners_altered += 1,
         Change::AlterRole { .. } => summary.roles_altered += 1,
         Change::SetComment { .. } => summary.roles_altered += 1,
         Change::DropRole { .. } => summary.roles_dropped += 1,
@@ -1789,6 +1789,8 @@ fn summarize_changes(changes: &[pgroles_core::diff::Change]) -> ChangeSummary {
     }
     summary.total = summary.roles_created
         + summary.roles_altered
+        + summary.schemas_created
+        + summary.schema_owners_altered
         + summary.roles_dropped
         + summary.sessions_terminated
         + summary.grants_added
@@ -2464,6 +2466,32 @@ mod tests {
     }
 
     #[test]
+    fn accumulate_summary_counts_schema_changes_separately() {
+        use pgroles_core::diff::Change;
+
+        let mut summary = ChangeSummary::default();
+
+        accumulate_summary(
+            &mut summary,
+            &Change::CreateSchema {
+                name: "inventory".to_string(),
+                owner: Some("inventory_owner".to_string()),
+            },
+        );
+        accumulate_summary(
+            &mut summary,
+            &Change::AlterSchemaOwner {
+                name: "catalog".to_string(),
+                owner: "catalog_owner".to_string(),
+            },
+        );
+
+        assert_eq!(summary.schemas_created, 1);
+        assert_eq!(summary.schema_owners_altered, 1);
+        assert_eq!(summary.grants_added, 0);
+    }
+
+    #[test]
     fn summarize_changes_sets_total() {
         use pgroles_core::diff::Change;
         use pgroles_core::model::RoleState;
@@ -2472,6 +2500,10 @@ mod tests {
             Change::CreateRole {
                 name: "test".to_string(),
                 state: RoleState::default(),
+            },
+            Change::CreateSchema {
+                name: "inventory".to_string(),
+                owner: Some("inventory_owner".to_string()),
             },
             Change::Grant {
                 role: "test".to_string(),
@@ -2486,8 +2518,9 @@ mod tests {
 
         let summary = summarize_changes(&changes);
         assert_eq!(summary.roles_created, 1);
+        assert_eq!(summary.schemas_created, 1);
         assert_eq!(summary.grants_added, 1);
-        assert_eq!(summary.total, 2);
+        assert_eq!(summary.total, 3);
     }
 
     #[test]
@@ -2518,6 +2551,20 @@ mod tests {
             &Change::AlterRole {
                 name: "r1".to_string(),
                 attributes: vec![pgroles_core::model::RoleAttribute::Login(true)],
+            },
+        );
+        accumulate_summary(
+            &mut summary,
+            &Change::CreateSchema {
+                name: "schema1".to_string(),
+                owner: Some("owner1".to_string()),
+            },
+        );
+        accumulate_summary(
+            &mut summary,
+            &Change::AlterSchemaOwner {
+                name: "schema2".to_string(),
+                owner: "owner2".to_string(),
             },
         );
         accumulate_summary(
@@ -2620,6 +2667,8 @@ mod tests {
         assert_eq!(summary.roles_created, 1);
         // AlterRole + SetComment both increment roles_altered
         assert_eq!(summary.roles_altered, 2);
+        assert_eq!(summary.schemas_created, 1);
+        assert_eq!(summary.schema_owners_altered, 1);
         assert_eq!(summary.roles_dropped, 1);
         assert_eq!(summary.sessions_terminated, 1);
         assert_eq!(summary.grants_added, 1);

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -1778,7 +1778,9 @@ fn accumulate_summary(summary: &mut ChangeSummary, change: &pgroles_core::diff::
         Change::TerminateSessions { .. } => summary.sessions_terminated += 1,
         Change::ReassignOwned { .. } => {}
         Change::DropOwned { .. } => {}
-        Change::Grant { .. } => summary.grants_added += 1,
+        Change::Grant { .. } | Change::EnsureSchemaOwnerPrivileges { .. } => {
+            summary.grants_added += 1
+        }
         Change::Revoke { .. } => summary.grants_revoked += 1,
         Change::SetDefaultPrivilege { .. } => summary.default_privileges_set += 1,
         Change::RevokeDefaultPrivilege { .. } => summary.default_privileges_revoked += 1,
@@ -1845,13 +1847,13 @@ async fn detect_sql_context(
     inspect_config: &pgroles_inspect::InspectConfig,
 ) -> Result<pgroles_core::sql::SqlContext, ReconcileError> {
     let pg_version = pgroles_inspect::detect_pg_version(pool).await?;
-    let managed_schemas: Vec<&str> = inspect_config
-        .managed_schemas
+    let privilege_schemas: Vec<&str> = inspect_config
+        .privilege_schemas
         .iter()
         .map(|schema| schema.as_str())
         .collect();
     let relation_inventory =
-        pgroles_inspect::fetch_relation_inventory(pool, &managed_schemas).await?;
+        pgroles_inspect::fetch_relation_inventory(pool, &privilege_schemas).await?;
     Ok(
         pgroles_core::sql::SqlContext::from_version_num(pg_version.version_num)
             .with_relation_inventory(relation_inventory),

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -500,11 +500,7 @@ async fn validate_referenced_schemas_exist(
     pool: &sqlx::PgPool,
     expanded: &pgroles_core::manifest::ExpandedManifest,
 ) -> Result<(), ReconcileError> {
-    let declared = declared_schema_names(expanded);
-    let referenced: std::collections::BTreeSet<String> = referenced_schema_names(expanded)
-        .into_iter()
-        .filter(|name| !is_system_schema(name) && !declared.contains(name))
-        .collect();
+    let referenced = externally_required_schema_names(expanded);
     if referenced.is_empty() {
         return Ok(());
     }
@@ -523,6 +519,16 @@ async fn validate_referenced_schemas_exist(
             .join(", ");
         Err(ReconcileError::MissingDatabaseObjects(formatted))
     }
+}
+
+fn externally_required_schema_names(
+    expanded: &pgroles_core::manifest::ExpandedManifest,
+) -> std::collections::BTreeSet<String> {
+    let declared = declared_schema_names(expanded);
+    referenced_schema_names(expanded)
+        .into_iter()
+        .filter(|name| !is_system_schema(name) && !declared.contains(name))
+        .collect()
 }
 
 /// Apply reconciliation — the main "ensure desired state" logic.
@@ -2910,6 +2916,48 @@ mod tests {
         let names = declared_schema_names(&expanded);
         assert_eq!(names.len(), 1);
         assert!(names.contains("cdc"));
+    }
+
+    #[test]
+    fn externally_required_schema_names_excludes_declared_schemas() {
+        use pgroles_core::manifest::{
+            ExpandedManifest, ExpandedSchema, Grant, ObjectTarget, ObjectType, Privilege,
+        };
+
+        let expanded = ExpandedManifest {
+            schemas: vec![ExpandedSchema {
+                name: "managed".into(),
+                owner: Some("managed_owner".into()),
+            }],
+            roles: Vec::new(),
+            grants: vec![
+                Grant {
+                    role: "app".into(),
+                    privileges: vec![Privilege::Usage],
+                    object: ObjectTarget {
+                        object_type: ObjectType::Schema,
+                        schema: None,
+                        name: Some("managed".into()),
+                    },
+                },
+                Grant {
+                    role: "app".into(),
+                    privileges: vec![Privilege::Select],
+                    object: ObjectTarget {
+                        object_type: ObjectType::Table,
+                        schema: Some("external".into()),
+                        name: Some("*".into()),
+                    },
+                },
+            ],
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+        };
+
+        let names = externally_required_schema_names(&expanded);
+        assert_eq!(names.len(), 1);
+        assert!(names.contains("external"));
+        assert!(!names.contains("managed"));
     }
 
     #[test]

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -49,7 +49,7 @@ If the output is `-- No changes needed`, the manifest matches the database and a
 
 ### 4. Enable additive apply
 
-Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, adding grants and memberships, setting default privileges — but never revokes existing privileges, transfers schema ownership, removes memberships, or drops roles.
+Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, adding grants and memberships, and setting default privileges when their owner context is already valid — but never revokes existing privileges, transfers schema ownership, removes memberships, or drops roles. If a schema's desired `owner` differs from the current owner, pgroles defers owner-bound follow-up steps such as `ALTER DEFAULT PRIVILEGES FOR ROLE <owner> ...` until a mode that allows the ownership transfer.
 
 ```yaml
 spec:

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -49,7 +49,7 @@ If the output is `-- No changes needed`, the manifest matches the database and a
 
 ### 4. Enable additive apply
 
-Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, converging schema ownership, adding grants and memberships, setting default privileges — but never revokes existing privileges, removes memberships, or drops roles.
+Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, adding grants and memberships, setting default privileges — but never revokes existing privileges, transfers schema ownership, removes memberships, or drops roles.
 
 ```yaml
 spec:

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -61,6 +61,17 @@ spec:
 
 Once the manifest covers all roles and grants you want managed, switch to `reconciliation_mode: authoritative` to enable full convergence. Review the planned revocations carefully before switching — in a typical brownfield database, this may include thousands of existing grants to roles not yet in the manifest.
 
+## Multi-team adoption with bundles
+
+If platform and application teams need separate ownership boundaries, use CLI bundle mode instead of forcing everyone into one large manifest.
+
+- put shared profiles and `default_owner` in the bundle root
+- let one source document manage schema `owner` facets
+- let another source document manage schema `bindings` facets
+- run `validate`, `diff`, and `apply` against the bundle so pgroles rejects overlapping ownership before any database work begins
+
+This split is especially useful when platform owns schema creation/ownership, while application teams own the profile bindings and memberships that sit on top of those schemas.
+
 ## App-owned schemas
 
 Applications that create their own schemas via migrations (e.g. `awa`, `analytics`) now have two viable patterns:

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -49,7 +49,7 @@ If the output is `-- No changes needed`, the manifest matches the database and a
 
 ### 4. Enable additive apply
 
-Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles, adding grants and memberships, setting default privileges — but never revokes existing privileges, removes memberships, or drops roles.
+Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, converging schema ownership, adding grants and memberships, setting default privileges — but never revokes existing privileges, removes memberships, or drops roles.
 
 ```yaml
 spec:
@@ -63,12 +63,10 @@ Once the manifest covers all roles and grants you want managed, switch to `recon
 
 ## App-owned schemas
 
-Applications that create their own schemas via migrations (e.g. `awa`, `analytics`) require a **two-stage** manifest:
+Applications that create their own schemas via migrations (e.g. `awa`, `analytics`) now have two viable patterns:
 
-1. **Bootstrap** — create login roles and database-level grants *before* migrations run
-2. **Full** — add schema-level grants, object grants, and default privileges *after* migrations have created the schema
-
-This is necessary because `GRANT USAGE ON SCHEMA foo` fails if `foo` does not exist yet.
+1. **Let pgroles manage the schema** — declare it under `schemas:` with an optional `owner`, and pgroles can create it before grants/default privileges are applied.
+2. **Let the application manage the schema** — keep using a two-stage manifest where migrations create the schema first, then pgroles applies schema/object grants afterward.
 
 ```yaml
 # Stage 1: bootstrap (pre-migration)
@@ -84,14 +82,15 @@ grants:
 ```
 
 ```yaml
-# Stage 2: full (post-migration)
+# Stage 2: full (pgroles manages schema)
 schemas:
   - name: app_schema
+    owner: app_owner
     profiles: [editor, viewer]
 ```
 
-{% callout type="note" title="Schema existence" %}
-pgroles does not create schemas. If a schema referenced in grants or profiles does not exist, the apply will fail. Ensure your application migrations run before applying schema-level grants.
+{% callout type="note" title="Declared vs referenced schemas" %}
+pgroles can create schemas that are explicitly declared under `schemas:`. Schemas that are only referenced from top-level `grants:` or `default_privileges:` must still exist before apply.
 {% /callout %}
 
 ## PUBLIC privilege caveats

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -3,34 +3,41 @@ title: CLI commands
 description: Reference for all pgroles CLI commands and options.
 ---
 
-The `pgroles` CLI provides five commands for managing PostgreSQL role policies. {% .lead %}
+The `pgroles` CLI provides six commands for managing PostgreSQL role policies. {% .lead %}
 
 ---
 
 ## Global options
 
-All commands accept `-f` / `--file` to specify the manifest path. If omitted, it defaults to `pgroles.yaml` in the current directory.
+Commands that operate on desired state accept either:
+
+- `-f` / `--file` for a single manifest file
+- `--bundle` for a composed bundle root file
+
+If omitted, manifest-based commands default to `pgroles.yaml` in the current directory.
 
 Commands that connect to a database accept `--database-url` or read from the `DATABASE_URL` environment variable.
 
 ## validate
 
-Parse and validate a manifest file without connecting to a database.
+Parse and validate a manifest file or composed bundle without connecting to a database.
 
 ```shell
 pgroles validate
 pgroles validate -f path/to/policy.yaml
+pgroles validate --bundle path/to/pgroles.bundle.yaml
 ```
 
 Reports the number of roles, grants, default privileges, and memberships after profile expansion.
 
 ## diff / plan
 
-Show the SQL changes needed to converge the database to the manifest. `plan` is an alias for `diff`.
+Show the SQL changes needed to converge the database to the manifest or bundle. `plan` is an alias for `diff`.
 
 ```shell
 pgroles diff --database-url postgres://localhost/mydb
 pgroles plan --database-url postgres://localhost/mydb
+pgroles diff --bundle path/to/pgroles.bundle.yaml --database-url postgres://localhost/mydb
 ```
 
 ### Options
@@ -38,12 +45,19 @@ pgroles plan --database-url postgres://localhost/mydb
 | Flag | Description |
 |---|---|
 | `-f`, `--file` | Manifest file path (default: `pgroles.yaml`) |
+| `--bundle` | Bundle root file path |
 | `--database-url` | PostgreSQL connection string (or `DATABASE_URL` env) |
 | `--format` | Output format: `sql` (default), `summary`, or `json` |
 | `--mode` | Reconciliation mode: `authoritative` (default), `additive`, or `adopt` |
 | `--exit-code` | Exit with code 2 when drift is detected (default: `true`) |
 
-The `sql` format prints the full SQL script. The `summary` format shows counts of each change type. The `json` format outputs the change list as a JSON array, suitable for CI/CD pipelines and programmatic consumption.
+The `sql` format prints the full SQL script. The `summary` format shows counts of each change type.
+
+For single-manifest mode, the `json` format outputs the change list as a JSON array. For bundle mode, the `json` format returns a typed object with:
+
+- `schema_version`
+- `managed_scope`
+- per-change ownership annotations (`document` plus managed key details)
 
 ### CI drift detection
 
@@ -86,11 +100,12 @@ That causes the generated plan to insert session termination, `REASSIGN OWNED BY
 
 ## apply
 
-Apply changes to bring the database in sync with the manifest.
+Apply changes to bring the database in sync with the manifest or bundle.
 
 ```shell
 pgroles apply --database-url postgres://localhost/mydb
 pgroles apply --database-url postgres://localhost/mydb --dry-run
+pgroles apply --bundle path/to/pgroles.bundle.yaml --database-url postgres://localhost/mydb
 ```
 
 ### Options
@@ -98,6 +113,7 @@ pgroles apply --database-url postgres://localhost/mydb --dry-run
 | Flag | Description |
 |---|---|
 | `-f`, `--file` | Manifest file path (default: `pgroles.yaml`) |
+| `--bundle` | Bundle root file path |
 | `--database-url` | PostgreSQL connection string (or `DATABASE_URL` env) |
 | `--mode` | Reconciliation mode: `authoritative` (default), `additive`, or `adopt` |
 | `--dry-run` | Print the SQL without executing it |
@@ -144,13 +160,15 @@ If pgroles still sees unhandled role-drop hazards after accounting for the decla
 
 ## inspect
 
-Show the current database state for roles and privileges managed by the manifest.
+Show the current database state for roles and privileges.
 
 ```shell
 pgroles inspect --database-url postgres://localhost/mydb
+pgroles inspect -f pgroles.yaml --database-url postgres://localhost/mydb
+pgroles inspect --bundle path/to/pgroles.bundle.yaml --database-url postgres://localhost/mydb
 ```
 
-This connects to the database, inspects the current roles/grants/memberships that are relevant to the manifest, and prints a summary.
+Without `-f` or `--bundle`, `inspect` shows all non-system roles and visible privileges. With `-f`, it scopes inspection to the manifest's managed roles and referenced schemas. With `--bundle`, it scopes inspection to the composed managed ownership boundary and prints a managed-scope summary before the role graph summary.
 
 ## generate
 
@@ -179,6 +197,49 @@ The generated manifest is a flat snapshot of the current state. After generating
 `generate` is best used as a starting point for brownfield adoption. Before applying the generated manifest in production, review it like any other infrastructure policy because once committed it becomes the desired state.
 {% /callout %}
 
+## graph
+
+Render the role graph as a terminal tree or machine-readable graph.
+
+```shell
+pgroles graph desired -f pgroles.yaml --format tree
+pgroles graph desired --bundle path/to/pgroles.bundle.yaml --format json
+pgroles graph current --database-url postgres://localhost/mydb --scope all --format tree
+pgroles graph current --bundle path/to/pgroles.bundle.yaml --database-url postgres://localhost/mydb --scope managed --format json
+```
+
+### desired
+
+Build the graph from a manifest or bundle.
+
+| Flag | Description |
+|---|---|
+| `-f`, `--file` | Manifest file path |
+| `--bundle` | Bundle root file path |
+| `--format` | `tree` (default), `json`, `dot`, or `mermaid` |
+| `-o`, `--output` | Write the rendered graph to a file |
+
+### current
+
+Build the graph from a live database.
+
+| Flag | Description |
+|---|---|
+| `-f`, `--file` | Manifest file path |
+| `--bundle` | Bundle root file path |
+| `--database-url` | PostgreSQL connection string |
+| `--scope` | `managed` (default) or `all` |
+| `--format` | `tree` (default), `json`, `dot`, or `mermaid` |
+| `-o`, `--output` | Write the rendered graph to a file |
+
+`graph current --scope managed` requires either `-f` or `--bundle` so pgroles knows which roles or bundle scope are considered managed.
+
+Bundle-aware graph JSON includes:
+
+- top-level `schema_version`
+- the normal graph payload
+- `meta.managed_scope` describing bundle-managed roles and schema facets
+
 ## Reconciliation modes
 
 The `--mode` flag controls how aggressively pgroles converges the database. Both `diff` and `apply` accept this flag.
@@ -200,6 +261,8 @@ pgroles apply --database-url postgres://localhost/mydb --mode additive
 ```
 
 Additive mode filters out: `REVOKE`, `REVOKE DEFAULT PRIVILEGE`, `REMOVE MEMBER`, `DROP ROLE`, `DROP OWNED`, `REASSIGN OWNED`, and `TERMINATE SESSIONS`.
+
+If additive mode skips a schema ownership transfer, pgroles also defers owner-bound follow-up steps such as schema-owner privilege repair and `ALTER DEFAULT PRIVILEGES FOR ROLE ...` for that owner context.
 
 ### adopt
 

--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -56,11 +56,11 @@ inside the Docker publish jobs.
 To reproduce the live CLI tests against a local PostgreSQL:
 
 ```shell
-docker run --rm --name pgroles-pg16 \
+docker run --rm --name pgroles-pg18 \
   -e POSTGRES_PASSWORD=testpassword \
   -e POSTGRES_DB=pgroles_test \
   -p 5432:5432 \
-  postgres:16
+  postgres:18
 ```
 
 In another shell:
@@ -71,7 +71,7 @@ cargo test -p pgroles-cli --test cli live_db::diff_against_live_db -- --ignored 
 cargo test -p pgroles-cli --test cli live_db::diff_summary_format -- --ignored --exact
 ```
 
-Use `postgres:17` or `postgres:18` to mirror the CI matrix.
+Use `postgres:16` or `postgres:17` if you want to reproduce the full CI matrix locally.
 
 ## Contributor notes
 

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -106,6 +106,29 @@ When a schema is declared under `schemas:`:
 
 If a schema is only referenced from top-level `grants:` or `default_privileges:` and is not declared under `schemas:`, it must already exist.
 
+### Declared vs referenced example
+
+```yaml
+schemas:
+  - name: app_managed
+    owner: app_owner
+    profiles: []
+
+grants:
+  - role: reporting
+    privileges: [USAGE]
+    object: { type: schema, name: app_managed }
+
+  - role: reporting
+    privileges: [SELECT]
+    object: { type: table, schema: existing_warehouse, name: "*" }
+```
+
+In this example:
+
+- `app_managed` is declared under `schemas:`, so pgroles can create it and set its owner.
+- `existing_warehouse` is only referenced from a top-level grant, so it must already exist before `apply` runs.
+
 ## roles
 
 Each role definition specifies a PostgreSQL role and its attributes:

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -3,7 +3,7 @@ title: Manifest format
 description: Complete reference for the pgroles YAML manifest schema.
 ---
 
-A pgroles manifest is a YAML file that declares the desired state of your PostgreSQL roles, grants, default privileges, and memberships. {% .lead %}
+A pgroles manifest is a YAML file that declares the desired state of your PostgreSQL roles, schemas, grants, default privileges, and memberships. {% .lead %}
 
 ---
 
@@ -13,7 +13,7 @@ A pgroles manifest is a YAML file that declares the desired state of your Postgr
 default_owner: pgloader_pg       # Owner for ALTER DEFAULT PRIVILEGES
 auth_providers: []                # Cloud IAM provider declarations
 profiles: {}                      # Reusable privilege templates
-schemas: []                       # Schema-profile bindings
+schemas: []                       # Managed schemas and schema-profile bindings
 roles: []                         # Role definitions
 grants: []                        # Object privilege grants
 default_privileges: []            # Default privilege rules
@@ -67,6 +67,44 @@ default_owner: pgloader_pg
 ```
 
 Individual schemas can override this with their own `owner` field.
+
+## schemas
+
+The `schemas` section serves two related purposes:
+
+- declare schemas pgroles should manage
+- bind profiles to those schemas so profile-generated roles and grants are expanded
+
+```yaml
+schemas:
+  - name: inventory
+    owner: app_owner
+    profiles: [editor, viewer]
+
+  - name: cdc
+    owner: cdc_owner
+    profiles: []
+```
+
+### Schema fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | *required* | Schema name |
+| `profiles` | list[string] | `[]` | Profiles to expand for this schema |
+| `owner` | string | `default_owner` | Desired schema owner; if omitted and `default_owner` is unset, pgroles only ensures the schema exists |
+| `role_pattern` | string | `"{schema}-{profile}"` | Naming pattern for profile-generated roles |
+
+### Schema ownership and creation
+
+When a schema is declared under `schemas:`:
+
+- pgroles can create it if it does not exist
+- pgroles can converge its owner with `ALTER SCHEMA ... OWNER TO ...`
+- pgroles does not manage dropping schemas
+- pgroles does not reassign ownership of objects inside the schema
+
+If a schema is only referenced from top-level `grants:` or `default_privileges:` and is not declared under `schemas:`, it must already exist.
 
 ## roles
 
@@ -211,7 +249,7 @@ memberships:
 ## Convergent model
 
 {% callout type="warning" title="pgroles is convergent" %}
-The manifest represents the **entire desired state**. Roles, grants, default privileges, and memberships that exist in the database but are absent from the manifest will be dropped or revoked. Only declare roles that pgroles should manage.
+The manifest represents the **entire desired state**. Roles, grants, default privileges, and memberships that exist in the database but are absent from the manifest will be dropped or revoked. Declared schemas are created and their owner may be converged, but schemas are not dropped automatically. Only declare roles and schemas that pgroles should manage.
 {% /callout %}
 
 ## retirements

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -22,6 +22,89 @@ memberships: []                   # Role membership edges
 
 All fields are optional. A minimal manifest might only define `roles` and `grants`.
 
+## Bundle mode
+
+The CLI can also compose a **bundle** from one root file plus multiple scoped policy documents:
+
+```yaml
+# pgroles.bundle.yaml
+shared:
+  default_owner: app_owner
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+```
+
+Each source file is a `PolicyFragment`:
+
+```yaml
+# platform.yaml
+policy:
+  name: platform
+scope:
+  roles: [app_owner]
+  schemas:
+    - name: inventory
+      facets: [owner]
+
+roles:
+  - name: app_owner
+
+schemas:
+  - name: inventory
+    owner: app_owner
+```
+
+```yaml
+# app.yaml
+policy:
+  name: app
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+
+schemas:
+  - name: inventory
+    profiles: [editor]
+```
+
+Bundle composition is currently a CLI/core feature. The Kubernetes operator still reconciles a single `PostgresPolicy` resource.
+
+### Shared bundle fields
+
+| Field | Description |
+|---|---|
+| `shared.default_owner` | Default owner context shared across source documents |
+| `shared.auth_providers` | Shared auth provider metadata |
+| `shared.profiles` | Shared profile registry used by source documents |
+| `sources` | Relative file paths to policy documents that will be composed together |
+
+### Policy fragment fields
+
+Each source document adds two fields on top of the normal manifest content:
+
+| Field | Description |
+|---|---|
+| `policy.name` | Human-readable source label used in conflict and plan output |
+| `scope` | The ownership boundary this document is allowed to manage |
+
+### Scoped schema facets
+
+Schema scope is split into explicit facets:
+
+| Facet | Description |
+|---|---|
+| `owner` | Manage schema creation and ownership convergence |
+| `bindings` | Manage profile expansion, grants, and default privileges tied to the schema |
+
+Two source documents may reference the same schema only when they manage disjoint facets. If two documents claim the same role, grant, default-privilege rule, membership selector, or schema facet, composition fails before any database inspection begins.
+
 ## auth_providers
 
 Declare cloud authentication providers to document how IAM-mapped roles connect to the database. This is currently informational metadata used for validation and documentation purposes.

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -18,6 +18,10 @@ The operator brings the same convergent model as the CLI into Kubernetes. Instea
 - Status conditions and change summaries on the custom resource
 - Finalizer-based cleanup on resource deletion
 
+{% callout type="note" title="Bundle composition is CLI-only today" %}
+The CLI can compose a multi-file bundle with scoped ownership boundaries before diff or apply. The operator does **not** yet reconcile bundle fragments directly — each `PostgresPolicy` is still a single policy document.
+{% /callout %}
+
 {% callout title="Maturity" %}
 The operator provides serialized reconciliation with conflict detection, failure-aware retry, and observable status reporting. The API is `v1alpha1` — controller semantics are stable but the CRD contract has no documented upgrade path. Review the [production status](#production-status) section before deploying.
 {% /callout %}

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -199,6 +199,7 @@ spec:
 
   schemas:
     - name: inventory
+      owner: app_owner
       profiles: [editor]
 
   roles:
@@ -221,6 +222,8 @@ spec:
       reassign_owned_to: app_owner
       drop_owned: true
 ```
+
+Declared schemas can be created and have ownership converged by the operator. Schemas that are only referenced from top-level grants or default privileges must already exist in the database.
 
 ### Database connection
 

--- a/docs/src/pages/docs/profiles.md
+++ b/docs/src/pages/docs/profiles.md
@@ -123,7 +123,7 @@ By default, profile-generated roles have `login: false` (NOLOGIN).
 
 ## Owner overrides
 
-Each schema binding can override the `default_owner` for its default privileges:
+Each schema binding can override the `default_owner` for its default privileges and, when declared, the schema owner itself:
 
 ```yaml
 default_owner: app_owner
@@ -136,7 +136,7 @@ schemas:
     owner: legacy_admin
 ```
 
-Here, `inventory`'s default privileges use `app_owner`, while `legacy`'s use `legacy_admin`.
+Here, `inventory`'s default privileges use `app_owner`, while `legacy`'s use `legacy_admin`. If those schemas are managed by pgroles, the same owner resolution is used for `CREATE SCHEMA` and `ALTER SCHEMA ... OWNER TO ...`.
 
 ## Combining profiles with one-off definitions
 

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -809,68 +809,76 @@
                     "nullable": true,
                     "properties": {
                       "default_privileges_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "default_privileges_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_removed": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "passwords_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_altered": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_dropped": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schema_owners_altered": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schemas_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "sessions_terminated": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "total": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       }
                     },
-                    "required": [
-                      "default_privileges_revoked",
-                      "default_privileges_set",
-                      "grants_added",
-                      "grants_revoked",
-                      "members_added",
-                      "members_removed",
-                      "passwords_set",
-                      "roles_altered",
-                      "roles_created",
-                      "roles_dropped",
-                      "sessions_terminated",
-                      "total"
-                    ],
                     "type": "object"
                   },
                   "conditions": {

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -762,6 +762,7 @@
                           "type": "string"
                         },
                         "profiles": {
+                          "default": [],
                           "items": {
                             "type": "string"
                           },
@@ -774,8 +775,7 @@
                         }
                       },
                       "required": [
-                        "name",
-                        "profiles"
+                        "name"
                       ],
                       "type": "object"
                     },

--- a/k8s/postgrespolicyplan-crd.yaml
+++ b/k8s/postgrespolicyplan-crd.yaml
@@ -152,68 +152,76 @@
                     "nullable": true,
                     "properties": {
                       "default_privileges_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "default_privileges_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "grants_revoked": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_added": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "members_removed": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "passwords_set": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_altered": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "roles_dropped": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schema_owners_altered": {
+                        "default": 0,
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "schemas_created": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "sessions_terminated": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       },
                       "total": {
+                        "default": 0,
                         "format": "int32",
                         "type": "integer"
                       }
                     },
-                    "required": [
-                      "default_privileges_revoked",
-                      "default_privileges_set",
-                      "grants_added",
-                      "grants_revoked",
-                      "members_added",
-                      "members_removed",
-                      "passwords_set",
-                      "roles_altered",
-                      "roles_created",
-                      "roles_dropped",
-                      "sessions_terminated",
-                      "total"
-                    ],
                     "type": "object"
                   },
                   "computedAt": {

--- a/k8s/samples/schema-owner-policy.yaml
+++ b/k8s/samples/schema-owner-policy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: pgroles.io/v1alpha1
+kind: PostgresPolicy
+metadata:
+  name: schema-owner-policy
+  namespace: default
+spec:
+  connection:
+    secretRef:
+      name: postgres-credentials
+  interval: "5m"
+
+  schemas:
+    - name: operator_owned_schema
+      owner: operator_schema_owner
+      profiles: []
+
+  roles:
+    - name: operator_schema_owner

--- a/scripts/e2e-helpers.sh
+++ b/scripts/e2e-helpers.sh
@@ -135,6 +135,16 @@ assert_role_absent() {
   fi
 }
 
+assert_schema_exists() {
+  pg_query "SELECT nspname FROM pg_namespace WHERE nspname = '$1'" | grep -qx "$1"
+}
+
+assert_schema_owner() {
+  local schema="$1"
+  local expected_owner="$2"
+  pg_query "SELECT pg_get_userbyid(nspowner) FROM pg_namespace WHERE nspname = '$schema'" | grep -qx "$expected_owner"
+}
+
 get_password_hash() {
   pg_query "SELECT rolpassword FROM pg_authid WHERE rolname = '$1'"
 }


### PR DESCRIPTION
## Summary
- manage declared schemas as first-class state so pgroles can create missing schemas and converge schema ownership via `schemas[].owner`
- extend inspection/export/operator handling for managed schemas, including filtering implicit owner schema ACLs so apply + diff converge cleanly
- document declared-vs-referenced schema behavior and add unit plus live PostgreSQL coverage for schema creation and ownership convergence

## Testing
- cargo fmt --all
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- SQLX_OFFLINE=true cargo build --workspace
- cargo test --workspace
- DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test cargo test -p pgroles-cli --test cli -- --ignored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declare and manage database schemas (optional owner) in manifests; inspection/export show managed schemas and owners. Operator can create schemas and converge schema ownership; generated SQL includes CREATE/ALTER SCHEMA. Plan/apply summaries now report schema creations and owner alterations.

* **Tests**
  * Added unit, integration, CLI, live-db, operator e2e tests for schema create/owner-alter/duplicates and SQL generation.

* **Documentation**
  * README and docs updated with schema-management semantics, examples, and operator guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->