### PR TITLE
Fix unsatisfiable wildcard grant churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.2] - 2026-05-08
 
+### Changed
+
+- Wildcard diagnostics now avoid grantability catalog scans when current ACLs already satisfy the wildcard, and scope grantability checks to the unsatisfied wildcard schema/object-type pairs.
+
 ### Fixed
 
 - **Unsatisfiable wildcard grants now fail with a clear diagnostic instead of re-planning forever.** A wildcard such as `function name: "*"` remains strict desired state: every matching object must either already have the requested privilege or be grantable by the executor. When a matching object is missing the privilege and the executor lacks the corresponding `WITH GRANT OPTION`, CLI `diff`/`plan`/`apply` now stop with `UnsatisfiableWildcardGrant` instead of printing or applying repeated wildcard SQL. The operator reports `Ready=False` and `Degraded=True` with the same reason, leaves no new `PostgresPolicyPlan` or SQL ConfigMap for that reconcile, and retries at the normal policy interval. (#105, #106)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-05-08
+
+### Fixed
+
+- **Unsatisfiable wildcard grants now fail with a clear diagnostic instead of re-planning forever.** A wildcard such as `function name: "*"` remains strict desired state: every matching object must either already have the requested privilege or be grantable by the executor. When a matching object is missing the privilege and the executor lacks the corresponding `WITH GRANT OPTION`, CLI `diff`/`plan`/`apply` now stop with `UnsatisfiableWildcardGrant` instead of printing or applying repeated wildcard SQL. The operator reports `Ready=False` and `Degraded=True` with the same reason, leaves no new `PostgresPolicyPlan` or SQL ConfigMap for that reconcile, and retries at the normal policy interval. (#105, #106)
+
 ## [0.7.1] - 2026-05-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -98,7 +98,12 @@ DROP ROLE "old-reader";
 
 For wildcard relation grants, pgroles expands the current objects of the requested
 type safely, so table grants do not accidentally touch views or materialized
-views.
+views. A wildcard grant remains a strict desired-state declaration: every
+matching current object must either already have the requested privilege or be
+grantable by the database user running pgroles. If some matching objects are
+owned by another role and are missing the required grant option, `diff`, `plan`,
+and `apply` fail with an `UnsatisfiableWildcardGrant` diagnostic instead of
+printing or applying repeated wildcard SQL.
 
 Then `pgroles apply` to execute it.
 

--- a/correctness/races/Convergence.cfg
+++ b/correctness/races/Convergence.cfg
@@ -3,11 +3,13 @@ SPECIFICATION Spec
 CONSTANTS
     Inventory = {f1, f2, f3}
     UseFixedDiff = TRUE
+    UseDiagnostics = TRUE
     MaxDrops = 2
 
 INVARIANT
     TypeOK
 
 PROPERTY
-    EventuallyConverged
+    EventuallySettled
     NoStrictlyWorseReconcile
+    DiagnosticDoesNotMutateGrants

--- a/correctness/races/Convergence.tla
+++ b/correctness/races/Convergence.tla
@@ -18,6 +18,8 @@ EXTENDS FiniteSets, Naturals
     1. Manifest has a single wildcard grant: every object in `Inventory`
        must have the privilege for the role. (One role, one schema,
        one object type, one privilege — the smallest faithful slice.)
+       Each object also has per-object grantability from the executor's
+       point of view, modelling ownership / WITH GRANT OPTION.
     2. The operator inspects, computes a diff against the wildcard,
        and applies. Apply runs every GRANT before any REVOKE — matches
        diff() in pgroles-core/src/diff.rs.
@@ -25,7 +27,8 @@ EXTENDS FiniteSets, Naturals
        CREATEs an object, resetting its proacl to NULL. The inspector's
        per-name aclexplode then misses that object, and the
        wildcard-collapse in normalize_wildcard_grants fails for the
-       (role, schema, type) scope.
+       (role, schema, type) scope. The recreated object may be owned by
+       the executor (grantable) or by another role (not grantable).
     4. The operator reconciles again.
 
   Two diff semantics are modelled:
@@ -45,13 +48,21 @@ EXTENDS FiniteSets, Naturals
       emits the wildcard GRANT only; the next reconcile's collapse
       succeeds and the diff is empty.
 
+    - UseDiagnostics = TRUE — the v0.7.2 behaviour (PR #106). Before
+      planning/applying, inspection detects any object that is both
+      missing the wildcard privilege and not grantable by the executor.
+      Reconcile reports an UnsatisfiableWildcardGrant diagnostic and
+      does not mutate grants or create another plan.
+
   Property to verify:
 
-    EventuallyConverged ==
-        <>[](currentGrants = Inventory)
+    EventuallySettled ==
+        <>[](currentGrants = Inventory \/ diagnosed)
 
-  Holds under UseFixedDiff = TRUE; fails under UseFixedDiff = FALSE
-  with a TLC trace that exhibits the flap.
+  With all objects grantable, "settled" means converged. With a
+  non-grantable object missing the wildcard privilege, "settled" means
+  diagnosed and stable instead of repeatedly planning impossible SQL.
+  Under UseFixedDiff = FALSE, TLC still finds the v0.7.0 flap.
 
   Caveats / what is NOT modelled:
     - Multiple roles / schemas / object types — the bug is a per-scope
@@ -59,6 +70,9 @@ EXTENDS FiniteSets, Naturals
     - Privilege subsets — the bug surfaces with exactly one privilege
       (EXECUTE for functions). A multi-privilege model would add no
       new behaviour.
+    - PostgreSQL's detailed grantor chains — per-object grantability is
+      reduced to "executor can grant this object" vs "cannot grant this
+      object", which is the distinction used by diagnostics.
     - The plan lifecycle around the apply (Pending/Approved/Applying
       etc.) — covered by PlanLifecycle.tla. We collapse a reconcile
       into a single atomic state transition.
@@ -67,11 +81,13 @@ EXTENDS FiniteSets, Naturals
 CONSTANTS
     Inventory,        \* Set of object names in the managed schema, e.g. {f1,f2,f3}
     UseFixedDiff,     \* TRUE for v0.7.1 semantics, FALSE for v0.7.0 (buggy)
+    UseDiagnostics,   \* TRUE for v0.7.2 unsatisfiable-wildcard diagnostics
     MaxDrops          \* Bound the number of external drop+creates for model checking
 
 ASSUME
     /\ Inventory /= {}
     /\ UseFixedDiff \in BOOLEAN
+    /\ UseDiagnostics \in BOOLEAN
     /\ MaxDrops \in Nat
 
 VARIABLES
@@ -81,60 +97,99 @@ VARIABLES
     \* collapse succeeds and the system is converged.
     currentGrants,
 
+    \* Set of objects for which the executor can currently grant the
+    \* wildcard privilege. This abstracts ownership / WITH GRANT OPTION.
+    grantable,
+
     \* How many external drop+creates remain. Each one removes one object
     \* from currentGrants. Bounded so TLC explores a finite state space.
-    dropsRemaining
+    dropsRemaining,
 
-vars == <<currentGrants, dropsRemaining>>
+    \* Whether reconcile has surfaced UnsatisfiableWildcardGrant. A new
+    \* external mutation clears it because the environment changed.
+    diagnosed
+
+vars == <<currentGrants, grantable, dropsRemaining, diagnosed>>
 
 TypeOK ==
     /\ currentGrants \subseteq Inventory
+    /\ grantable \subseteq Inventory
     /\ dropsRemaining \in 0..MaxDrops
+    /\ diagnosed \in BOOLEAN
 
 Init ==
     \* Start in the steady state: every object has the per-role ACL,
-    \* the inspector's collapse holds, the diff is empty.
+    \* the inspector's collapse holds, and the diff is empty. Ownership
+    \* starts grantable, but external drop+create can change it per object.
     /\ currentGrants = Inventory
+    /\ grantable = Inventory
     /\ dropsRemaining = MaxDrops
+    /\ diagnosed = FALSE
+
+MissingNonGrantable ==
+    (Inventory \ currentGrants) \ grantable
 
 \* An external service (e.g. cdc-relay) DROPs and CREATEs an object.
 \* Its proacl resets to NULL, so the inspector no longer produces a row
-\* for it under managed_roles, and the wildcard collapse fails.
+\* for it under managed_roles, and the wildcard collapse fails. The
+\* recreated object may be grantable by the executor or owned by another
+\* role; all other object ownership is unchanged.
 ExternalDropCreate ==
     /\ dropsRemaining > 0
     /\ \E n \in currentGrants:
-        currentGrants' = currentGrants \ {n}
+        /\ currentGrants' = currentGrants \ {n}
+        /\ grantable' \in { grantable \ {n}, grantable \cup {n} }
     /\ dropsRemaining' = dropsRemaining - 1
+    /\ diagnosed' = FALSE
 
 \* No-op reconcile: already converged.
 ReconcileNoop ==
     /\ currentGrants = Inventory
-    /\ UNCHANGED vars
+    /\ diagnosed' = FALSE
+    /\ UNCHANGED <<currentGrants, grantable, dropsRemaining>>
+
+\* v0.7.2 diagnostic reconcile. If a wildcard target is missing the
+\* privilege and is not grantable by the executor, strict desired-state
+\* semantics stop before planning/applying repeated SQL.
+ReconcileDiagnostic ==
+    /\ UseDiagnostics
+    /\ currentGrants /= Inventory
+    /\ MissingNonGrantable /= {}
+    /\ diagnosed' = TRUE
+    /\ UNCHANGED <<currentGrants, grantable, dropsRemaining>>
 
 \* v0.7.0 (buggy) reconcile. When collapse fails, diff emits:
 \*   - GRANT wildcard                   (covers all of Inventory)
 \*   - REVOKE per-name FOR EACH n in currentGrants
 \* Apply order is GRANTs then REVOKEs, so:
-\*   after wildcard GRANT:    set = Inventory
-\*   after per-name REVOKEs:  set = Inventory \ currentGrants_before
+\*   after wildcard GRANT:    grantable objects have ACLs
+\*   after per-name REVOKEs:  previous currentGrants are stripped
 \* The set of "objects with an ACL" INVERTS each reconcile.
 ReconcileBuggy ==
     /\ ~UseFixedDiff
     /\ currentGrants /= Inventory
-    /\ currentGrants' = Inventory \ currentGrants
+    /\ ~(UseDiagnostics /\ MissingNonGrantable /= {})
+    /\ currentGrants' = (currentGrants \cup grantable) \ currentGrants
+    /\ diagnosed' = FALSE
     /\ UNCHANGED dropsRemaining
+    /\ UNCHANGED grantable
 
 \* v0.7.1 reconcile. Per-name REVOKEs are filtered when their privileges
 \* are shadowed by a desired wildcard for the same scope, so the diff
-\* emits only the wildcard GRANT and apply converges in one step.
+\* emits only the wildcard GRANT. It converges in one step when every
+\* missing object is grantable; otherwise v0.7.2 diagnostics preempt it.
 ReconcileFixed ==
     /\ UseFixedDiff
     /\ currentGrants /= Inventory
-    /\ currentGrants' = Inventory
+    /\ ~(UseDiagnostics /\ MissingNonGrantable /= {})
+    /\ currentGrants' = currentGrants \cup grantable
+    /\ diagnosed' = FALSE
     /\ UNCHANGED dropsRemaining
+    /\ UNCHANGED grantable
 
 Reconcile ==
     \/ ReconcileNoop
+    \/ ReconcileDiagnostic
     \/ ReconcileBuggy
     \/ ReconcileFixed
 
@@ -153,18 +208,29 @@ Spec ==
 
 \* --- Properties ---
 
-\* Eventually-permanently converged. Under fairness on Reconcile and a
-\* finite number of external drops, the database eventually matches the
-\* manifest and stays there. Holds under UseFixedDiff = TRUE; fails
-\* under UseFixedDiff = FALSE with a counterexample showing the flap.
+\* Eventually-permanently settled. Under fairness on Reconcile and a
+\* finite number of external drops, the database either matches the
+\* manifest or has surfaced a stable UnsatisfiableWildcardGrant
+\* diagnostic. With all missing objects grantable, this reduces to
+\* convergence; with a missing non-grantable object, strict semantics
+\* settle by diagnosing instead of churning.
+EventuallySettled ==
+    <>[]((currentGrants = Inventory) \/ diagnosed)
+
+\* Eventually-permanently converged. This remains useful in configs where
+\* all objects stay grantable, but is intentionally stronger than the
+\* v0.7.2 ownership-aware contract.
 EventuallyConverged ==
     <>[](currentGrants = Inventory)
 
 \* Bounded-step convergence: under the fixed semantics, the gap between
-\* desired and current shrinks monotonically across reconciles (a single
-\* reconcile closes it). Useful as a sanity check on the action shape.
+\* desired and current never grows across fixed/diagnostic reconciles.
+\* Useful as a sanity check on the action shape.
 NoStrictlyWorseReconcile ==
-    [][(currentGrants /= Inventory /\ Reconcile) =>
+    [][(currentGrants /= Inventory /\ (ReconcileFixed \/ ReconcileDiagnostic)) =>
         Cardinality(Inventory \ currentGrants') <= Cardinality(Inventory \ currentGrants)]_vars
+
+DiagnosticDoesNotMutateGrants ==
+    [][ReconcileDiagnostic => currentGrants' = currentGrants]_vars
 
 ====

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -419,7 +419,7 @@ async fn cmd_diff(
         let validated = validate_bundle_file(bundle_path)?;
         let pool = connect_db(database_url).await?;
         let inspect_config = inspect_config_for_bundle(&validated);
-        let current = inspect_current_with_config(&pool, &inspect_config).await?;
+        let current = inspect_current_for_plan_with_config(&pool, &inspect_config).await?;
         let resolved_passwords = resolve_passwords(&validated.composed.expanded)
             .context("failed to resolve role passwords")?;
         info!(%mode, "reconciliation mode");
@@ -480,7 +480,7 @@ async fn cmd_diff(
     let validated = validate_manifest(&yaml)?;
 
     let pool = connect_db(database_url).await?;
-    let current = inspect_current(&pool, &validated).await?;
+    let current = inspect_current_for_plan(&pool, &validated).await?;
 
     let resolved_passwords =
         resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
@@ -550,7 +550,7 @@ async fn cmd_apply(
             .context("failed to detect privilege level")?;
         info!(level = %privilege_level, "detected privilege level");
 
-        let current = inspect_current_with_config(&pool, &inspect_config).await?;
+        let current = inspect_current_for_plan_with_config(&pool, &inspect_config).await?;
 
         let resolved_passwords = resolve_passwords(&validated.composed.expanded)
             .context("failed to resolve role passwords")?;
@@ -636,7 +636,7 @@ async fn cmd_apply(
         .context("failed to detect privilege level")?;
     info!(level = %privilege_level, "detected privilege level");
 
-    let current = inspect_current(&pool, &validated).await?;
+    let current = inspect_current_for_plan(&pool, &validated).await?;
 
     let resolved_passwords =
         resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
@@ -1199,6 +1199,28 @@ async fn inspect_current(
     inspect_current_with_config(pool, &config).await
 }
 
+async fn inspect_current_for_plan(
+    pool: &PgPool,
+    validated: &pgroles_cli::ValidatedManifest,
+) -> Result<pgroles_core::model::RoleGraph> {
+    let has_database_grants = validated
+        .expanded
+        .grants
+        .iter()
+        .any(|g| g.object.object_type == pgroles_core::manifest::ObjectType::Database);
+
+    let config = InspectConfig::from_expanded(&validated.expanded, has_database_grants)
+        .with_additional_roles(
+            validated
+                .manifest
+                .retirements
+                .iter()
+                .map(|retirement| retirement.role.clone()),
+        );
+
+    inspect_current_for_plan_with_config(pool, &config).await
+}
+
 fn inspect_config_for_bundle(validated: &pgroles_cli::ValidatedBundle) -> InspectConfig {
     InspectConfig::from_managed_scope(
         &validated.composed.managed_scope,
@@ -1232,6 +1254,26 @@ async fn inspect_current_with_config(
     pgroles_inspect::inspect(pool, config)
         .await
         .context("failed to inspect database state")
+}
+
+async fn inspect_current_for_plan_with_config(
+    pool: &PgPool,
+    config: &InspectConfig,
+) -> Result<pgroles_core::model::RoleGraph> {
+    info!(
+        managed_roles = config.managed_roles.len(),
+        managed_schemas = config.managed_schemas.len(),
+        privilege_schemas = config.privilege_schemas.len(),
+        "inspecting current database state"
+    );
+
+    let inspection = pgroles_inspect::inspect_with_diagnostics(pool, config)
+        .await
+        .context("failed to inspect database state")?;
+    if !inspection.diagnostics.is_empty() {
+        anyhow::bail!("{}", inspection.diagnostics);
+    }
+    Ok(inspection.graph)
 }
 
 async fn inspect_drop_safety(

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -1180,44 +1180,31 @@ async fn inspect_current(
     pool: &PgPool,
     validated: &pgroles_cli::ValidatedManifest,
 ) -> Result<pgroles_core::model::RoleGraph> {
-    // Determine whether the manifest has database-level grants.
+    let config = inspect_config_for_manifest(validated);
+    inspect_current_with_config(pool, &config).await
+}
+
+fn inspect_config_for_manifest(validated: &pgroles_cli::ValidatedManifest) -> InspectConfig {
     let has_database_grants = validated
         .expanded
         .grants
         .iter()
         .any(|g| g.object.object_type == pgroles_core::manifest::ObjectType::Database);
 
-    let config = InspectConfig::from_expanded(&validated.expanded, has_database_grants)
-        .with_additional_roles(
-            validated
-                .manifest
-                .retirements
-                .iter()
-                .map(|retirement| retirement.role.clone()),
-        );
-
-    inspect_current_with_config(pool, &config).await
+    InspectConfig::from_expanded(&validated.expanded, has_database_grants).with_additional_roles(
+        validated
+            .manifest
+            .retirements
+            .iter()
+            .map(|retirement| retirement.role.clone()),
+    )
 }
 
 async fn inspect_current_for_plan(
     pool: &PgPool,
     validated: &pgroles_cli::ValidatedManifest,
 ) -> Result<pgroles_core::model::RoleGraph> {
-    let has_database_grants = validated
-        .expanded
-        .grants
-        .iter()
-        .any(|g| g.object.object_type == pgroles_core::manifest::ObjectType::Database);
-
-    let config = InspectConfig::from_expanded(&validated.expanded, has_database_grants)
-        .with_additional_roles(
-            validated
-                .manifest
-                .retirements
-                .iter()
-                .map(|retirement| retirement.role.clone()),
-        );
-
+    let config = inspect_config_for_manifest(validated);
     inspect_current_for_plan_with_config(pool, &config).await
 }
 

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -3089,6 +3089,96 @@ grants:
 
     #[test]
     #[ignore]
+    fn wildcard_function_grant_fails_before_partial_apply_when_object_not_grantable() {
+        let schema = unique_name("wildfn_mixed_owner_schema");
+        let executor = unique_name("wildfn_executor");
+        let definer = unique_name("wildfn_definer");
+        let role = unique_name("wildfn_editor");
+        let password = "pgroles-test-password";
+        let executor_url = database_url_for_role(&executor, password);
+
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{role}";
+            DROP ROLE IF EXISTS "{definer}";
+            DROP ROLE IF EXISTS "{executor}";
+            "#
+        ));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{role}";
+            DROP ROLE IF EXISTS "{definer}";
+            DROP ROLE IF EXISTS "{executor}";
+            CREATE ROLE "{executor}" LOGIN PASSWORD '{password}';
+            CREATE ROLE "{definer}" NOLOGIN;
+            CREATE ROLE "{role}" NOLOGIN;
+            CREATE SCHEMA "{schema}" AUTHORIZATION "{executor}";
+            CREATE FUNCTION "{schema}".f1() RETURNS int LANGUAGE sql AS 'SELECT 1';
+            ALTER FUNCTION "{schema}".f1() OWNER TO "{executor}";
+            CREATE FUNCTION "{schema}".f2() RETURNS int LANGUAGE sql AS 'SELECT 2';
+            ALTER FUNCTION "{schema}".f2() OWNER TO "{definer}";
+            REVOKE EXECUTE ON FUNCTION "{schema}".f1() FROM PUBLIC;
+            REVOKE EXECUTE ON FUNCTION "{schema}".f2() FROM PUBLIC;
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+roles:
+  - name: {role}
+
+grants:
+  - role: {role}
+    privileges: [EXECUTE]
+    object: {{ type: function, schema: {schema}, name: "*" }}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &executor_url,
+                "--format",
+                "sql",
+            ])
+            .assert()
+            .failure()
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains("UnsatisfiableWildcardGrant"))
+            .stderr(predicate::str::contains("f2()"))
+            .stderr(predicate::str::contains(&definer))
+            .stderr(predicate::str::contains("GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA").not());
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &executor_url,
+            ])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("UnsatisfiableWildcardGrant"));
+
+        assert!(
+            !query_has_function_privilege(&role, &format!(r#""{schema}"."f1"()"#)),
+            "apply should fail before partially granting the grantable function"
+        );
+        assert!(
+            !query_has_function_privilege(&role, &format!(r#""{schema}"."f2"()"#)),
+            "non-grantable function should remain ungranted"
+        );
+    }
+
+    #[test]
+    #[ignore]
     fn specific_function_grants_apply_and_converge() {
         let schema = unique_name("function_schema");
         let role = unique_name("function_role");

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -19,7 +19,7 @@ use sqlx::PgPool;
 use thiserror::Error;
 use tracing::debug;
 
-use pgroles_core::manifest::Privilege;
+use pgroles_core::manifest::{ObjectType, Privilege};
 use pgroles_core::model::RoleGraph;
 use pgroles_core::ownership::ManagedScope;
 
@@ -45,6 +45,97 @@ pub use version::{PgVersion, detect_pg_version};
 pub enum InspectError {
     #[error("database query error: {0}")]
     Database(#[from] sqlx::Error),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InspectionDiagnostics {
+    pub unsatisfiable_wildcard_grants: Vec<UnsatisfiableWildcardGrant>,
+}
+
+impl InspectionDiagnostics {
+    pub fn is_empty(&self) -> bool {
+        self.unsatisfiable_wildcard_grants.is_empty()
+    }
+}
+
+impl std::fmt::Display for InspectionDiagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, diagnostic) in self.unsatisfiable_wildcard_grants.iter().enumerate() {
+            if index > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{diagnostic}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsatisfiableWildcardGrant {
+    pub role: String,
+    pub object_type: ObjectType,
+    pub schema: String,
+    pub privileges: std::collections::BTreeSet<Privilege>,
+    pub executor: String,
+    pub skipped_count: usize,
+    pub examples: Vec<UnsatisfiableWildcardObject>,
+}
+
+impl std::fmt::Display for UnsatisfiableWildcardGrant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let privileges = self
+            .privileges
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let examples = self
+            .examples
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        write!(
+            f,
+            "UnsatisfiableWildcardGrant: cannot fully satisfy wildcard grant \
+             {privileges} ON {} * IN SCHEMA \"{}\" TO \"{}\" as executor \"{}\"; \
+             {} matching object(s) are missing the desired privilege and are not grantable",
+            self.object_type, self.schema, self.role, self.executor, self.skipped_count
+        )?;
+        if !examples.is_empty() {
+            write!(f, " (examples: {examples})")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsatisfiableWildcardObject {
+    pub name: String,
+    pub owner: String,
+    pub privileges: std::collections::BTreeSet<Privilege>,
+}
+
+impl std::fmt::Display for UnsatisfiableWildcardObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let privileges = self
+            .privileges
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(
+            f,
+            "\"{}\" owned by \"{}\" missing [{}]",
+            self.name, self.owner, privileges
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InspectionResult {
+    pub graph: RoleGraph,
+    pub diagnostics: InspectionDiagnostics,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -283,7 +374,8 @@ pub async fn inspect_all(
             &role_refs,
             &[], // no wildcard patterns
         )
-        .await?;
+        .await?
+        .grants;
         for (key, state) in privilege_grants {
             graph.grants.insert(key, state);
         }
@@ -312,7 +404,17 @@ pub async fn inspect_all(
 /// Queries roles, memberships, object privileges, and default privileges,
 /// scoped to the managed set defined by `config`.
 pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph, InspectError> {
+    Ok(inspect_with_diagnostics(pool, config).await?.graph)
+}
+
+/// Inspect the current database state and return diagnostics for desired-state
+/// intent that cannot be satisfied by the current executor.
+pub async fn inspect_with_diagnostics(
+    pool: &PgPool,
+    config: &InspectConfig,
+) -> Result<InspectionResult, InspectError> {
     let mut graph = RoleGraph::default();
+    let mut diagnostics = InspectionDiagnostics::default();
 
     // Build &str slices for the query functions
     let role_refs: Vec<&str> = config.managed_roles.iter().map(|s| s.as_str()).collect();
@@ -368,13 +470,17 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
             schemas = ?privilege_schema_refs,
             "inspecting object privileges via aclexplode"
         );
-        let privilege_grants = privileges::fetch_privileges_with_wildcards(
+        let privilege_result = privileges::fetch_privileges_with_wildcards(
             pool,
             &privilege_schema_refs,
             &role_refs,
             &config.wildcard_grants,
         )
         .await?;
+        diagnostics
+            .unsatisfiable_wildcard_grants
+            .extend(privilege_result.diagnostics);
+        let privilege_grants = privilege_result.grants;
         for (key, state) in privilege_grants {
             graph.grants.insert(key, state);
         }
@@ -409,7 +515,7 @@ pub async fn inspect(pool: &PgPool, config: &InspectConfig) -> Result<RoleGraph,
         );
     }
 
-    Ok(graph)
+    Ok(InspectionResult { graph, diagnostics })
 }
 
 /// Fetch the names of all non-system schemas in the target database.

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use sqlx::PgPool;
 
-use crate::WildcardGrantPattern;
+use crate::{UnsatisfiableWildcardGrant, UnsatisfiableWildcardObject, WildcardGrantPattern};
 use pgroles_core::manifest::{ObjectType, Privilege};
 use pgroles_core::model::{GrantKey, GrantState};
 
@@ -35,6 +35,28 @@ struct AclRow {
     object_name: String,
     /// The object type discriminator we embed in the query.
     obj_type: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct GrantabilityRow {
+    schema_name: String,
+    object_name: String,
+    owner_name: String,
+    obj_type: String,
+    can_select: bool,
+    can_insert: bool,
+    can_update: bool,
+    can_delete: bool,
+    can_truncate: bool,
+    can_references: bool,
+    can_trigger: bool,
+    can_execute: bool,
+    can_usage: bool,
+}
+
+pub(crate) struct PrivilegeInspectionResult {
+    pub grants: BTreeMap<GrantKey, GrantState>,
+    pub diagnostics: Vec<UnsatisfiableWildcardGrant>,
 }
 
 /// Map a PostgreSQL ACL privilege character to our `Privilege` enum.
@@ -83,7 +105,11 @@ pub async fn fetch_privileges(
     managed_schemas: &[&str],
     managed_roles: &[&str],
 ) -> Result<BTreeMap<GrantKey, GrantState>, sqlx::Error> {
-    fetch_privileges_with_wildcards(pool, managed_schemas, managed_roles, &[]).await
+    Ok(
+        fetch_privileges_with_wildcards(pool, managed_schemas, managed_roles, &[])
+            .await?
+            .grants,
+    )
 }
 
 /// Fetch schema-scoped object names grouped by object type.
@@ -195,7 +221,7 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     managed_schemas: &[&str],
     managed_roles: &[&str],
     wildcard_grants: &[WildcardGrantPattern],
-) -> Result<BTreeMap<GrantKey, GrantState>, sqlx::Error> {
+) -> Result<PrivilegeInspectionResult, sqlx::Error> {
     let mut grants: BTreeMap<GrantKey, GrantState> = BTreeMap::new();
     let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
 
@@ -281,11 +307,219 @@ pub(crate) async fn fetch_privileges_with_wildcards(
         entry.privileges.insert(privilege);
     }
 
-    Ok(normalize_wildcard_grants(
+    let diagnostics = if wildcard_grants.is_empty() {
+        Vec::new()
+    } else {
+        let executor = fetch_current_user(pool).await?;
+        let grantability = fetch_wildcard_grantability(pool, managed_schemas).await?;
+        detect_unsatisfiable_wildcards(&grants, &grantability, wildcard_grants, &executor)
+    };
+
+    let grants = normalize_wildcard_grants(grants, &inventory, wildcard_grants);
+    Ok(PrivilegeInspectionResult {
         grants,
-        &inventory,
-        wildcard_grants,
-    ))
+        diagnostics,
+    })
+}
+
+async fn fetch_current_user(pool: &PgPool) -> Result<String, sqlx::Error> {
+    let (user,) = sqlx::query_as::<_, (String,)>("SELECT current_user::text")
+        .fetch_one(pool)
+        .await?;
+    Ok(user)
+}
+
+async fn fetch_wildcard_grantability(
+    pool: &PgPool,
+    managed_schemas: &[&str],
+) -> Result<BTreeMap<(ObjectType, String, String), GrantabilityRow>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, GrantabilityRow>(
+        r#"
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS object_name,
+            pg_get_userbyid(c.relowner) AS owner_name,
+            CASE c.relkind
+                WHEN 'r' THEN 'table'
+                WHEN 'p' THEN 'table'
+                WHEN 'v' THEN 'view'
+                WHEN 'm' THEN 'materialized_view'
+            END AS obj_type,
+            has_table_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION') AS can_select,
+            has_table_privilege(current_user, c.oid, 'INSERT WITH GRANT OPTION') AS can_insert,
+            has_table_privilege(current_user, c.oid, 'UPDATE WITH GRANT OPTION') AS can_update,
+            has_table_privilege(current_user, c.oid, 'DELETE WITH GRANT OPTION') AS can_delete,
+            has_table_privilege(current_user, c.oid, 'TRUNCATE WITH GRANT OPTION') AS can_truncate,
+            has_table_privilege(current_user, c.oid, 'REFERENCES WITH GRANT OPTION') AS can_references,
+            has_table_privilege(current_user, c.oid, 'TRIGGER WITH GRANT OPTION') AS can_trigger,
+            false AS can_execute,
+            false AS can_usage
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ANY($1)
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+
+        UNION ALL
+
+        SELECT
+            n.nspname AS schema_name,
+            c.relname AS object_name,
+            pg_get_userbyid(c.relowner) AS owner_name,
+            'sequence' AS obj_type,
+            has_sequence_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION') AS can_select,
+            false AS can_insert,
+            has_sequence_privilege(current_user, c.oid, 'UPDATE WITH GRANT OPTION') AS can_update,
+            false AS can_delete,
+            false AS can_truncate,
+            false AS can_references,
+            false AS can_trigger,
+            false AS can_execute,
+            has_sequence_privilege(current_user, c.oid, 'USAGE WITH GRANT OPTION') AS can_usage
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ANY($1)
+          AND c.relkind = 'S'
+
+        UNION ALL
+
+        SELECT
+            n.nspname AS schema_name,
+            p.proname || '(' || pg_catalog.pg_get_function_identity_arguments(p.oid) || ')' AS object_name,
+            pg_get_userbyid(p.proowner) AS owner_name,
+            'function' AS obj_type,
+            false AS can_select,
+            false AS can_insert,
+            false AS can_update,
+            false AS can_delete,
+            false AS can_truncate,
+            false AS can_references,
+            false AS can_trigger,
+            has_function_privilege(current_user, p.oid, 'EXECUTE WITH GRANT OPTION') AS can_execute,
+            false AS can_usage
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = ANY($1)
+
+        UNION ALL
+
+        SELECT
+            n.nspname AS schema_name,
+            t.typname AS object_name,
+            pg_get_userbyid(t.typowner) AS owner_name,
+            'type' AS obj_type,
+            false AS can_select,
+            false AS can_insert,
+            false AS can_update,
+            false AS can_delete,
+            false AS can_truncate,
+            false AS can_references,
+            false AS can_trigger,
+            false AS can_execute,
+            has_type_privilege(current_user, t.oid, 'USAGE WITH GRANT OPTION') AS can_usage
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = ANY($1)
+          AND t.typname NOT LIKE '\_%'
+          AND t.typtype <> 'p'
+
+        ORDER BY schema_name, obj_type, object_name
+        "#,
+    )
+    .bind(managed_schemas)
+    .fetch_all(pool)
+    .await?;
+
+    let mut grantability = BTreeMap::new();
+    for row in rows {
+        let Some(object_type) = obj_type_str_to_object_type(&row.obj_type) else {
+            continue;
+        };
+        grantability.insert(
+            (
+                object_type,
+                row.schema_name.clone(),
+                row.object_name.clone(),
+            ),
+            row,
+        );
+    }
+    Ok(grantability)
+}
+
+fn detect_unsatisfiable_wildcards(
+    grants: &BTreeMap<GrantKey, GrantState>,
+    grantability: &BTreeMap<(ObjectType, String, String), GrantabilityRow>,
+    wildcard_grants: &[WildcardGrantPattern],
+    executor: &str,
+) -> Vec<UnsatisfiableWildcardGrant> {
+    let mut diagnostics = Vec::new();
+
+    for wildcard in wildcard_grants {
+        let mut skipped_objects = Vec::new();
+        let mut skipped_privileges = BTreeSet::new();
+
+        for ((object_type, schema_name, object_name), row) in grantability {
+            if *object_type != wildcard.object_type || schema_name != &wildcard.schema {
+                continue;
+            }
+
+            let key = GrantKey {
+                role: wildcard.role.clone(),
+                object_type: wildcard.object_type,
+                schema: Some(wildcard.schema.clone()),
+                name: Some(object_name.clone()),
+            };
+            let existing = grants.get(&key);
+            let mut missing_non_grantable = BTreeSet::new();
+            for privilege in &wildcard.privileges {
+                if existing.is_some_and(|state| state.privileges.contains(privilege)) {
+                    continue;
+                }
+                if can_grant(row, *privilege) {
+                    continue;
+                }
+                missing_non_grantable.insert(*privilege);
+                skipped_privileges.insert(*privilege);
+            }
+
+            if !missing_non_grantable.is_empty() {
+                skipped_objects.push(UnsatisfiableWildcardObject {
+                    name: object_name.clone(),
+                    owner: row.owner_name.clone(),
+                    privileges: missing_non_grantable,
+                });
+            }
+        }
+
+        if !skipped_objects.is_empty() {
+            diagnostics.push(UnsatisfiableWildcardGrant {
+                role: wildcard.role.clone(),
+                object_type: wildcard.object_type,
+                schema: wildcard.schema.clone(),
+                privileges: skipped_privileges,
+                executor: executor.to_string(),
+                skipped_count: skipped_objects.len(),
+                examples: skipped_objects.into_iter().take(5).collect(),
+            });
+        }
+    }
+
+    diagnostics
+}
+
+fn can_grant(row: &GrantabilityRow, privilege: Privilege) -> bool {
+    match privilege {
+        Privilege::Select => row.can_select,
+        Privilege::Insert => row.can_insert,
+        Privilege::Update => row.can_update,
+        Privilege::Delete => row.can_delete,
+        Privilege::Truncate => row.can_truncate,
+        Privilege::References => row.can_references,
+        Privilege::Trigger => row.can_trigger,
+        Privilege::Execute => row.can_execute,
+        Privilege::Usage => row.can_usage,
+        Privilege::Create | Privilege::Connect | Privilege::Temporary => false,
+    }
 }
 
 /// Insert a vacuously-satisfied wildcard into the grants map. Used when no
@@ -609,6 +843,33 @@ mod tests {
     use super::*;
     use crate::WildcardGrantPattern;
 
+    fn grantability_row(object_name: &str, owner_name: &str, can_execute: bool) -> GrantabilityRow {
+        GrantabilityRow {
+            schema_name: "app".to_string(),
+            object_name: object_name.to_string(),
+            owner_name: owner_name.to_string(),
+            obj_type: "function".to_string(),
+            can_select: false,
+            can_insert: false,
+            can_update: false,
+            can_delete: false,
+            can_truncate: false,
+            can_references: false,
+            can_trigger: false,
+            can_execute,
+            can_usage: false,
+        }
+    }
+
+    fn execute_wildcard() -> WildcardGrantPattern {
+        WildcardGrantPattern {
+            role: "app-editor".to_string(),
+            object_type: ObjectType::Function,
+            schema: "app".to_string(),
+            privileges: BTreeSet::from([Privilege::Execute]),
+        }
+    }
+
     #[test]
     fn acl_char_mapping_covers_all_privileges() {
         // Standard PostgreSQL ACL characters
@@ -656,6 +917,90 @@ mod tests {
             );
         }
         assert_eq!(obj_type_str_to_object_type("unknown"), None);
+    }
+
+    #[test]
+    fn diagnostics_report_missing_non_grantable_wildcard_object() {
+        let grants = BTreeMap::new();
+        let grantability = BTreeMap::from([
+            (
+                (ObjectType::Function, "app".to_string(), "f1()".to_string()),
+                grantability_row("f1()", "app_owner", true),
+            ),
+            (
+                (ObjectType::Function, "app".to_string(), "f2()".to_string()),
+                grantability_row("f2()", "definer", false),
+            ),
+        ]);
+
+        let diagnostics = detect_unsatisfiable_wildcards(
+            &grants,
+            &grantability,
+            &[execute_wildcard()],
+            "app_owner",
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.role, "app-editor");
+        assert_eq!(diagnostic.object_type, ObjectType::Function);
+        assert_eq!(diagnostic.schema, "app");
+        assert_eq!(diagnostic.executor, "app_owner");
+        assert_eq!(diagnostic.skipped_count, 1);
+        assert_eq!(diagnostic.privileges, BTreeSet::from([Privilege::Execute]));
+        assert_eq!(diagnostic.examples[0].name, "f2()");
+        assert_eq!(diagnostic.examples[0].owner, "definer");
+        let rendered = diagnostic.to_string();
+        assert!(rendered.contains("UnsatisfiableWildcardGrant"));
+        assert!(rendered.contains("app_owner"));
+        assert!(rendered.contains("f2()"));
+        assert!(rendered.contains("EXECUTE"));
+    }
+
+    #[test]
+    fn diagnostics_ignore_missing_grantable_wildcard_object() {
+        let grants = BTreeMap::new();
+        let grantability = BTreeMap::from([(
+            (ObjectType::Function, "app".to_string(), "f1()".to_string()),
+            grantability_row("f1()", "app_owner", true),
+        )]);
+
+        let diagnostics = detect_unsatisfiable_wildcards(
+            &grants,
+            &grantability,
+            &[execute_wildcard()],
+            "app_owner",
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn diagnostics_ignore_non_grantable_object_that_already_has_privilege() {
+        let grants = BTreeMap::from([(
+            GrantKey {
+                role: "app-editor".to_string(),
+                object_type: ObjectType::Function,
+                schema: Some("app".to_string()),
+                name: Some("f2()".to_string()),
+            },
+            GrantState {
+                privileges: BTreeSet::from([Privilege::Execute]),
+            },
+        )]);
+        let grantability = BTreeMap::from([(
+            (ObjectType::Function, "app".to_string(), "f2()".to_string()),
+            grantability_row("f2()", "definer", false),
+        )]);
+
+        let diagnostics = detect_unsatisfiable_wildcards(
+            &grants,
+            &grantability,
+            &[execute_wildcard()],
+            "app_owner",
+        );
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -59,6 +59,103 @@ pub(crate) struct PrivilegeInspectionResult {
     pub diagnostics: Vec<UnsatisfiableWildcardGrant>,
 }
 
+struct WildcardScopeFilter {
+    schema_names: Vec<String>,
+    object_types: Vec<String>,
+    need_select: Vec<bool>,
+    need_insert: Vec<bool>,
+    need_update: Vec<bool>,
+    need_delete: Vec<bool>,
+    need_truncate: Vec<bool>,
+    need_references: Vec<bool>,
+    need_trigger: Vec<bool>,
+    need_execute: Vec<bool>,
+    need_usage: Vec<bool>,
+}
+
+impl WildcardScopeFilter {
+    fn from_wildcards(wildcard_grants: &[WildcardGrantPattern]) -> Self {
+        let mut scopes: BTreeMap<(ObjectType, String), BTreeSet<Privilege>> = BTreeMap::new();
+
+        for wildcard in wildcard_grants {
+            if matches!(
+                wildcard.object_type,
+                ObjectType::Schema | ObjectType::Database
+            ) {
+                continue;
+            }
+
+            scopes
+                .entry((wildcard.object_type, wildcard.schema.clone()))
+                .or_default()
+                .extend(wildcard.privileges.iter().copied());
+        }
+
+        let mut filter = Self {
+            schema_names: Vec::with_capacity(scopes.len()),
+            object_types: Vec::with_capacity(scopes.len()),
+            need_select: Vec::with_capacity(scopes.len()),
+            need_insert: Vec::with_capacity(scopes.len()),
+            need_update: Vec::with_capacity(scopes.len()),
+            need_delete: Vec::with_capacity(scopes.len()),
+            need_truncate: Vec::with_capacity(scopes.len()),
+            need_references: Vec::with_capacity(scopes.len()),
+            need_trigger: Vec::with_capacity(scopes.len()),
+            need_execute: Vec::with_capacity(scopes.len()),
+            need_usage: Vec::with_capacity(scopes.len()),
+        };
+
+        for ((object_type, schema), privileges) in scopes {
+            filter.schema_names.push(schema);
+            filter
+                .object_types
+                .push(object_type_label(object_type).to_string());
+            filter
+                .need_select
+                .push(privileges.contains(&Privilege::Select));
+            filter
+                .need_insert
+                .push(privileges.contains(&Privilege::Insert));
+            filter
+                .need_update
+                .push(privileges.contains(&Privilege::Update));
+            filter
+                .need_delete
+                .push(privileges.contains(&Privilege::Delete));
+            filter
+                .need_truncate
+                .push(privileges.contains(&Privilege::Truncate));
+            filter
+                .need_references
+                .push(privileges.contains(&Privilege::References));
+            filter
+                .need_trigger
+                .push(privileges.contains(&Privilege::Trigger));
+            filter
+                .need_execute
+                .push(privileges.contains(&Privilege::Execute));
+            filter
+                .need_usage
+                .push(privileges.contains(&Privilege::Usage));
+        }
+
+        filter
+    }
+
+    fn is_empty(&self) -> bool {
+        self.schema_names.is_empty()
+    }
+
+    fn contains(&self, object_type: ObjectType, schema_name: &str) -> bool {
+        self.schema_names
+            .iter()
+            .zip(&self.object_types)
+            .any(|(schema, obj_type)| {
+                schema == schema_name && obj_type == object_type_label(object_type)
+            })
+    }
+}
+
 /// Map a PostgreSQL ACL privilege character to our `Privilege` enum.
 fn acl_char_to_privilege(character: &str) -> Option<Privilege> {
     match character {
@@ -90,6 +187,19 @@ fn obj_type_str_to_object_type(obj_type: &str) -> Option<ObjectType> {
         "database" => Some(ObjectType::Database),
         "type" => Some(ObjectType::Type),
         _ => None,
+    }
+}
+
+fn object_type_label(object_type: ObjectType) -> &'static str {
+    match object_type {
+        ObjectType::Table => "table",
+        ObjectType::View => "view",
+        ObjectType::MaterializedView => "materialized_view",
+        ObjectType::Sequence => "sequence",
+        ObjectType::Function => "function",
+        ObjectType::Schema => "schema",
+        ObjectType::Database => "database",
+        ObjectType::Type => "type",
     }
 }
 
@@ -198,6 +308,146 @@ pub async fn fetch_object_inventory(
     Ok(inventory)
 }
 
+async fn fetch_object_inventory_for_wildcards(
+    pool: &PgPool,
+    filter: &WildcardScopeFilter,
+) -> Result<BTreeMap<(ObjectType, String), Vec<String>>, sqlx::Error> {
+    if filter.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let rows = sqlx::query_as::<_, AclRow>(
+        r#"
+        WITH wildcard_scope(
+            schema_name,
+            obj_type,
+            need_select,
+            need_insert,
+            need_update,
+            need_delete,
+            need_truncate,
+            need_references,
+            need_trigger,
+            need_execute,
+            need_usage
+        ) AS (
+            SELECT *
+            FROM unnest(
+                $1::text[],
+                $2::text[],
+                $3::bool[],
+                $4::bool[],
+                $5::bool[],
+                $6::bool[],
+                $7::bool[],
+                $8::bool[],
+                $9::bool[],
+                $10::bool[],
+                $11::bool[]
+            )
+        )
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            c.relname AS object_name,
+            CASE c.relkind
+                WHEN 'r' THEN 'table'
+                WHEN 'p' THEN 'table'
+                WHEN 'v' THEN 'view'
+                WHEN 'm' THEN 'materialized_view'
+            END AS obj_type
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = CASE c.relkind
+                WHEN 'r' THEN 'table'
+                WHEN 'p' THEN 'table'
+                WHEN 'v' THEN 'view'
+                WHEN 'm' THEN 'materialized_view'
+             END
+        WHERE c.relkind IN ('r', 'p', 'v', 'm')
+
+        UNION ALL
+
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            c.relname AS object_name,
+            'sequence' AS obj_type
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = 'sequence'
+        WHERE c.relkind = 'S'
+
+        UNION ALL
+
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            p.proname || '(' || pg_catalog.pg_get_function_identity_arguments(p.oid) || ')' AS object_name,
+            'function' AS obj_type
+        FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = 'function'
+
+        UNION ALL
+
+        SELECT
+            NULL::text AS grantee,
+            '' AS privilege_type,
+            n.nspname AS schema_name,
+            t.typname AS object_name,
+            'type' AS obj_type
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = 'type'
+        WHERE t.typname NOT LIKE '\_%'
+          AND t.typtype <> 'p'
+
+        ORDER BY schema_name, obj_type, object_name
+        "#,
+    )
+    .bind(&filter.schema_names)
+    .bind(&filter.object_types)
+    .bind(&filter.need_select)
+    .bind(&filter.need_insert)
+    .bind(&filter.need_update)
+    .bind(&filter.need_delete)
+    .bind(&filter.need_truncate)
+    .bind(&filter.need_references)
+    .bind(&filter.need_trigger)
+    .bind(&filter.need_execute)
+    .bind(&filter.need_usage)
+    .fetch_all(pool)
+    .await?;
+
+    let mut inventory = BTreeMap::new();
+    for row in rows {
+        let Some(object_type) = obj_type_str_to_object_type(&row.obj_type) else {
+            continue;
+        };
+        inventory
+            .entry((
+                object_type,
+                row.schema_name
+                    .expect("relation inventory rows always include schema"),
+            ))
+            .or_insert_with(Vec::new)
+            .push(row.object_name);
+    }
+    Ok(inventory)
+}
+
 /// Fetch only relation names (tables, views, materialized views) for callers
 /// that specifically need relation inventory.
 pub async fn fetch_relation_inventory(
@@ -224,11 +474,12 @@ pub(crate) async fn fetch_privileges_with_wildcards(
 ) -> Result<PrivilegeInspectionResult, sqlx::Error> {
     let mut grants: BTreeMap<GrantKey, GrantState> = BTreeMap::new();
     let has_wildcards = !wildcard_grants.is_empty();
+    let wildcard_scope_filter = WildcardScopeFilter::from_wildcards(wildcard_grants);
     let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
 
     if has_wildcards {
         for ((object_type, schema_name), object_names) in
-            fetch_object_inventory(pool, managed_schemas).await?
+            fetch_object_inventory_for_wildcards(pool, &wildcard_scope_filter).await?
         {
             inventory.insert(
                 (object_type, schema_name),
@@ -258,6 +509,7 @@ pub(crate) async fn fetch_privileges_with_wildcards(
             && let Some(object_type) = obj_type_str_to_object_type(&row.obj_type)
             && !matches!(object_type, ObjectType::Schema | ObjectType::Database)
             && let Some(schema_name) = &row.schema_name
+            && wildcard_scope_filter.contains(object_type, schema_name)
         {
             inventory
                 .entry((object_type, schema_name.clone()))
@@ -311,12 +563,19 @@ pub(crate) async fn fetch_privileges_with_wildcards(
         entry.privileges.insert(privilege);
     }
 
-    let diagnostics = if has_wildcards {
-        let executor = fetch_current_user(pool).await?;
-        let grantability = fetch_wildcard_grantability(pool, managed_schemas).await?;
-        detect_unsatisfiable_wildcards(&grants, &grantability, wildcard_grants, &executor)
+    let unsatisfied_wildcards = if has_wildcards {
+        unsatisfied_wildcard_grants(&grants, &inventory, wildcard_grants)
     } else {
         Vec::new()
+    };
+
+    let diagnostics = if unsatisfied_wildcards.is_empty() {
+        Vec::new()
+    } else {
+        let executor = fetch_current_user(pool).await?;
+        let grantability_filter = WildcardScopeFilter::from_wildcards(&unsatisfied_wildcards);
+        let grantability = fetch_wildcard_grantability(pool, &grantability_filter).await?;
+        detect_unsatisfiable_wildcards(&grants, &grantability, &unsatisfied_wildcards, &executor)
     };
 
     let grants = if has_wildcards {
@@ -338,12 +597,91 @@ async fn fetch_current_user(pool: &PgPool) -> Result<String, sqlx::Error> {
     Ok(user)
 }
 
+fn unsatisfied_wildcard_grants(
+    grants: &BTreeMap<GrantKey, GrantState>,
+    inventory: &BTreeMap<(ObjectType, String), BTreeSet<String>>,
+    wildcard_grants: &[WildcardGrantPattern],
+) -> Vec<WildcardGrantPattern> {
+    let mut unsatisfied = Vec::new();
+
+    for wildcard in wildcard_grants {
+        let Some(object_names) = inventory.get(&(wildcard.object_type, wildcard.schema.clone()))
+        else {
+            continue;
+        };
+
+        if object_names.is_empty() {
+            continue;
+        }
+
+        let mut missing_privileges = BTreeSet::new();
+        for object_name in object_names {
+            let key = GrantKey {
+                role: wildcard.role.clone(),
+                object_type: wildcard.object_type,
+                schema: Some(wildcard.schema.clone()),
+                name: Some(object_name.clone()),
+            };
+
+            let existing = grants.get(&key);
+            for privilege in &wildcard.privileges {
+                if !existing.is_some_and(|state| state.privileges.contains(privilege)) {
+                    missing_privileges.insert(*privilege);
+                }
+            }
+        }
+
+        if !missing_privileges.is_empty() {
+            unsatisfied.push(WildcardGrantPattern {
+                role: wildcard.role.clone(),
+                object_type: wildcard.object_type,
+                schema: wildcard.schema.clone(),
+                privileges: missing_privileges,
+            });
+        }
+    }
+
+    unsatisfied
+}
+
 async fn fetch_wildcard_grantability(
     pool: &PgPool,
-    managed_schemas: &[&str],
+    filter: &WildcardScopeFilter,
 ) -> Result<BTreeMap<(ObjectType, String, String), GrantabilityRow>, sqlx::Error> {
+    if filter.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
     let rows = sqlx::query_as::<_, GrantabilityRow>(
         r#"
+        WITH wildcard_scope(
+            schema_name,
+            obj_type,
+            need_select,
+            need_insert,
+            need_update,
+            need_delete,
+            need_truncate,
+            need_references,
+            need_trigger,
+            need_execute,
+            need_usage
+        ) AS (
+            SELECT *
+            FROM unnest(
+                $1::text[],
+                $2::text[],
+                $3::bool[],
+                $4::bool[],
+                $5::bool[],
+                $6::bool[],
+                $7::bool[],
+                $8::bool[],
+                $9::bool[],
+                $10::bool[],
+                $11::bool[]
+            )
+        )
         SELECT
             n.nspname AS schema_name,
             c.relname AS object_name,
@@ -354,19 +692,43 @@ async fn fetch_wildcard_grantability(
                 WHEN 'v' THEN 'view'
                 WHEN 'm' THEN 'materialized_view'
             END AS obj_type,
-            has_table_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION') AS can_select,
-            has_table_privilege(current_user, c.oid, 'INSERT WITH GRANT OPTION') AS can_insert,
-            has_table_privilege(current_user, c.oid, 'UPDATE WITH GRANT OPTION') AS can_update,
-            has_table_privilege(current_user, c.oid, 'DELETE WITH GRANT OPTION') AS can_delete,
-            has_table_privilege(current_user, c.oid, 'TRUNCATE WITH GRANT OPTION') AS can_truncate,
-            has_table_privilege(current_user, c.oid, 'REFERENCES WITH GRANT OPTION') AS can_references,
-            has_table_privilege(current_user, c.oid, 'TRIGGER WITH GRANT OPTION') AS can_trigger,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_select
+                 WHEN scope.need_select THEN has_table_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION')
+                 ELSE false END AS can_select,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_insert
+                 WHEN scope.need_insert THEN has_table_privilege(current_user, c.oid, 'INSERT WITH GRANT OPTION')
+                 ELSE false END AS can_insert,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_update
+                 WHEN scope.need_update THEN has_table_privilege(current_user, c.oid, 'UPDATE WITH GRANT OPTION')
+                 ELSE false END AS can_update,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_delete
+                 WHEN scope.need_delete THEN has_table_privilege(current_user, c.oid, 'DELETE WITH GRANT OPTION')
+                 ELSE false END AS can_delete,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_truncate
+                 WHEN scope.need_truncate THEN has_table_privilege(current_user, c.oid, 'TRUNCATE WITH GRANT OPTION')
+                 ELSE false END AS can_truncate,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_references
+                 WHEN scope.need_references THEN has_table_privilege(current_user, c.oid, 'REFERENCES WITH GRANT OPTION')
+                 ELSE false END AS can_references,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_trigger
+                 WHEN scope.need_trigger THEN has_table_privilege(current_user, c.oid, 'TRIGGER WITH GRANT OPTION')
+                 ELSE false END AS can_trigger,
             false AS can_execute,
             false AS can_usage
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = ANY($1)
-          AND c.relkind IN ('r', 'p', 'v', 'm')
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = CASE c.relkind
+                WHEN 'r' THEN 'table'
+                WHEN 'p' THEN 'table'
+                WHEN 'v' THEN 'view'
+                WHEN 'm' THEN 'materialized_view'
+             END
+        CROSS JOIN LATERAL (
+            SELECT pg_has_role(current_user, c.relowner, 'USAGE') AS can_grant_as_owner
+        ) owner_grant
+        WHERE c.relkind IN ('r', 'p', 'v', 'm')
 
         UNION ALL
 
@@ -375,19 +737,30 @@ async fn fetch_wildcard_grantability(
             c.relname AS object_name,
             pg_get_userbyid(c.relowner) AS owner_name,
             'sequence' AS obj_type,
-            has_sequence_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION') AS can_select,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_select
+                 WHEN scope.need_select THEN has_sequence_privilege(current_user, c.oid, 'SELECT WITH GRANT OPTION')
+                 ELSE false END AS can_select,
             false AS can_insert,
-            has_sequence_privilege(current_user, c.oid, 'UPDATE WITH GRANT OPTION') AS can_update,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_update
+                 WHEN scope.need_update THEN has_sequence_privilege(current_user, c.oid, 'UPDATE WITH GRANT OPTION')
+                 ELSE false END AS can_update,
             false AS can_delete,
             false AS can_truncate,
             false AS can_references,
             false AS can_trigger,
             false AS can_execute,
-            has_sequence_privilege(current_user, c.oid, 'USAGE WITH GRANT OPTION') AS can_usage
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_usage
+                 WHEN scope.need_usage THEN has_sequence_privilege(current_user, c.oid, 'USAGE WITH GRANT OPTION')
+                 ELSE false END AS can_usage
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = ANY($1)
-          AND c.relkind = 'S'
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = 'sequence'
+        CROSS JOIN LATERAL (
+            SELECT pg_has_role(current_user, c.relowner, 'USAGE') AS can_grant_as_owner
+        ) owner_grant
+        WHERE c.relkind = 'S'
 
         UNION ALL
 
@@ -403,11 +776,18 @@ async fn fetch_wildcard_grantability(
             false AS can_truncate,
             false AS can_references,
             false AS can_trigger,
-            has_function_privilege(current_user, p.oid, 'EXECUTE WITH GRANT OPTION') AS can_execute,
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_execute
+                 WHEN scope.need_execute THEN has_function_privilege(current_user, p.oid, 'EXECUTE WITH GRANT OPTION')
+                 ELSE false END AS can_execute,
             false AS can_usage
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = ANY($1)
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = 'function'
+        CROSS JOIN LATERAL (
+            SELECT pg_has_role(current_user, p.proowner, 'USAGE') AS can_grant_as_owner
+        ) owner_grant
 
         UNION ALL
 
@@ -424,17 +804,34 @@ async fn fetch_wildcard_grantability(
             false AS can_references,
             false AS can_trigger,
             false AS can_execute,
-            has_type_privilege(current_user, t.oid, 'USAGE WITH GRANT OPTION') AS can_usage
+            CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_usage
+                 WHEN scope.need_usage THEN has_type_privilege(current_user, t.oid, 'USAGE WITH GRANT OPTION')
+                 ELSE false END AS can_usage
         FROM pg_type t
         JOIN pg_namespace n ON n.oid = t.typnamespace
-        WHERE n.nspname = ANY($1)
-          AND t.typname NOT LIKE '\_%'
+        JOIN wildcard_scope scope
+          ON scope.schema_name = n.nspname
+         AND scope.obj_type = 'type'
+        CROSS JOIN LATERAL (
+            SELECT pg_has_role(current_user, t.typowner, 'USAGE') AS can_grant_as_owner
+        ) owner_grant
+        WHERE t.typname NOT LIKE '\_%'
           AND t.typtype <> 'p'
 
         ORDER BY schema_name, obj_type, object_name
         "#,
     )
-    .bind(managed_schemas)
+    .bind(&filter.schema_names)
+    .bind(&filter.object_types)
+    .bind(&filter.need_select)
+    .bind(&filter.need_insert)
+    .bind(&filter.need_update)
+    .bind(&filter.need_delete)
+    .bind(&filter.need_truncate)
+    .bind(&filter.need_references)
+    .bind(&filter.need_trigger)
+    .bind(&filter.need_execute)
+    .bind(&filter.need_usage)
     .fetch_all(pool)
     .await?;
 
@@ -1011,6 +1408,99 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unsatisfied_wildcards_are_empty_when_every_object_has_requested_privileges() {
+        let grants = BTreeMap::from([
+            (
+                GrantKey {
+                    role: "app-editor".to_string(),
+                    object_type: ObjectType::Function,
+                    schema: Some("app".to_string()),
+                    name: Some("f1()".to_string()),
+                },
+                GrantState {
+                    privileges: BTreeSet::from([Privilege::Execute]),
+                },
+            ),
+            (
+                GrantKey {
+                    role: "app-editor".to_string(),
+                    object_type: ObjectType::Function,
+                    schema: Some("app".to_string()),
+                    name: Some("f2()".to_string()),
+                },
+                GrantState {
+                    privileges: BTreeSet::from([Privilege::Execute]),
+                },
+            ),
+        ]);
+        let inventory = BTreeMap::from([(
+            (ObjectType::Function, "app".to_string()),
+            BTreeSet::from(["f1()".to_string(), "f2()".to_string()]),
+        )]);
+
+        let unsatisfied = unsatisfied_wildcard_grants(&grants, &inventory, &[execute_wildcard()]);
+
+        assert!(unsatisfied.is_empty());
+    }
+
+    #[test]
+    fn unsatisfied_wildcards_keep_only_missing_privileges() {
+        let wildcard = WildcardGrantPattern {
+            role: "app-editor".to_string(),
+            object_type: ObjectType::Table,
+            schema: "app".to_string(),
+            privileges: BTreeSet::from([Privilege::Select, Privilege::Insert]),
+        };
+        let grants = BTreeMap::from([(
+            GrantKey {
+                role: "app-editor".to_string(),
+                object_type: ObjectType::Table,
+                schema: Some("app".to_string()),
+                name: Some("widgets".to_string()),
+            },
+            GrantState {
+                privileges: BTreeSet::from([Privilege::Select]),
+            },
+        )]);
+        let inventory = BTreeMap::from([(
+            (ObjectType::Table, "app".to_string()),
+            BTreeSet::from(["widgets".to_string()]),
+        )]);
+
+        let unsatisfied = unsatisfied_wildcard_grants(&grants, &inventory, &[wildcard]);
+
+        assert_eq!(unsatisfied.len(), 1);
+        assert_eq!(
+            unsatisfied[0].privileges,
+            BTreeSet::from([Privilege::Insert])
+        );
+    }
+
+    #[test]
+    fn wildcard_scope_filter_deduplicates_scopes_and_unions_privileges() {
+        let filter = WildcardScopeFilter::from_wildcards(&[
+            WildcardGrantPattern {
+                role: "reader".to_string(),
+                object_type: ObjectType::Table,
+                schema: "app".to_string(),
+                privileges: BTreeSet::from([Privilege::Select]),
+            },
+            WildcardGrantPattern {
+                role: "writer".to_string(),
+                object_type: ObjectType::Table,
+                schema: "app".to_string(),
+                privileges: BTreeSet::from([Privilege::Insert]),
+            },
+        ]);
+
+        assert_eq!(filter.schema_names, vec!["app"]);
+        assert_eq!(filter.object_types, vec!["table"]);
+        assert_eq!(filter.need_select, vec![true]);
+        assert_eq!(filter.need_insert, vec![true]);
+        assert_eq!(filter.need_update, vec![false]);
     }
 
     #[test]

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -527,6 +527,7 @@ fn can_grant(row: &GrantabilityRow, privilege: Privilege) -> bool {
         Privilege::Trigger => row.can_trigger,
         Privilege::Execute => row.can_execute,
         Privilege::Usage => row.can_usage,
+        // Database and schema privileges are not object-wildcard grant targets.
         Privilege::Create | Privilege::Connect | Privilege::Temporary => false,
     }
 }

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -223,15 +223,18 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     wildcard_grants: &[WildcardGrantPattern],
 ) -> Result<PrivilegeInspectionResult, sqlx::Error> {
     let mut grants: BTreeMap<GrantKey, GrantState> = BTreeMap::new();
+    let has_wildcards = !wildcard_grants.is_empty();
     let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
 
-    for ((object_type, schema_name), object_names) in
-        fetch_object_inventory(pool, managed_schemas).await?
-    {
-        inventory.insert(
-            (object_type, schema_name),
-            object_names.into_iter().collect(),
-        );
+    if has_wildcards {
+        for ((object_type, schema_name), object_names) in
+            fetch_object_inventory(pool, managed_schemas).await?
+        {
+            inventory.insert(
+                (object_type, schema_name),
+                object_names.into_iter().collect(),
+            );
+        }
     }
 
     // Run all the independent queries and collect results.
@@ -251,7 +254,8 @@ pub(crate) async fn fetch_privileges_with_wildcards(
         .collect();
 
     for row in &all_rows {
-        if let Some(object_type) = obj_type_str_to_object_type(&row.obj_type)
+        if has_wildcards
+            && let Some(object_type) = obj_type_str_to_object_type(&row.obj_type)
             && !matches!(object_type, ObjectType::Schema | ObjectType::Database)
             && let Some(schema_name) = &row.schema_name
         {
@@ -307,15 +311,20 @@ pub(crate) async fn fetch_privileges_with_wildcards(
         entry.privileges.insert(privilege);
     }
 
-    let diagnostics = if wildcard_grants.is_empty() {
-        Vec::new()
-    } else {
+    let diagnostics = if has_wildcards {
         let executor = fetch_current_user(pool).await?;
         let grantability = fetch_wildcard_grantability(pool, managed_schemas).await?;
         detect_unsatisfiable_wildcards(&grants, &grantability, wildcard_grants, &executor)
+    } else {
+        Vec::new()
     };
 
-    let grants = normalize_wildcard_grants(grants, &inventory, wildcard_grants);
+    let grants = if has_wildcards {
+        normalize_wildcard_grants(grants, &inventory, wildcard_grants)
+    } else {
+        grants
+    };
+
     Ok(PrivilegeInspectionResult {
         grants,
         diagnostics,

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -581,6 +581,8 @@ async fn reconcile_apply(
             let error_reason = err.reason();
             let is_transient_failure =
                 retry_class_for_reconcile_error(&err) == RetryClass::Transient;
+            let clear_current_plan_ref =
+                matches!(&err, ReconcileError::UnsatisfiableWildcardGrant(_));
             match error_reason {
                 "DatabaseConnectionFailed" => {
                     ctx.observability.record_database_connection_failure()
@@ -599,6 +601,7 @@ async fn reconcile_apply(
                     error_reason,
                     &error_message,
                     is_transient_failure,
+                    clear_current_plan_ref,
                 );
             })
             .await
@@ -615,6 +618,7 @@ fn mark_reconcile_failure_status(
     error_reason: &str,
     error_message: &str,
     is_transient_failure: bool,
+    clear_current_plan_ref: bool,
 ) {
     status.set_condition(ready_condition(false, error_reason, error_message));
     status.set_condition(degraded_condition(error_reason, error_message));
@@ -622,11 +626,14 @@ fn mark_reconcile_failure_status(
         c.condition_type != "Reconciling"
             && c.condition_type != "Paused"
             && c.condition_type != "Drifted"
+            && c.condition_type != "Conflict"
     });
     status.change_summary = None;
     status.planned_sql = None;
     status.planned_sql_truncated = false;
-    status.current_plan_ref = None;
+    if clear_current_plan_ref {
+        status.current_plan_ref = None;
+    }
     status.last_error = Some(error_message.to_string());
     if is_transient_failure {
         status.transient_failure_count += 1;
@@ -2752,6 +2759,7 @@ mod tests {
         let mut status = PostgresPolicyStatus {
             conditions: vec![
                 ready_condition(true, "Planned", "Plan computed"),
+                conflict_condition("ConflictingPolicy", "Policy overlaps another policy"),
                 reconciling_condition("Reconciliation in progress"),
                 drifted_condition(true, "DriftDetected", "1 planned change pending"),
             ],
@@ -2772,7 +2780,13 @@ mod tests {
             ..Default::default()
         };
 
-        mark_reconcile_failure_status(&mut status, "UnsatisfiableWildcardGrant", message, false);
+        mark_reconcile_failure_status(
+            &mut status,
+            "UnsatisfiableWildcardGrant",
+            message,
+            false,
+            true,
+        );
 
         let ready = status
             .conditions
@@ -2797,9 +2811,11 @@ mod tests {
 
         assert!(
             status.conditions.iter().all(|condition| {
-                condition.condition_type != "Reconciling" && condition.condition_type != "Drifted"
+                condition.condition_type != "Reconciling"
+                    && condition.condition_type != "Drifted"
+                    && condition.condition_type != "Conflict"
             }),
-            "transient planning conditions should be cleared on degraded status"
+            "transient planning and stale conflict conditions should be cleared on degraded status"
         );
         assert!(status.change_summary.is_none());
         assert!(status.planned_sql.is_none());
@@ -2807,6 +2823,42 @@ mod tests {
         assert!(status.current_plan_ref.is_none());
         assert_eq!(status.last_error.as_deref(), Some(message));
         assert_eq!(status.transient_failure_count, 0);
+    }
+
+    #[test]
+    fn reconcile_failure_status_preserves_plan_reference_when_requested() {
+        let mut status = PostgresPolicyStatus {
+            current_plan_ref: Some(crate::crd::PlanReference {
+                name: "approved-plan".into(),
+            }),
+            planned_sql: Some("ALTER ROLE \"app\" LOGIN;".into()),
+            planned_sql_truncated: true,
+            transient_failure_count: 2,
+            ..Default::default()
+        };
+
+        mark_reconcile_failure_status(
+            &mut status,
+            "ApplyFailed",
+            "SQL execution error: connection closed",
+            true,
+            false,
+        );
+
+        assert_eq!(
+            status
+                .current_plan_ref
+                .as_ref()
+                .map(|plan| plan.name.as_str()),
+            Some("approved-plan")
+        );
+        assert!(status.planned_sql.is_none());
+        assert!(!status.planned_sql_truncated);
+        assert_eq!(
+            status.last_error.as_deref(),
+            Some("SQL execution error: connection closed")
+        );
+        assert_eq!(status.transient_failure_count, 3);
     }
 
     #[test]

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -581,6 +581,8 @@ async fn reconcile_apply(
             let error_reason = err.reason();
             let is_transient_failure =
                 retry_class_for_reconcile_error(&err) == RetryClass::Transient;
+            // Unsatisfiable wildcards would regenerate the same impossible plan.
+            // Other failures keep any plan ref so the same plan can be retried.
             let clear_current_plan_ref =
                 matches!(&err, ReconcileError::UnsatisfiableWildcardGrant(_));
             match error_reason {

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -131,6 +131,9 @@ pub enum ReconcileError {
     MissingDatabaseObjects(String),
 
     #[error("{0}")]
+    UnsatisfiableWildcardGrant(String),
+
+    #[error("{0}")]
     ConflictingPolicy(String),
 
     #[error("lock contention on database \"{0}\": {1}")]
@@ -350,6 +353,7 @@ fn retry_class_for_reconcile_error(error: &ReconcileError) -> RetryClass {
         | ReconcileError::InvalidInterval(_, _)
         | ReconcileError::InvalidSpec(_)
         | ReconcileError::MissingDatabaseObjects(_)
+        | ReconcileError::UnsatisfiableWildcardGrant(_)
         | ReconcileError::ConflictingPolicy(_)
         | ReconcileError::UnsafeRoleDrops(_)
         | ReconcileError::EmptyPasswordSecret { .. }
@@ -583,29 +587,19 @@ async fn reconcile_apply(
                 }
                 "InvalidSpec" => ctx.observability.record_invalid_spec(),
                 "ConflictingPolicy" => ctx.observability.record_policy_conflict(),
-                "ApplyFailed" | "MissingDatabaseObject" => {
+                "ApplyFailed" | "MissingDatabaseObject" | "UnsatisfiableWildcardGrant" => {
                     ctx.observability.record_apply_result("error")
                 }
                 _ => {}
             }
             reconcile_guard.record_result("error", error_reason);
             if let Err(status_err) = update_status(ctx, resource, |status| {
-                status.set_condition(ready_condition(false, error_reason, &error_message));
-                status.set_condition(degraded_condition(error_reason, &error_message));
-                status.conditions.retain(|c| {
-                    c.condition_type != "Reconciling"
-                        && c.condition_type != "Paused"
-                        && c.condition_type != "Drifted"
-                });
-                status.change_summary = None;
-                status.planned_sql = None;
-                status.planned_sql_truncated = false;
-                status.last_error = Some(error_message.clone());
-                if is_transient_failure {
-                    status.transient_failure_count += 1;
-                } else {
-                    status.transient_failure_count = 0;
-                }
+                mark_reconcile_failure_status(
+                    status,
+                    error_reason,
+                    &error_message,
+                    is_transient_failure,
+                );
             })
             .await
             {
@@ -613,6 +607,31 @@ async fn reconcile_apply(
             }
             Err(err)
         }
+    }
+}
+
+fn mark_reconcile_failure_status(
+    status: &mut PostgresPolicyStatus,
+    error_reason: &str,
+    error_message: &str,
+    is_transient_failure: bool,
+) {
+    status.set_condition(ready_condition(false, error_reason, error_message));
+    status.set_condition(degraded_condition(error_reason, error_message));
+    status.conditions.retain(|c| {
+        c.condition_type != "Reconciling"
+            && c.condition_type != "Paused"
+            && c.condition_type != "Drifted"
+    });
+    status.change_summary = None;
+    status.planned_sql = None;
+    status.planned_sql_truncated = false;
+    status.current_plan_ref = None;
+    status.last_error = Some(error_message.to_string());
+    if is_transient_failure {
+        status.transient_failure_count += 1;
+    } else {
+        status.transient_failure_count = 0;
     }
 }
 
@@ -858,7 +877,13 @@ async fn apply_under_lock(
                     .iter()
                     .map(|retirement| retirement.role.clone()),
             );
-    let current = pgroles_inspect::inspect(pool, &inspect_config).await?;
+    let inspection = pgroles_inspect::inspect_with_diagnostics(pool, &inspect_config).await?;
+    if !inspection.diagnostics.is_empty() {
+        return Err(ReconcileError::UnsatisfiableWildcardGrant(
+            inspection.diagnostics.to_string(),
+        ));
+    }
+    let current = inspection.graph;
 
     // 6b. Pre-flight: validate that every schema referenced by the policy
     // exists in the target database. This turns a mid-transaction
@@ -2047,6 +2072,7 @@ impl ReconcileError {
             | ReconcileError::InvalidInterval(_, _)
             | ReconcileError::InvalidSpec(_) => "InvalidSpec",
             ReconcileError::ConflictingPolicy(_) => "ConflictingPolicy",
+            ReconcileError::UnsatisfiableWildcardGrant(_) => "UnsatisfiableWildcardGrant",
             ReconcileError::LockContention(_, _) => "LockContention",
             ReconcileError::Context(context) => match context.as_ref() {
                 ContextError::SecretFetch { .. } => "SecretFetchFailed",
@@ -2712,6 +2738,78 @@ mod tests {
     }
 
     #[test]
+    fn error_reason_unsatisfiable_wildcard_grant() {
+        let err = ReconcileError::UnsatisfiableWildcardGrant(
+            "UnsatisfiableWildcardGrant: function f2() is not grantable".into(),
+        );
+        assert_eq!(err.reason(), "UnsatisfiableWildcardGrant");
+        assert!(err.to_string().contains("UnsatisfiableWildcardGrant"));
+    }
+
+    #[test]
+    fn unsatisfiable_wildcard_status_is_degraded_without_plan_reference() {
+        let message = "UnsatisfiableWildcardGrant: cannot fully satisfy wildcard grant EXECUTE ON function * IN SCHEMA \"app\" TO \"reader\" as executor \"app_owner\"; 1 matching object(s) are missing the desired privilege and are not grantable (examples: \"f2()\" owned by \"definer\" missing [EXECUTE])";
+        let mut status = PostgresPolicyStatus {
+            conditions: vec![
+                ready_condition(true, "Planned", "Plan computed"),
+                reconciling_condition("Reconciliation in progress"),
+                drifted_condition(true, "DriftDetected", "1 planned change pending"),
+            ],
+            change_summary: Some(ChangeSummary {
+                grants_added: 1,
+                total: 1,
+                ..Default::default()
+            }),
+            planned_sql: Some(
+                "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA \"app\" TO \"reader\";".into(),
+            ),
+            planned_sql_truncated: true,
+            last_error: None,
+            transient_failure_count: 3,
+            current_plan_ref: Some(crate::crd::PlanReference {
+                name: "example-plan".into(),
+            }),
+            ..Default::default()
+        };
+
+        mark_reconcile_failure_status(&mut status, "UnsatisfiableWildcardGrant", message, false);
+
+        let ready = status
+            .conditions
+            .iter()
+            .find(|condition| condition.condition_type == "Ready")
+            .expect("Ready condition should be present");
+        assert_eq!(ready.status, "False");
+        assert_eq!(ready.reason.as_deref(), Some("UnsatisfiableWildcardGrant"));
+        assert_eq!(ready.message.as_deref(), Some(message));
+
+        let degraded = status
+            .conditions
+            .iter()
+            .find(|condition| condition.condition_type == "Degraded")
+            .expect("Degraded condition should be present");
+        assert_eq!(degraded.status, "True");
+        assert_eq!(
+            degraded.reason.as_deref(),
+            Some("UnsatisfiableWildcardGrant")
+        );
+        assert_eq!(degraded.message.as_deref(), Some(message));
+
+        assert!(
+            status.conditions.iter().all(|condition| {
+                condition.condition_type != "Reconciling" && condition.condition_type != "Drifted"
+            }),
+            "transient planning conditions should be cleared on degraded status"
+        );
+        assert!(status.change_summary.is_none());
+        assert!(status.planned_sql.is_none());
+        assert!(!status.planned_sql_truncated);
+        assert!(status.current_plan_ref.is_none());
+        assert_eq!(status.last_error.as_deref(), Some(message));
+        assert_eq!(status.transient_failure_count, 0);
+    }
+
+    #[test]
     fn error_display_missing_database_objects_lists_schemas() {
         let err = ReconcileError::MissingDatabaseObjects("schema \"etl\", schema \"jobs\"".into());
         let msg = err.to_string();
@@ -3121,6 +3219,14 @@ mod tests {
     fn retry_classifies_missing_database_objects_as_slow() {
         let error = finalizer::Error::ApplyFailed(ReconcileError::MissingDatabaseObjects(
             "schema \"etl\"".into(),
+        ));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
+    }
+
+    #[test]
+    fn retry_classifies_unsatisfiable_wildcard_grant_as_slow() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::UnsatisfiableWildcardGrant(
+            "UnsatisfiableWildcardGrant: function f2() is not grantable".into(),
         ));
         assert_eq!(retry_class(&error), RetryClass::Slow);
     }

--- a/docs/src/pages/docs/grants.md
+++ b/docs/src/pages/docs/grants.md
@@ -82,6 +82,21 @@ touch the others.
 
 If a schema has no objects of the declared type (e.g. no sequences yet), the wildcard grant is treated as vacuously satisfied — pgroles will not re-issue the statement on subsequent reconciles. When objects are later added, the next reconcile detects the new objects and applies the appropriate grants.
 
+Wildcard grants are strict desired state. `name: "*"` means every matching
+current object in the schema, not only the objects the current executor happens
+to own. During `diff`, `plan`, and `apply`, pgroles checks whether each missing
+wildcard privilege is grantable by the connected database user. If a matching
+object is missing the requested privilege and the executor lacks the matching
+`WITH GRANT OPTION`, pgroles stops with `UnsatisfiableWildcardGrant` instead of
+printing or applying a wildcard `GRANT` that would churn on every reconcile.
+
+The diagnostic includes the role, object type, schema, requested privileges,
+executor, skipped object count, and example object names with owners. To resolve
+it, run pgroles as a role that can grant the requested privileges on every
+matching object, transfer ownership, grant the executor the needed grant option,
+or narrow the manifest to objects that are intentionally managed by that
+executor.
+
 ### Specific object
 
 ```yaml

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -348,6 +348,13 @@ Use `name: "*"` to grant on all current objects of a type in a schema. pgroles
 expands relation wildcards safely by object type, so `table`, `view`, and
 `materialized_view` privileges do not bleed across each other.
 
+Wildcard grants are strict: every matching current object must either already
+have the requested privilege or be grantable by the database user running
+pgroles. If a matching object is missing the privilege and the executor lacks
+the corresponding `WITH GRANT OPTION`, `diff`, `plan`, and `apply` stop with an
+`UnsatisfiableWildcardGrant` diagnostic instead of emitting a repeating wildcard
+`GRANT`.
+
 ## default_privileges
 
 Default privileges configure what happens when new objects are created:

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -81,6 +81,7 @@ The operator runs as `nobody` (UID 65534) with a read-only root filesystem, no c
 
 - Use one `PostgresPolicy` per database and credential boundary.
 - Prefer a dedicated management role rather than an application login for reconciliation.
+- Ensure the management role can grant every wildcard-managed privilege on every matching object, either by owning those objects or holding the required `WITH GRANT OPTION`.
 - Validate and review the manifest with the CLI before handing it to the operator.
 - Treat deletion as "stop managing", not "revert the database".
 
@@ -100,6 +101,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 
 - Transient operational failures use exponential backoff with jitter.
 - Invalid specs, conflicts, and unsafe role-drop workflows fall back to the normal reconcile interval without hot-looping.
+- Unsatisfiable wildcard grants are reported as `Ready=False` and `Degraded=True` with reason `UnsatisfiableWildcardGrant`; the operator does not create a `PostgresPolicyPlan` or SQL ConfigMap for that reconcile.
 - Lock contention has its own short retry path.
 
 **Observability:**


### PR DESCRIPTION
## Summary
- add pgroles-inspect diagnostics for wildcard grants that cannot be satisfied by the current executor
- fail CLI diff/plan/apply before rendering or applying repeated wildcard SQL when diagnostics are present
- surface UnsatisfiableWildcardGrant in the operator with slow retry classification and degraded status without stale plan refs

Fixes #105.

## Validation
- cargo fmt --all -- --check
- git diff --check
- SQLX_OFFLINE=true cargo test --workspace
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test SQLX_OFFLINE=true cargo test -p pgroles-cli --test cli wildcard_ -- --ignored
- scripts/check-crd-drift.sh
- ./correctness/run-tlc.sh races/Convergence.tla races/Convergence.cfg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now detects unsatisfiable wildcard grants and surfaces actionable diagnostics; plan/apply fail early to avoid partial or broad wildcard grants
  * Reconciliation now stops on unsatisfiable wildcard grants and reflects failure in status/plan fields

* **Tests**
  * Added unit and live integration tests covering wildcard grant diagnostics, failure modes, and status behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->