### PR TITLE
fix: keep additive mode from rewriting brownfield roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Declarative PostgreSQL access control. Define roles, schema ownership, grants, a
 
 For simple setups, use a single manifest. For larger teams, the CLI also supports bundle composition: shared profiles plus multiple scoped policy fragments merged into one desired plan with conflict checks before any database diff or apply.
 
-By default, anything not in the manifest gets revoked or dropped. Same model as Terraform, applied to PostgreSQL. For incremental adoption, use `--mode additive` to only grant and never revoke, or `--mode adopt` to manage declared roles fully without dropping undeclared ones.
+By default, anything not in the manifest gets revoked or dropped. Same model as Terraform, applied to PostgreSQL. For incremental adoption, use `--mode additive` to only grant and never revoke, or `--mode adopt` to manage declared roles fully without dropping undeclared ones. In additive mode, pgroles also leaves attributes and comments unchanged on pre-existing roles.
 
 ## How it works
 
@@ -144,7 +144,7 @@ docker run --rm ghcr.io/hardbyte/pgroles --help
 
 - **Convergent** — the manifest is the desired state. Missing roles get created, extra roles get dropped, drifted grants get fixed.
 - **Reconciliation modes** — `--mode authoritative` (default) for full convergence, `--mode additive` to only grant and never revoke, `--mode adopt` to manage declared roles without dropping undeclared ones. Additive mode is the safest way to start using pgroles on an existing database.
-- **Profiles** — define privilege templates once, apply them across schemas. Each `schema x profile` pair becomes a role.
+- **Profiles** — define privilege templates once, apply them across schemas. Each `schema x profile` pair becomes a role, and profiles can set generated-role `login` and `inherit` attributes.
 - **Bundle composition** — compose shared profiles plus multiple scoped policy fragments in the CLI, with duplicate/conflict detection and managed-scope enforcement before diff or apply.
 - **Schema management** — declared schemas can be created and have ownership converged, while undeclared referenced schemas must already exist.
 - **Safer privilege bundles** — common application profiles can pair table, sequence, and function privileges so identity columns and trigger-driven routines are covered together.

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -584,6 +584,10 @@
                           },
                           "type": "array"
                         },
