### PR TITLE
ci: install PostgresPolicyPlan CRD in operator-fairness-load workflow

### DIFF
--- a/.github/workflows/operator-fairness-load.yml
+++ b/.github/workflows/operator-fairness-load.yml
@@ -109,8 +109,15 @@ jobs:
       - name: Create kind cluster
         run: kind create cluster --name pgroles-fairness --wait 60s
 
-      - name: Install CRD
-        run: kubectl apply -f k8s/crd.yaml
+      - name: Install CRDs
+        run: |
+          # Both CRDs must be installed: the operator writes
+          # `PostgresPolicyPlan` resources alongside `PostgresPolicy`,
+          # and a missing plan CRD surfaces as a 404 on every reconcile.
+          # The shared composite action `.github/actions/setup-e2e` does
+          # the same thing for CI's E2E suites.
+          kubectl apply -f k8s/crd.yaml
+          kubectl apply -f k8s/postgrespolicyplan-crd.yaml
 
       - name: Deploy dev PostgreSQL
         run: |


### PR DESCRIPTION
## Summary

The scheduled `Operator Fairness and Load` workflow has been failing every day for ~26 consecutive runs since 2026-04-12 (commit `d9f0349`, leading into v0.5.0). Last successful run: 2026-04-11 on `3fd7fd1`. Schedule-only trigger, so the failure was hidden from the regular CI suite.

## Root cause

The operator writes `PostgresPolicyPlan` resources alongside `PostgresPolicy` (added in #74). This workflow has its own inline cluster setup that only applied `k8s/crd.yaml` (PostgresPolicy). Every plan-write hit the apiserver's default 404 handler whose body is plaintext `"404 page not found\n"` — not a parseable Kubernetes Status object — so `kube-rs` surfaced it as:

```
Kubernetes API error: ApiError: 404 page not found
: Failed to parse error data (Status { ..., reason: "Failed to parse error data" })
```

The policy itself was actually working — `status.owned_roles` and `status.owned_schemas` listed the 40 roles + 20 schemas it had successfully created. But the operator couldn't write its plan CR, so `Ready=False/KubernetesApiError`, and `wait_for_ready_true fair-a` timed out at 90 attempts.

## Fix

Add `kubectl apply -f k8s/postgrespolicyplan-crd.yaml` alongside the existing `k8s/crd.yaml` apply. The shared composite action `.github/actions/setup-e2e/action.yml` (used by all of CI's E2E suites) already installs both — this workflow's inline copy just drifted.

Consolidating both workflows onto the shared composite action is the obvious follow-up; this PR keeps the change minimal and surgical.

## Test plan

- [ ] Manual workflow_dispatch on this branch lands green.
- [ ] After merge, watch the next scheduled run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reconciliation errors during operator testing by ensuring all required Kubernetes Custom Resource Definitions are properly installed to prevent 404 errors in the deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->