### PR TITLE
Address plan storage review follow-ups

### DIFF
--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -344,6 +344,9 @@ pub async fn create_or_update_plan(
             Ok(plan) => (plan, true),
             Err(kube::Error::Api(api_err)) if api_err.code == 409 => {
                 let existing = plans_api.get(&plan_name).await?;
+                if !should_patch_existing_plan_status(&existing) {
+                    return Ok(PlanCreationResult::Deduplicated(existing.name_any()));
+                }
                 (existing, false)
             }
             Err(err) => {
@@ -686,7 +689,7 @@ fn build_plan_sql_configmap_object(
                 ),
                 (
                     LABEL_PLAN.to_string(),
-                    sanitize_label_value(configmap_plan_name(configmap_name)),
+                    plan_label_value(configmap_plan_name(configmap_name)),
                 ),
             ])),
             annotations: Some(BTreeMap::from([
@@ -718,6 +721,10 @@ fn configmap_plan_name(configmap_name: &str) -> &str {
     configmap_name
         .strip_suffix("-sql")
         .unwrap_or(configmap_name)
+}
+
+fn plan_label_value(plan_name: &str) -> String {
+    compute_sql_hash(plan_name)[..32].to_string()
 }
 
 fn validate_existing_sql_configmap(
@@ -913,11 +920,13 @@ async fn cleanup_orphan_sql_configmaps(
         .await?;
     let known_plan_labels: BTreeSet<String> = existing_plans
         .iter()
-        .map(|plan| sanitize_label_value(&plan.name_any()))
+        .map(|plan| plan_label_value(&plan.name_any()))
         .collect();
+    let known_plan_names: BTreeSet<String> =
+        existing_plans.iter().map(ResourceExt::name_any).collect();
 
     for configmap in configmaps {
-        if !is_orphan_sql_configmap(&configmap, &known_plan_labels, now_ts) {
+        if !is_orphan_sql_configmap(&configmap, &known_plan_names, &known_plan_labels, now_ts) {
             continue;
         }
 
@@ -944,6 +953,7 @@ async fn cleanup_orphan_sql_configmaps(
 
 fn is_orphan_sql_configmap(
     configmap: &ConfigMap,
+    known_plan_names: &BTreeSet<String>,
     known_plan_labels: &BTreeSet<String>,
     now_ts: i64,
 ) -> bool {
@@ -953,9 +963,19 @@ fn is_orphan_sql_configmap(
     if !labels.contains_key(LABEL_POLICY) || !is_stale_object(configmap, now_ts) {
         return false;
     }
+    if known_plan_names.contains(configmap_plan_name(&configmap.name_any())) {
+        return false;
+    }
     labels
         .get(LABEL_PLAN)
         .map(|plan_label| !known_plan_labels.contains(plan_label))
+        .unwrap_or(true)
+}
+
+fn should_patch_existing_plan_status(plan: &PostgresPolicyPlan) -> bool {
+    plan.status
+        .as_ref()
+        .map(|status| status.phase == PlanPhase::Pending)
         .unwrap_or(true)
 }
 
@@ -1554,6 +1574,36 @@ mod tests {
     }
 
     #[test]
+    fn plan_label_value_is_stable_and_label_safe_for_long_names() {
+        let plan_name = "very-long-policy-name-".repeat(20);
+        let label = plan_label_value(&plan_name);
+        assert_eq!(label, plan_label_value(&plan_name));
+        assert_eq!(label.len(), 32);
+        assert!(label.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn existing_non_pending_plan_status_is_not_repatched_on_create_conflict() {
+        let approved = test_plan("plan-1", PlanPhase::Approved, None);
+        let applying = test_plan("plan-1", PlanPhase::Applying, None);
+        let applied = test_plan("plan-1", PlanPhase::Applied, None);
+
+        assert!(!should_patch_existing_plan_status(&approved));
+        assert!(!should_patch_existing_plan_status(&applying));
+        assert!(!should_patch_existing_plan_status(&applied));
+    }
+
+    #[test]
+    fn existing_pending_or_statusless_plan_can_be_patched_on_create_conflict() {
+        let pending = test_plan("plan-1", PlanPhase::Pending, None);
+        let mut statusless = pending.clone();
+        statusless.status = None;
+
+        assert!(should_patch_existing_plan_status(&pending));
+        assert!(should_patch_existing_plan_status(&statusless));
+    }
+
+    #[test]
     fn prepare_plan_sql_keeps_small_sql_inline() {
         let prepared = prepare_plan_sql("plan-1", "CREATE ROLE app LOGIN;").unwrap();
 
@@ -1671,15 +1721,50 @@ mod tests {
         assert!(is_orphan_sql_configmap(
             &configmap,
             &BTreeSet::new(),
+            &BTreeSet::new(),
             ORPHAN_GRACE_SECS + 1
         ));
     }
 
     #[test]
-    fn stale_policy_sql_configmap_with_known_plan_label_is_not_orphan() {
-        let plan_label = sanitize_label_value("test-policy-plan-20260506-000000-abcdef012345");
+    fn stale_policy_sql_configmap_with_current_plan_name_is_not_orphan() {
+        let plan_name = "test-policy-plan-20260506-000000-abcdef012345";
         let configmap = ConfigMap {
             metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some(format!("{plan_name}-sql")),
+                labels: Some(BTreeMap::from([
+                    (
+                        LABEL_POLICY.to_string(),
+                        sanitize_label_value("test-policy"),
+                    ),
+                    (
+                        LABEL_PLAN.to_string(),
+                        sanitize_label_value("legacy-colliding-label"),
+                    ),
+                ])),
+                creation_timestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                    jiff::Timestamp::from_second(0).unwrap(),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(!is_orphan_sql_configmap(
+            &configmap,
+            &BTreeSet::from([plan_name.to_string()]),
+            &BTreeSet::new(),
+            ORPHAN_GRACE_SECS + 1
+        ));
+    }
+
+    #[test]
+    fn stale_policy_sql_configmap_with_known_hash_plan_label_is_not_orphan() {
+        let plan_name = "test-policy-plan-20260506-000000-abcdef012345";
+        let plan_label = plan_label_value(plan_name);
+        let configmap = ConfigMap {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("different-plan-sql".to_string()),
                 labels: Some(BTreeMap::from([
                     (
                         LABEL_POLICY.to_string(),
@@ -1697,7 +1782,39 @@ mod tests {
 
         assert!(!is_orphan_sql_configmap(
             &configmap,
+            &BTreeSet::new(),
             &BTreeSet::from([plan_label]),
+            ORPHAN_GRACE_SECS + 1
+        ));
+    }
+
+    #[test]
+    fn stale_policy_sql_configmap_with_only_legacy_colliding_label_is_orphan() {
+        let plan_name =
+            "very-long-policy-name-that-would-have-collided-plan-20260506-000000-abcdef012345";
+        let legacy_label = sanitize_label_value(plan_name);
+        let configmap = ConfigMap {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("deleted-historical-plan-sql".to_string()),
+                labels: Some(BTreeMap::from([
+                    (
+                        LABEL_POLICY.to_string(),
+                        sanitize_label_value("test-policy"),
+                    ),
+                    (LABEL_PLAN.to_string(), legacy_label.clone()),
+                ])),
+                creation_timestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                    jiff::Timestamp::from_second(0).unwrap(),
+                )),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(is_orphan_sql_configmap(
+            &configmap,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
             ORPHAN_GRACE_SECS + 1
         ));
     }

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -770,6 +770,8 @@ async fn reconcile_apply_inner(
     // Release advisory lock (always, even on error).
     advisory_lock.release().await;
 
+    crate::plan::cleanup_old_plans_best_effort(&ctx.kube_client, resource, None).await;
+
     result
 }
 
@@ -980,8 +982,6 @@ async fn apply_under_lock(
         })
         .await?;
 
-        crate::plan::cleanup_old_plans_best_effort(&ctx.kube_client, resource, None).await;
-
         info!(
             name,
             namespace,
@@ -1100,8 +1100,6 @@ async fn apply_under_lock(
             })
             .await?;
 
-            crate::plan::cleanup_old_plans_best_effort(&ctx.kube_client, resource, None).await;
-
             Ok((
                 Action::requeue(requeue_interval),
                 ReconcileOutcome::Reconciled,
@@ -1207,13 +1205,6 @@ async fn apply_under_lock(
                             })
                             .await?;
 
-                            crate::plan::cleanup_old_plans_best_effort(
-                                &ctx.kube_client,
-                                resource,
-                                None,
-                            )
-                            .await;
-
                             return Ok((
                                 Action::requeue(requeue_interval),
                                 ReconcileOutcome::Planned,
@@ -1311,13 +1302,6 @@ async fn apply_under_lock(
                             status.transient_failure_count = 0;
                         })
                         .await?;
-
-                        crate::plan::cleanup_old_plans_best_effort(
-                            &ctx.kube_client,
-                            resource,
-                            None,
-                        )
-                        .await;
 
                         return Ok((
                             Action::requeue(requeue_interval),
@@ -1494,8 +1478,6 @@ async fn apply_under_lock(
                 });
             })
             .await?;
-
-            crate::plan::cleanup_old_plans_best_effort(&ctx.kube_client, resource, None).await;
 
             info!(
                 name,
@@ -3124,6 +3106,13 @@ mod tests {
     }
 
     #[test]
+    fn retry_classifies_plan_sql_storage_as_slow() {
+        let error =
+            finalizer::Error::ApplyFailed(ReconcileError::PlanSqlStorage("gzip failed".into()));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
+    }
+
+    #[test]
     fn retry_classifies_secret_missing_as_slow() {
         let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
             crate::context::ContextError::SecretMissing {
@@ -3315,6 +3304,12 @@ mod tests {
     fn error_reason_sql_exec_transient_is_apply_failed() {
         let err = ReconcileError::SqlExec(transient_sqlx_error());
         assert_eq!(err.reason(), "ApplyFailed");
+    }
+
+    #[test]
+    fn error_reason_plan_sql_storage_failed() {
+        let err = ReconcileError::PlanSqlStorage("gzip failed".into());
+        assert_eq!(err.reason(), "PlanSqlStorageFailed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #100 / v0.7.0-beta.2 for the actionable PR review comments.

- Use a non-truncated hash label for new plan SQL ConfigMaps, while preserving current legacy ConfigMaps by deriving the full plan name from the ConfigMap name.
- Treat stale legacy ConfigMaps with only colliding truncated labels as orphans instead of keeping them alive because another long-name plan shares the same label prefix.
- Avoid clobbering an existing same-name plan status on create `409` if that plan has already advanced beyond `Pending`.
- Move post-reconcile best-effort plan cleanup to after PostgreSQL advisory lock release so Kubernetes cleanup latency does not extend DB lock hold time.
- Add regression tests for the label identity, 409 status guard, orphan classification, and `PlanSqlStorageFailed` retry/reason mapping.

## Validation

- `cargo test -p pgroles-operator --lib`
- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- `scripts/check-crd-drift.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Plan resource labels are now stable and hash-based, improving consistency across reconciliation cycles
  * Orphan resource detection has been strengthened to better identify and properly handle known plan resources
  * Plan creation now intelligently handles conflicts through deduplication when appropriate instead of applying conflicting patches

* **Performance**
  * Plan cleanup operations have been optimized to execute earlier in the reconciliation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->