+                        "inherit": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
                         "login": {
                           "nullable": true,
                           "type": "boolean"

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -5,7 +5,8 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{PgPool, Row};
 use tracing::info;
 
 use pgroles_cli::{
@@ -589,31 +590,7 @@ async fn cmd_apply(
 
         // Execute the entire plan in one transaction to avoid partial convergence.
         info!(changes = summary.total(), "applying changes");
-        let mut transaction = pool.begin().await.context("failed to start transaction")?;
-        for change in &changes {
-            let is_sensitive = matches!(change, pgroles_core::diff::Change::SetPassword { .. });
-            for statement in pgroles_core::sql::render_statements_with_context(change, &sql_ctx) {
-                if is_sensitive {
-                    info!("executing: ALTER ROLE ... PASSWORD [REDACTED]");
-                } else {
-                    info!(sql = %statement, "executing");
-                }
-                sqlx::query(&statement)
-                    .execute(transaction.as_mut())
-                    .await
-                    .with_context(|| {
-                        if is_sensitive {
-                            "failed to execute: ALTER ROLE ... PASSWORD [REDACTED]".to_string()
-                        } else {
-                            format!("failed to execute: {statement}")
-                        }
-                    })?;
-            }
-        }
-        transaction
-            .commit()
-            .await
-            .context("failed to commit transaction")?;
+        execute_changes(&pool, &changes, &sql_ctx).await?;
 
         println!(
             "Applied {total} change(s) successfully.",
@@ -692,31 +669,7 @@ async fn cmd_apply(
 
     // Execute the entire plan in one transaction to avoid partial convergence.
     info!(changes = summary.total(), "applying changes");
-    let mut transaction = pool.begin().await.context("failed to start transaction")?;
-    for change in &changes {
-        let is_sensitive = matches!(change, pgroles_core::diff::Change::SetPassword { .. });
-        for statement in pgroles_core::sql::render_statements_with_context(change, &sql_ctx) {
-            if is_sensitive {
-                info!("executing: ALTER ROLE ... PASSWORD [REDACTED]");
-            } else {
-                info!(sql = %statement, "executing");
-            }
-            sqlx::query(&statement)
-                .execute(transaction.as_mut())
-                .await
-                .with_context(|| {
-                    if is_sensitive {
-                        "failed to execute: ALTER ROLE ... PASSWORD [REDACTED]".to_string()
-                    } else {
-                        format!("failed to execute: {statement}")
-                    }
-                })?;
-        }
-    }
-    transaction
-        .commit()
-        .await
-        .context("failed to commit transaction")?;
+    execute_changes(&pool, &changes, &sql_ctx).await?;
 
     println!(
         "Applied {total} change(s) successfully.",
@@ -920,9 +873,140 @@ fn write_output(content: &str, output: Option<&Path>) -> Result<()> {
 
 async fn connect_db(database_url: &str) -> Result<PgPool> {
     info!("connecting to database");
-    PgPool::connect(database_url)
+    // The CLI is a one-shot tool, so prefer a single pooled connection. This
+    // avoids hopping across different backends when a hostname resolves to
+    // multiple PostgreSQL servers.
+    PgPoolOptions::new()
+        .max_connections(1)
+        .connect(database_url)
         .await
         .context("failed to connect to database")
+}
+
+#[derive(Debug, Clone)]
+struct ExecutionBackendInfo {
+    server_addr: String,
+    server_port: String,
+    backend_pid: i32,
+    database_name: String,
+    user_name: String,
+    in_recovery: bool,
+}
+
+impl std::fmt::Display for ExecutionBackendInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "server={} port={} pid={} db={} user={} recovery={}",
+            self.server_addr,
+            self.server_port,
+            self.backend_pid,
+            self.database_name,
+            self.user_name,
+            self.in_recovery
+        )
+    }
+}
+
+async fn fetch_execution_backend_info<'e, E>(
+    executor: E,
+) -> Result<ExecutionBackendInfo, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let row = sqlx::query(
+        r#"
+        SELECT
+            COALESCE(inet_server_addr()::text, 'local') AS server_addr,
+            COALESCE(inet_server_port()::text, 'local') AS server_port,
+            pg_backend_pid() AS backend_pid,
+            current_database() AS database_name,
+            current_user AS user_name,
+            pg_is_in_recovery() AS in_recovery
+        "#,
+    )
+    .fetch_one(executor)
+    .await?;
+
+    Ok(ExecutionBackendInfo {
+        server_addr: row.get("server_addr"),
+        server_port: row.get("server_port"),
+        backend_pid: row.get("backend_pid"),
+        database_name: row.get("database_name"),
+        user_name: row.get("user_name"),
+        in_recovery: row.get("in_recovery"),
+    })
+}
+
+fn render_execution_failure(
+    statement: &str,
+    backend: Option<&ExecutionBackendInfo>,
+    error: &sqlx::Error,
+) -> String {
+    let backend_suffix = backend
+        .map(|backend| format!(" on backend [{backend}]"))
+        .unwrap_or_default();
+
+    if let Some(database_error) = error.as_database_error() {
+        let code = database_error
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let message = database_error.message();
+        format!("failed to execute: {statement}{backend_suffix}: SQLSTATE {code}: {message}")
+    } else {
+        format!("failed to execute: {statement}{backend_suffix}: {error}")
+    }
+}
+
+async fn execute_changes(
+    pool: &PgPool,
+    changes: &[pgroles_core::diff::Change],
+    sql_ctx: &pgroles_core::sql::SqlContext,
+) -> Result<()> {
+    let mut transaction = pool.begin().await.context("failed to start transaction")?;
+    let execution_backend = match fetch_execution_backend_info(transaction.as_mut()).await {
+        Ok(backend) => {
+            info!(backend = %backend, "using execution backend");
+            Some(backend)
+        }
+        Err(error) => {
+            tracing::warn!(%error, "failed to query execution backend details");
+            None
+        }
+    };
+
+    for change in changes {
+        let is_sensitive = matches!(change, pgroles_core::diff::Change::SetPassword { .. });
+        for statement in pgroles_core::sql::render_statements_with_context(change, sql_ctx) {
+            let statement_for_error = if is_sensitive {
+                "ALTER ROLE ... PASSWORD [REDACTED]".to_string()
+            } else {
+                statement.clone()
+            };
+            if is_sensitive {
+                info!("executing: ALTER ROLE ... PASSWORD [REDACTED]");
+            } else {
+                info!(sql = %statement, "executing");
+            }
+            if let Err(error) = sqlx::query(&statement).execute(transaction.as_mut()).await {
+                anyhow::bail!(
+                    "{}",
+                    render_execution_failure(
+                        &statement_for_error,
+                        execution_backend.as_ref(),
+                        &error
+                    )
+                );
+            }
+        }
+    }
+    transaction
+        .commit()
+        .await
+        .context("failed to commit transaction")?;
+
+    Ok(())
 }
 
 async fn detect_sql_context(
@@ -1032,6 +1116,47 @@ async fn inspect_drop_safety(
 mod tests {
     use super::*;
     use pgroles_core::model::{RoleGraph, RoleState};
+    use sqlx::error::{DatabaseError, ErrorKind};
+
+    #[derive(Debug)]
+    struct TestDatabaseError {
+        message: String,
+        code: Option<&'static str>,
+    }
+
+    impl std::fmt::Display for TestDatabaseError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl std::error::Error for TestDatabaseError {}
+
+    impl DatabaseError for TestDatabaseError {
+        fn message(&self) -> &str {
+            &self.message
+        }
+
+        fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+            self.code.map(std::borrow::Cow::Borrowed)
+        }
+
+        fn as_error(&self) -> &(dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn as_error_mut(&mut self) -> &mut (dyn std::error::Error + Send + Sync + 'static) {
+            self
+        }
+
+        fn into_error(self: Box<Self>) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+            self
+        }
+
+        fn kind(&self) -> ErrorKind {
+            ErrorKind::Other
+        }
+    }
 
     fn sample_visual_graph() -> pgroles_core::visual::VisualGraph {
         let mut graph = RoleGraph::default();
@@ -1098,5 +1223,40 @@ mod tests {
                 .contains("--file or --bundle is required when --scope=managed"),
             "unexpected error: {error:#}"
         );
+    }
+
+    #[test]
+    fn render_execution_failure_includes_backend_and_sqlstate() {
+        let backend = ExecutionBackendInfo {
+            server_addr: "10.0.0.5".to_string(),
+            server_port: "5432".to_string(),
+            backend_pid: 4242,
+            database_name: "pgroles_test".to_string(),
+            user_name: "postgres".to_string(),
+            in_recovery: false,
+        };
+        let error = sqlx::Error::Database(Box::new(TestDatabaseError {
+            message: "role \"accounts-editor\" does not exist".to_string(),
+            code: Some("42704"),
+        }));
+
+        let rendered = render_execution_failure(
+            r#"ALTER ROLE "accounts-editor" NOLOGIN INHERIT;"#,
+            Some(&backend),
+            &error,
+        );
+
+        assert!(rendered.contains("SQLSTATE 42704"));
+        assert!(rendered.contains("server=10.0.0.5"));
+        assert!(rendered.contains("role \"accounts-editor\" does not exist"));
+    }
+
+    #[test]
+    fn render_execution_failure_without_database_error_falls_back_to_display() {
+        let error = sqlx::Error::Io(std::io::Error::from(std::io::ErrorKind::TimedOut));
+        let rendered = render_execution_failure("SELECT 1;", None, &error);
+
+        assert!(rendered.contains("failed to execute: SELECT 1;"));
+        assert!(rendered.contains("timed out"));
     }
 }

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -1056,6 +1056,26 @@ mod live_db {
         std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for live DB tests")
     }
 
+    fn database_url_for_role(role: &str, password: &str) -> String {
+        let base = database_url();
+        let scheme_end = base
+            .find("://")
+            .map(|index| index + 3)
+            .expect("DATABASE_URL should include a scheme");
+        let auth_end = base[scheme_end..]
+            .find('@')
+            .map(|index| scheme_end + index)
+            .expect("DATABASE_URL should include credentials");
+
+        format!(
+            "{}{}:{}{}",
+            &base[..scheme_end],
+            role,
+            password,
+            &base[auth_end..]
+        )
+    }
+
     fn unique_name(prefix: &str) -> String {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1152,6 +1172,21 @@ mod live_db {
                     .await
                     .expect("failed to query role existence");
             row.get("present")
+        })
+    }
+
+    fn query_role_login_and_inherit(role: &str) -> Option<(bool, bool)> {
+        with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            let row =
+                sqlx::query("SELECT rolcanlogin, rolinherit FROM pg_roles WHERE rolname = $1")
+                    .bind(role)
+                    .fetch_optional(&pool)
+                    .await
+                    .expect("failed to query role attributes");
+            row.map(|row| (row.get("rolcanlogin"), row.get("rolinherit")))
         })
     }
 
