### PR TITLE
ci(fairness): switch to shared setup-e2e composite action

### DIFF
--- a/.github/workflows/operator-fairness-load.yml
+++ b/.github/workflows/operator-fairness-load.yml
@@ -92,72 +92,30 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Shared with CI's E2E suites — installs kind, both CRDs, deploys
+      # dev PostgreSQL, builds and deploys the operator, and verifies it
+      # by reconciling `basic-policy`. Keeping fairness on the same
+      # composite action prevents the inline copy from drifting again
+      # (as it did between #74 and #102).
+      - uses: ./.github/actions/setup-e2e
+        with:
+          cluster-name: pgroles-fairness
 
-      - uses: Swatinem/rust-cache@v2
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Install kind
+      - name: Prepare fairness-specific state
         run: |
-          [ -f /usr/local/bin/kind ] || {
-            curl -Lo /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
-            echo "b89aada5a39d620da3fcd16435b7f28d858927dd53f92cbac77686b0588b600d  /usr/local/bin/kind" | sha256sum -c -
-            chmod +x /usr/local/bin/kind
-          }
+          # Free up `basic-policy` (created by the composite for its
+          # health check) so it doesn't compete with fairness scenarios.
+          kubectl delete pgr basic-policy --wait=true
 
-      - name: Create kind cluster
-        run: kind create cluster --name pgroles-fairness --wait 60s
-
-      - name: Install CRDs
-        run: |
-          # Both CRDs must be installed: the operator writes
-          # `PostgresPolicyPlan` resources alongside `PostgresPolicy`,
-          # and a missing plan CRD surfaces as a 404 on every reconcile.
-          # The shared composite action `.github/actions/setup-e2e` does
-          # the same thing for CI's E2E suites.
-          kubectl apply -f k8s/crd.yaml
-          kubectl apply -f k8s/postgrespolicyplan-crd.yaml
-
-      - name: Deploy dev PostgreSQL
-        run: |
-          kubectl apply -f k8s/dev/postgres.yaml
-          kubectl rollout status statefulset/postgres --timeout=120s
-
-      - name: Wait for PostgreSQL readiness
-        run: kubectl wait --for=condition=ready pod/postgres-0 --timeout=90s
-
-      - name: Seed databases and secrets
-        run: |
+          # Add the second `churntest` database + secret. The composite
+          # already provisions `loadtest` + `loadtest-postgres-credentials`.
           kubectl exec -i postgres-0 -- psql -v ON_ERROR_STOP=1 -U postgres -d postgres <<'SQL'
-          CREATE DATABASE loadtest;
           CREATE DATABASE churntest;
           SQL
-
-          kubectl create secret generic loadtest-postgres-credentials \
-            --from-literal=DATABASE_URL='postgres://postgres:devpassword@postgres.default.svc.cluster.local:5432/loadtest' \
-            --dry-run=client -o yaml | kubectl apply -f -
 
           kubectl create secret generic churntest-postgres-credentials \
             --from-literal=DATABASE_URL='postgres://postgres:devpassword@postgres.default.svc.cluster.local:5432/churntest' \
             --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Build operator image and load into kind
-        run: |
-          docker build -f docker/Dockerfile --target operator -t pgroles-operator:fairness .
-          kind load docker-image pgroles-operator:fairness --name pgroles-fairness
-
-      - name: Deploy operator
-        run: |
-          kubectl apply -f k8s/deploy/namespace.yaml
-          kubectl apply -f k8s/deploy/rbac.yaml
-
-          sed 's|ghcr.io/hardbyte/pgroles-operator:latest|pgroles-operator:fairness|' \
-            k8s/deploy/deployment.yaml | \
-            sed 's|imagePullPolicy:.*|imagePullPolicy: Never|' | \
-            kubectl apply -f -
-
-          kubectl -n pgroles-system rollout status deployment/pgroles-operator --timeout=60s
 
       - name: Run fairness and load scenarios
         run: |


### PR DESCRIPTION
## Summary

Replaces the inline cluster bootstrap in `operator-fairness-load.yml` (~56 lines: kind install/create, CRDs, dev postgres, secrets, operator build/deploy) with `uses: ./.github/actions/setup-e2e@cluster-name: pgroles-fairness`. Same composite action CI's three E2E suites use.

Net change: **-56 / +14**.

## Why

#102 fixed the immediate breakage (missing `PostgresPolicyPlan` CRD installation), but the underlying problem was that fairness had its own copy of the cluster setup that drifted out of sync with the shared composite. Consolidating now means future operator changes (new CRDs, new env vars, new RBAC) only have to be plumbed once.

## What stays / what changes

**Identical to the previous behaviour** (composite covers it):
- kind install (same `v0.24.0` + SHA)
- kind cluster create with `--wait 60s`
- both CRDs applied
- dev postgres deploy + readiness wait
- operator Docker image build
- operator deploy

**New for free** (composite includes these; fairness didn't):
- otel-collector deployment (the operator now reports metrics during the run)
- `basic-policy` reconciliation health check up-front (catches setup problems before fairness scenarios start running)
- `limited_operator` role + secret (unused by fairness, harmless)

**Fairness-specific, kept in a new `Prepare fairness-specific state` step**:
- `kubectl delete pgr basic-policy --wait=true` — frees the composite's health-check policy so it doesn't compete with the `fair-a/b/c` policies for the shared `postgres-credentials` secret.
- `CREATE DATABASE churntest` + `churntest-postgres-credentials` secret — the composite already provisions `loadtest`.

**Cosmetic**: operator image tag `pgroles-operator:fairness` → `pgroles-operator:e2e`. The kind cluster is isolated, so the tag rename is invisible.

## Test plan

- [ ] Manual `workflow_dispatch` on this branch lands green (will trigger after push).
- [ ] After merge, watch the next scheduled run pick up the consolidated path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD workflow to use shared setup automation, improving consistency and efficiency of testing infrastructure processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->