@@ -3637,6 +3672,130 @@ grants:
             DROP ROLE IF EXISTS "{role}";
             "#
         ));
+    }
+
+    /// Additive mode: does not rewrite brownfield role attributes for a
+    /// pre-existing role, which lets a limited CREATEROLE manager converge
+    /// grants without needing ADMIN on every existing role.
+    #[test]
+    #[ignore]
+    fn additive_mode_does_not_rewrite_preexisting_role_attributes() {
+        let managed_role = unique_name("addattrs_role");
+        let manager_role = unique_name("addattrs_manager");
+        let manager_password = unique_name("pw");
+        let manager_url = database_url_for_role(&manager_role, &manager_password);
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed_role}";
+            DROP ROLE IF EXISTS "{manager_role}";
+            CREATE ROLE "{managed_role}" LOGIN NOINHERIT;
+            CREATE ROLE "{manager_role}" LOGIN CREATEROLE PASSWORD '{manager_password}';
+            "#
+        ));
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP ROLE IF EXISTS "{managed_role}";
+            DROP ROLE IF EXISTS "{manager_role}";
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+roles:
+  - name: {managed_role}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &manager_url,
+                "--mode",
+                "additive",
+            ])
+            .assert()
+            .success();
+
+        assert_eq!(
+            query_role_login_and_inherit(&managed_role),
+            Some((true, false)),
+            "additive mode should leave existing role attributes unchanged"
+        );
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &manager_url,
+                "--mode",
+                "additive",
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+    }
+
+    /// Generated roles inherit profile-level inherit/login attributes.
+    #[test]
+    #[ignore]
+    fn apply_profile_generated_role_preserves_inherit_attribute() {
+        let schema = unique_name("profile_inherit_schema");
+        let generated_role = format!("{schema}-editor");
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{generated_role}";
+            CREATE SCHEMA "{schema}";
+            "#
+        ));
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{generated_role}";
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+profiles:
+  editor:
+    login: false
+    inherit: false
+    grants:
+      - privileges: [USAGE]
+        object: {{ type: schema }}
+
+schemas:
+  - name: {schema}
+    profiles: [editor]
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success();
+
+        assert_eq!(
+            query_role_login_and_inherit(&generated_role),
+            Some((false, false)),
+            "generated role should preserve profile login/inherit flags"
+        );
     }
 
     /// Adopt mode: revokes extra grants within managed scope but does

--- a/crates/pgroles-core/src/composition.rs
+++ b/crates/pgroles-core/src/composition.rs
@@ -711,6 +711,7 @@ roles:
                     "viewer".to_string(),
                     Profile {
                         login: None,
+                        inherit: None,
                         grants: vec![],
                         default_privileges: vec![],
                     },

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -190,8 +190,8 @@ impl std::fmt::Display for ReconciliationMode {
 /// Filter a list of changes according to the reconciliation mode.
 ///
 /// - **Authoritative**: returns all changes unmodified.
-/// - **Additive**: strips revokes, membership removals, role drops, and
-///   retirement cleanup steps.
+/// - **Additive**: strips revokes, membership removals, owner transfers,
+///   role rewrites, role drops, and retirement cleanup steps.
 /// - **Adopt**: strips role drops and retirement cleanup steps, but keeps
 ///   revokes and membership removals.
 pub fn filter_changes(changes: Vec<Change>, mode: ReconciliationMode) -> Vec<Change> {
@@ -223,6 +223,7 @@ fn filter_additive_changes(changes: Vec<Change>) -> Vec<Change> {
             Change::SetDefaultPrivilege { schema, owner, .. } => {
                 !skipped_owner_transfers.contains(&(schema.clone(), owner.clone()))
             }
+            Change::AlterRole { .. } | Change::SetComment { .. } => false,
             _ => !is_destructive(change),
         })
         .collect()
@@ -1395,8 +1396,8 @@ memberships:
     fn filter_additive_keeps_only_constructive_changes() {
         let filtered = filter_changes(all_change_variants(), ReconciliationMode::Additive);
 
-        // Should keep: CreateRole, CreateSchema, AlterRole, SetComment, Grant, SetDefaultPrivilege, AddMember
-        assert_eq!(filtered.len(), 7);
+        // Should keep: CreateRole, CreateSchema, Grant, SetDefaultPrivilege, AddMember
+        assert_eq!(filtered.len(), 5);
 
         // Verify no destructive changes remain
         for change in &filtered {
@@ -1405,6 +1406,8 @@ memberships:
                     change,
                     Change::AlterSchemaOwner { .. }
                         | Change::EnsureSchemaOwnerPrivileges { .. }
+                        | Change::AlterRole { .. }
+                        | Change::SetComment { .. }
                         | Change::Revoke { .. }
                         | Change::RevokeDefaultPrivilege { .. }
                         | Change::RemoveMember { .. }
@@ -1431,12 +1434,7 @@ memberships:
         assert!(
             filtered
                 .iter()
-                .any(|c| matches!(c, Change::AlterRole { .. }))
-        );
-        assert!(
-            filtered
-                .iter()
-                .any(|c| matches!(c, Change::SetComment { .. }))
+                .all(|c| !matches!(c, Change::AlterRole { .. } | Change::SetComment { .. }))
         );
         assert!(filtered.iter().any(|c| matches!(c, Change::Grant { .. })));
         assert!(

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -221,6 +221,9 @@ pub struct Profile {
     pub login: Option<bool>,
 
     #[serde(default)]
+    pub inherit: Option<bool>,
+
+    #[serde(default)]
     pub grants: Vec<ProfileGrant>,
 
     #[serde(default)]
@@ -545,7 +548,7 @@ pub fn expand_manifest(manifest: &PolicyManifest) -> Result<ExpandedManifest, Ma
                 superuser: None,
                 createdb: None,
                 createrole: None,
-                inherit: None,
+                inherit: profile.inherit,
                 replication: None,
                 bypassrls: None,
                 connection_limit: None,
@@ -884,6 +887,7 @@ schemas:
         assert_eq!(expanded.roles.len(), 1);
         assert_eq!(expanded.roles[0].name, "myschema-editor");
         assert_eq!(expanded.roles[0].login, Some(false));
+        assert_eq!(expanded.roles[0].inherit, None);
 
         // Schema usage grant + table grant
         assert_eq!(expanded.grants.len(), 2);
@@ -934,6 +938,31 @@ schemas:
                 },
             ]
         );
+    }
+
+    #[test]
+    fn expand_profiles_preserves_generated_role_inherit() {
+        let yaml = r#"
+profiles:
+  editor:
+    login: false
+    inherit: false
+    grants:
+      - privileges: [USAGE]
+        object: { type: schema }
+
+schemas:
+  - name: myschema
+    profiles: [editor]
+"#;
+
+        let manifest = parse_manifest(yaml).unwrap();
+        let expanded = expand_manifest(&manifest).unwrap();
+
+        assert_eq!(expanded.roles.len(), 1);
+        assert_eq!(expanded.roles[0].name, "myschema-editor");
+        assert_eq!(expanded.roles[0].login, Some(false));
+        assert_eq!(expanded.roles[0].inherit, Some(false));
     }
 
     #[test]

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -433,6 +433,9 @@ pub struct ProfileSpec {
     pub login: Option<bool>,
 
     #[serde(default)]
+    pub inherit: Option<bool>,
+
+    #[serde(default)]
     pub grants: Vec<ProfileGrantSpec>,
 
     #[serde(default)]
@@ -1193,6 +1196,7 @@ impl PostgresPolicySpec {
             .map(|(name, spec)| {
                 let profile = Profile {
                     login: spec.login,
+                    inherit: spec.inherit,
                     grants: spec
                         .grants
                         .iter()
@@ -1543,6 +1547,44 @@ mod tests {
     }
 
     #[test]
+    fn spec_to_policy_manifest_preserves_profile_inherit() {
+        let spec = PostgresPolicySpec {
+            connection: ConnectionSpec {
+                secret_ref: Some(SecretReference {
+                    name: "pg-secret".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
+            },
+            interval: "5m".to_string(),
+            suspend: false,
+            mode: PolicyMode::Apply,
+            reconciliation_mode: CrdReconciliationMode::default(),
+            default_owner: None,
+            profiles: std::collections::HashMap::from([(
+                "editor".to_string(),
+                ProfileSpec {
+                    login: Some(false),
+                    inherit: Some(false),
+                    grants: vec![],
+                    default_privileges: vec![],
+                },
+            )]),
+            schemas: vec![],
+            roles: vec![],
+            grants: vec![],
+            default_privileges: vec![],
+            memberships: vec![],
+            retirements: vec![],
+            approval: None,
+        };
+
+        let manifest = spec.to_policy_manifest();
+        assert_eq!(manifest.profiles["editor"].login, Some(false));
+        assert_eq!(manifest.profiles["editor"].inherit, Some(false));
+    }
+
+    #[test]
     fn status_set_condition_replaces_existing() {
         let mut status = PostgresPolicyStatus::default();
 
@@ -1581,6 +1623,7 @@ mod tests {
             "editor".to_string(),
             ProfileSpec {
                 login: Some(false),
+                inherit: None,
                 grants: vec![],
                 default_privileges: vec![],
             },

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -410,24 +410,11 @@ enum SqlErrorKind {
 }
 
 fn classify_sqlx_error(error: &sqlx::Error) -> SqlErrorKind {
-    let database_error = error.as_database_error();
-    let code = database_error
-        .as_ref()
-        .and_then(|database_error| database_error.code());
-    let message = database_error
-        .as_ref()
-        .map(|database_error| database_error.message().to_ascii_lowercase());
-
-    // Some providers have been observed to surface role-alter permission
-    // failures with a misleading SQLSTATE 42704. Fall back to English message
-    // text here to avoid misclassifying them as missing objects.
-    if message.as_deref().is_some_and(|message| {
-        message.contains("permission denied") || message.contains("must be superuser")
-    }) {
-        return SqlErrorKind::InsufficientPrivileges;
-    }
-
-    match code.as_deref() {
+    match error
+        .as_database_error()
+        .and_then(|database_error| database_error.code())
+        .as_deref()
+    {
         Some(SQLSTATE_INSUFFICIENT_PRIVILEGE) => SqlErrorKind::InsufficientPrivileges,
         Some(SQLSTATE_INVALID_SCHEMA_NAME)
         | Some(SQLSTATE_UNDEFINED_TABLE)
@@ -2190,13 +2177,6 @@ mod tests {
         }))
     }
 
-    fn permission_denied_alter_role_sqlx_error_with_wrong_code() -> sqlx::Error {
-        sqlx::Error::Database(Box::new(TestDatabaseError {
-            message: "permission denied to alter role".to_string(),
-            code: Some(SQLSTATE_UNDEFINED_OBJECT),
-        }))
-    }
-
     fn transient_sqlx_error() -> sqlx::Error {
         sqlx::Error::Database(Box::new(TestDatabaseError {
             message: "connection timed out".to_string(),
@@ -3255,10 +3235,6 @@ mod tests {
             SqlErrorKind::MissingDatabaseObject
         );
         assert_eq!(
-            classify_sqlx_error(&permission_denied_alter_role_sqlx_error_with_wrong_code()),
-            SqlErrorKind::InsufficientPrivileges
-        );
-        assert_eq!(
             classify_sqlx_error(&transient_sqlx_error()),
             SqlErrorKind::Transient
         );
@@ -3290,13 +3266,6 @@ mod tests {
     fn error_reason_sql_exec_missing_database_object() {
         let err = ReconcileError::SqlExec(missing_schema_sqlx_error());
         assert_eq!(err.reason(), "MissingDatabaseObject");
-    }
-
-    #[test]
-    fn error_reason_sql_exec_permission_denied_role_change_is_insufficient_privileges() {
-        let err =
-            ReconcileError::SqlExec(permission_denied_alter_role_sqlx_error_with_wrong_code());
-        assert_eq!(err.reason(), "InsufficientPrivileges");
     }
 
     #[test]

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -410,11 +410,21 @@ enum SqlErrorKind {
 }
 
 fn classify_sqlx_error(error: &sqlx::Error) -> SqlErrorKind {
-    match error
-        .as_database_error()
-        .and_then(|database_error| database_error.code())
-        .as_deref()
-    {
+    let database_error = error.as_database_error();
+    let code = database_error
+        .as_ref()
+        .and_then(|database_error| database_error.code());
+    let message = database_error
+        .as_ref()
+        .map(|database_error| database_error.message().to_ascii_lowercase());
+
+    if message.as_deref().is_some_and(|message| {
+        message.contains("permission denied") || message.contains("must be superuser")
+    }) {
+        return SqlErrorKind::InsufficientPrivileges;
+    }
+
+    match code.as_deref() {
         Some(SQLSTATE_INSUFFICIENT_PRIVILEGE) => SqlErrorKind::InsufficientPrivileges,
         Some(SQLSTATE_INVALID_SCHEMA_NAME)
         | Some(SQLSTATE_UNDEFINED_TABLE)
@@ -2177,6 +2187,13 @@ mod tests {
         }))
     }
 
+    fn permission_denied_alter_role_sqlx_error_with_wrong_code() -> sqlx::Error {
+        sqlx::Error::Database(Box::new(TestDatabaseError {
+            message: "permission denied to alter role".to_string(),
+            code: Some(SQLSTATE_UNDEFINED_OBJECT),
+        }))
+    }
+
     fn transient_sqlx_error() -> sqlx::Error {
         sqlx::Error::Database(Box::new(TestDatabaseError {
             message: "connection timed out".to_string(),
@@ -3235,6 +3252,10 @@ mod tests {
             SqlErrorKind::MissingDatabaseObject
         );
         assert_eq!(
+            classify_sqlx_error(&permission_denied_alter_role_sqlx_error_with_wrong_code()),
+            SqlErrorKind::InsufficientPrivileges
+        );
+        assert_eq!(
             classify_sqlx_error(&transient_sqlx_error()),
             SqlErrorKind::Transient
         );
@@ -3266,6 +3287,13 @@ mod tests {
     fn error_reason_sql_exec_missing_database_object() {
         let err = ReconcileError::SqlExec(missing_schema_sqlx_error());
         assert_eq!(err.reason(), "MissingDatabaseObject");
+    }
+
+    #[test]
+    fn error_reason_sql_exec_permission_denied_role_change_is_insufficient_privileges() {
+        let err =
+            ReconcileError::SqlExec(permission_denied_alter_role_sqlx_error_with_wrong_code());
+        assert_eq!(err.reason(), "InsufficientPrivileges");
     }
 
     #[test]

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -418,6 +418,9 @@ fn classify_sqlx_error(error: &sqlx::Error) -> SqlErrorKind {
         .as_ref()
         .map(|database_error| database_error.message().to_ascii_lowercase());
 
+    // Some providers have been observed to surface role-alter permission
+    // failures with a misleading SQLSTATE 42704. Fall back to English message
+    // text here to avoid misclassifying them as missing objects.
     if message.as_deref().is_some_and(|message| {
         message.contains("permission denied") || message.contains("must be superuser")
     }) {

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -9,7 +9,7 @@ Guide to rolling out pgroles against existing databases without disruption. {% .
 
 ## Brownfield vs greenfield
 
-If your database already has roles, grants, and schemas, you are in a **brownfield** scenario. pgroles is designed for this — use `additive` mode to layer managed roles on top of existing state without revoking anything.
+If your database already has roles, grants, and schemas, you are in a **brownfield** scenario. pgroles is designed for this — use `additive` mode to layer managed roles on top of existing state without revoking anything or rewriting pre-existing role attributes during the first rollout.
 
 For new databases where pgroles owns everything from the start, `authoritative` mode is appropriate.
 
@@ -49,7 +49,7 @@ If the output is `-- No changes needed`, the manifest matches the database and a
 
 ### 4. Enable additive apply
 
-Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, adding grants and memberships, and setting default privileges when their owner context is already valid — but never revokes existing privileges, transfers schema ownership, removes memberships, or drops roles. If a schema's desired `owner` differs from the current owner, pgroles defers owner-bound follow-up steps such as `ALTER DEFAULT PRIVILEGES FOR ROLE <owner> ...` until a mode that allows the ownership transfer.
+Switch to `mode: apply` with `reconciliation_mode: additive`. This applies all non-destructive changes — creating roles and declared schemas, adding grants and memberships, and setting default privileges when their owner context is already valid — but never revokes existing privileges, rewrites attributes/comments on pre-existing roles, transfers schema ownership, removes memberships, or drops roles. If a schema's desired `owner` differs from the current owner, pgroles defers owner-bound follow-up steps such as `ALTER DEFAULT PRIVILEGES FOR ROLE <owner> ...` until a mode that allows the ownership transfer.
 
 ```yaml
 spec:
@@ -112,7 +112,7 @@ This means:
 
 - A role may have effective privileges not visible in `pgroles inspect` output
 - A manifest that omits `TEMPORARY` does not guarantee the role lacks `TEMPORARY` — it may still inherit it from `PUBLIC`
-- `additive` mode showing "no changes needed" does not mean effective privileges match the manifest exactly
+- `additive` mode showing "no changes needed" does not mean effective privileges or existing role attributes match the manifest exactly
 
 If least-privilege enforcement is important, you may need to manually revoke unwanted `PUBLIC` grants:
 

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -260,9 +260,11 @@ Only grant, never revoke. New roles, grants, memberships, and default privileges
 pgroles apply --database-url postgres://localhost/mydb --mode additive
 ```
 
-Additive mode filters out: `REVOKE`, `REVOKE DEFAULT PRIVILEGE`, `REMOVE MEMBER`, `DROP ROLE`, `DROP OWNED`, `REASSIGN OWNED`, and `TERMINATE SESSIONS`.
+Additive mode filters out: `ALTER ROLE`, `COMMENT ON ROLE`, `REVOKE`, `REVOKE DEFAULT PRIVILEGE`, `REMOVE MEMBER`, `ALTER SCHEMA ... OWNER TO ...`, `DROP ROLE`, `DROP OWNED`, `REASSIGN OWNED`, and `TERMINATE SESSIONS`.
 
 If additive mode skips a schema ownership transfer, pgroles also defers owner-bound follow-up steps such as schema-owner privilege repair and `ALTER DEFAULT PRIVILEGES FOR ROLE ...` for that owner context.
+
+For brownfield roles that already exist, additive mode intentionally leaves role attributes and comments unchanged. That means a pre-existing `LOGIN NOINHERIT` role can stay that way during adoption even if a minimal manifest would otherwise imply `NOLOGIN INHERIT`.
 
 ### adopt
 

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -151,6 +151,36 @@ default_owner: pgloader_pg
 
 Individual schemas can override this with their own `owner` field.
 
+## profiles
+
+Profiles are reusable templates that expand into concrete roles, grants, and default privileges when bound to schemas.
+
+```yaml
+profiles:
+  editor:
+    login: false
+    inherit: false
+    grants:
+      - privileges: [USAGE]
+        object: { type: schema }
+      - privileges: [SELECT, INSERT, UPDATE, DELETE]
+        object: { type: table, name: "*" }
+    default_privileges:
+      - privileges: [SELECT, INSERT, UPDATE, DELETE]
+        on_type: table
+```
+
+### Profile fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `login` | bool | `false` | Login attribute for generated roles |
+| `inherit` | bool | `true` | Inherit attribute for generated roles |
+| `grants` | list[grant template] | `[]` | Grants expanded into each bound schema |
+| `default_privileges` | list[default privilege template] | `[]` | Default privileges expanded into each bound schema |
+
+The generated role attributes apply only to roles created from `schema x profile` expansion. One-off roles under `roles:` still declare their own attributes directly.
+
 ## schemas
 
 The `schemas` section serves two related purposes:
@@ -188,6 +218,10 @@ When a schema is declared under `schemas:`:
 - pgroles does not reassign ownership of objects inside the schema
 
 If a schema is only referenced from top-level `grants:` or `default_privileges:` and is not declared under `schemas:`, it must already exist.
+
+{% callout type="note" title="Additive mode and schema bindings" %}
+In `additive` mode, pgroles still creates missing generated roles and grants, but it does not rewrite attributes or comments on pre-existing roles. If a generated role already exists with different attributes, additive mode leaves it unchanged until you switch to a mode that allows full convergence.
+{% /callout %}
 
 ### Declared vs referenced example
 

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -184,6 +184,8 @@ spec:
 
   profiles:
     editor:
+      login: false
+      inherit: false
       grants:
         - privileges: [USAGE]
           object: { type: schema }
@@ -227,7 +229,7 @@ spec:
       drop_owned: true
 ```
 
-Declared schemas can be created and have ownership converged by the operator. Schemas that are only referenced from top-level grants or default privileges must already exist in the database.
+Declared schemas can be created and have ownership converged by the operator. Schemas that are only referenced from top-level grants or default privileges must already exist in the database. Profile-generated roles also inherit the profile-level `login` and `inherit` attributes shown above.
 
 ### Database connection
 
@@ -456,7 +458,7 @@ spec:
 | Value | Behavior |
 | --- | --- |
 | `authoritative` (default) | Full convergence — anything not in the manifest is revoked or dropped |
-| `additive` | Only grant, never revoke — safe for incremental adoption |
+| `additive` | Only grant, never revoke — safe for incremental adoption, and it leaves pre-existing role attributes/comments unchanged |
 | `adopt` | Manage declared roles fully, but never drop undeclared roles |
 
 This is the same behavior as the CLI `--mode` flag. See the [CLI reconciliation modes](/docs/cli#reconciliation-modes) section for detailed semantics.

--- a/docs/src/pages/docs/profiles.md
+++ b/docs/src/pages/docs/profiles.md
@@ -106,20 +106,23 @@ This produces `legacy-viewer` instead of `legacy_data-viewer`.
 
 The pattern **must** contain `{profile}`. The `{schema}` placeholder is optional.
 
-## Profile login attribute
+## Generated role attributes
 
-Profiles can specify a `login` attribute that applies to generated roles:
+Profiles can specify `login` and `inherit` attributes that apply to generated roles:
 
 ```yaml
 profiles:
   service:
     login: true
+    inherit: false
     grants:
       - privileges: [USAGE]
         object: { type: schema }
 ```
 
-By default, profile-generated roles have `login: false` (NOLOGIN).
+By default, profile-generated roles have `login: false` (NOLOGIN) and `inherit: true` (INHERIT).
+
+This is especially useful for IAM-style patterns where a generated role should not be directly usable as a login role, or where you want generated roles to stay `NOINHERIT` until explicitly assumed.
 
 ## Owner overrides
 

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -584,6 +584,10 @@
                           },
                           "type": "array"
                         },
+                        "inherit": {
+                          "nullable": true,
+                          "type": "boolean"
+                        },
                         "login": {
                           "nullable": true,
                           "type": "boolean"


### PR DESCRIPTION
## Summary
- stop additive mode from rewriting attributes and comments on pre-existing roles
- add profile-level generated-role `inherit` support and thread it through the operator CRD
- make CLI execution stick to a single backend and include backend identity in SQL execution failures
- update user-facing docs for additive brownfield behavior and generated-role attributes

## Why
A brownfield role like `accounts_editor LOGIN NOINHERIT` could cause additive mode to plan `ALTER ROLE ... NOLOGIN INHERIT`, which is not consistent with additive adoption semantics.

In environments where one hostname can resolve to multiple PostgreSQL servers, one-shot CLI commands could also inspect one backend and execute mutations against another. This change reduces that risk by keeping CLI execution on a single connection and improves diagnosis by surfacing backend identity when SQL execution fails.

## Validation
- cargo test --workspace
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- scripts/check-crd-drift.sh
- DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test cargo test -p pgroles-cli --test cli additive_mode -- --ignored --test-threads=1
- DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test cargo test --workspace -- --include-ignored

Fixes #94
