### PR TITLE
Prepare v0.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.2] - 2026-05-08
 
+### Added
+
+- **Operator OTLP metrics now expose database inspection cost.** The operator records inspection phase durations, inspected object counts, wildcard inventory size, unsatisfied wildcard scope counts, and grantability query/object counts so large-schema deployments can spot catalog-query regressions.
+
 ### Changed
 
 - Wildcard diagnostics now avoid grantability catalog scans when current ACLs already satisfy the wildcard, and scope grantability checks to the unsatisfied wildcard schema/object-type pairs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "hmac 0.13.0",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-inspect"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "pgroles-core",
  "sqlx",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-operator"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 authors = ["Brian Thorne <brian@thorne.link>"]
 license = "MIT"
@@ -54,8 +54,8 @@ k8s-openapi = { version = "0.27.1", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Internal crates
-pgroles-core = { path = "crates/pgroles-core", version = "0.7.1" }
-pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.1" }
+pgroles-core = { path = "crates/pgroles-core", version = "0.7.2" }
+pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.2" }
 
 [profile.release]
 strip = "symbols"

--- a/charts/pgroles-operator/Chart.yaml
+++ b/charts/pgroles-operator/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Define roles, memberships, grants, and default privileges in YAML
   and let the operator converge your database to the desired state.
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.7.2
+appVersion: "0.7.2"
 icon: https://raw.githubusercontent.com/hardbyte/pgroles/main/docs/public/logo.svg
 sources:
   - https://github.com/hardbyte/pgroles
@@ -16,10 +16,12 @@ maintainers:
     url: https://hardbyte.nz
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: 'OTLP metrics now include database inspection phase durations and wildcard diagnostic counters.'
     - kind: fixed
-      description: 'Wildcard grants no longer flap when an inventory object loses its ACL (e.g. externally DROP+CREATEd functions).'
-    - kind: fixed
-      description: 'Connection failures detected at pool-creation time (e.g. after a credential Secret rotation) no longer starve sibling policies on the in-process lock.'
+      description: 'Unsatisfiable wildcard grants now fail with clear diagnostics instead of re-planning forever.'
+    - kind: changed
+      description: 'Wildcard diagnostics avoid grantability scans on already-satisfied wildcards and scope grantability checks to unsatisfied wildcard targets.'
   artifacthub.io/category: database
   artifacthub.io/operator: "true"
   artifacthub.io/prerelease: "false"

--- a/crates/pgroles-inspect/src/lib.rs
+++ b/crates/pgroles-inspect/src/lib.rs
@@ -14,6 +14,7 @@ mod safety;
 mod version;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::{Duration, Instant};
 
 use sqlx::PgPool;
 use thiserror::Error;
@@ -136,6 +137,35 @@ impl std::fmt::Display for UnsatisfiableWildcardObject {
 pub struct InspectionResult {
     pub graph: RoleGraph,
     pub diagnostics: InspectionDiagnostics,
+    pub stats: InspectionStats,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InspectionStats {
+    pub roles: usize,
+    pub memberships: usize,
+    pub schemas: usize,
+    pub grants: usize,
+    pub default_privileges: usize,
+    pub phase_durations: BTreeMap<&'static str, Duration>,
+    pub wildcard: WildcardInspectionStats,
+}
+
+impl InspectionStats {
+    fn record_phase(&mut self, phase: &'static str, duration: Duration) {
+        self.phase_durations.insert(phase, duration);
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WildcardInspectionStats {
+    pub configured_grants: usize,
+    pub configured_scopes: usize,
+    pub inventory_objects: usize,
+    pub unsatisfied_grants: usize,
+    pub unsatisfied_scopes: usize,
+    pub grantability_queries: usize,
+    pub grantability_objects: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -415,6 +445,7 @@ pub async fn inspect_with_diagnostics(
 ) -> Result<InspectionResult, InspectError> {
     let mut graph = RoleGraph::default();
     let mut diagnostics = InspectionDiagnostics::default();
+    let mut stats = InspectionStats::default();
 
     // Build &str slices for the query functions
     let role_refs: Vec<&str> = config.managed_roles.iter().map(|s| s.as_str()).collect();
@@ -430,15 +461,20 @@ pub async fn inspect_with_diagnostics(
         count = role_refs.len(),
         "inspecting managed roles from pg_roles"
     );
+    let phase_started_at = Instant::now();
     let role_rows = fetch_roles(pool, Some(&role_refs)).await?;
+    stats.record_phase("roles", phase_started_at.elapsed());
     for row in &role_rows {
         graph.roles.insert(row.rolname.clone(), row.to_role_state());
     }
+    stats.roles = graph.roles.len();
     debug!(found = graph.roles.len(), "roles inspected");
 
     // --- Memberships ---
     debug!("inspecting memberships from pg_auth_members");
+    let phase_started_at = Instant::now();
     let membership_rows = fetch_memberships(pool, Some(&role_refs)).await?;
+    stats.record_phase("memberships", phase_started_at.elapsed());
     for row in &membership_rows {
         graph.memberships.insert(row.to_membership_edge());
     }
@@ -446,12 +482,15 @@ pub async fn inspect_with_diagnostics(
     // This captures cases like "user@example.com is a member of inventory-editor"
     // where inventory-editor is the group (managed) and user@example.com is the member.
     // The fetch above already handles this (filters on group role = managed).
+    stats.memberships = graph.memberships.len();
     debug!(found = graph.memberships.len(), "memberships inspected");
 
     // --- Schemas ---
     if !schema_refs.is_empty() {
         debug!(schemas = ?schema_refs, "inspecting schemas from pg_namespace");
+        let phase_started_at = Instant::now();
         let schema_rows = fetch_schemas(pool, &schema_refs).await?;
+        stats.record_phase("schemas", phase_started_at.elapsed());
         for row in &schema_rows {
             graph.schemas.insert(
                 row.schema_name.clone(),
@@ -461,6 +500,7 @@ pub async fn inspect_with_diagnostics(
                 },
             );
         }
+        stats.schemas = graph.schemas.len();
         debug!(found = graph.schemas.len(), "schemas inspected");
     }
 
@@ -470,6 +510,7 @@ pub async fn inspect_with_diagnostics(
             schemas = ?privilege_schema_refs,
             "inspecting object privileges via aclexplode"
         );
+        let phase_started_at = Instant::now();
         let privilege_result = privileges::fetch_privileges_with_wildcards(
             pool,
             &privilege_schema_refs,
@@ -477,6 +518,8 @@ pub async fn inspect_with_diagnostics(
             &config.wildcard_grants,
         )
         .await?;
+        stats.record_phase("object_privileges", phase_started_at.elapsed());
+        stats.wildcard = privilege_result.wildcard_stats;
         diagnostics
             .unsatisfiable_wildcard_grants
             .extend(privilege_result.diagnostics);
@@ -485,16 +528,20 @@ pub async fn inspect_with_diagnostics(
             graph.grants.insert(key, state);
         }
         remove_redundant_schema_owner_grants(&mut graph);
+        stats.grants = graph.grants.len();
         debug!(found = graph.grants.len(), "privilege grants inspected");
     }
 
     // --- Database-level privileges ---
     if config.include_database_privileges {
         debug!("inspecting database-level privileges");
+        let phase_started_at = Instant::now();
         let db_grants = fetch_database_privileges(pool, &role_refs).await?;
+        stats.record_phase("database_privileges", phase_started_at.elapsed());
         for (key, state) in db_grants {
             graph.grants.insert(key, state);
         }
+        stats.grants = graph.grants.len();
         debug!(
             total = graph.grants.len(),
             "grants after database privileges"
@@ -504,18 +551,25 @@ pub async fn inspect_with_diagnostics(
     // --- Default privileges ---
     if !privilege_schema_refs.is_empty() {
         debug!("inspecting default privileges from pg_default_acl");
+        let phase_started_at = Instant::now();
         let default_privs =
             fetch_default_privileges(pool, &privilege_schema_refs, &role_refs).await?;
+        stats.record_phase("default_privileges", phase_started_at.elapsed());
         for (key, state) in default_privs {
             graph.default_privileges.insert(key, state);
         }
+        stats.default_privileges = graph.default_privileges.len();
         debug!(
             found = graph.default_privileges.len(),
             "default privileges inspected"
         );
     }
 
-    Ok(InspectionResult { graph, diagnostics })
+    Ok(InspectionResult {
+        graph,
+        diagnostics,
+        stats,
+    })
 }
 
 /// Fetch the names of all non-system schemas in the target database.

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -18,7 +18,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use sqlx::PgPool;
 
-use crate::{UnsatisfiableWildcardGrant, UnsatisfiableWildcardObject, WildcardGrantPattern};
+use crate::{
+    UnsatisfiableWildcardGrant, UnsatisfiableWildcardObject, WildcardGrantPattern,
+    WildcardInspectionStats,
+};
 use pgroles_core::manifest::{ObjectType, Privilege};
 use pgroles_core::model::{GrantKey, GrantState};
 
@@ -57,6 +60,7 @@ struct GrantabilityRow {
 pub(crate) struct PrivilegeInspectionResult {
     pub grants: BTreeMap<GrantKey, GrantState>,
     pub diagnostics: Vec<UnsatisfiableWildcardGrant>,
+    pub wildcard_stats: WildcardInspectionStats,
 }
 
 struct WildcardScopeFilter {
@@ -144,6 +148,10 @@ impl WildcardScopeFilter {
 
     fn is_empty(&self) -> bool {
         self.schema_names.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.schema_names.len()
     }
 
     fn contains(&self, object_type: ObjectType, schema_name: &str) -> bool {
@@ -475,6 +483,11 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     let mut grants: BTreeMap<GrantKey, GrantState> = BTreeMap::new();
     let has_wildcards = !wildcard_grants.is_empty();
     let wildcard_scope_filter = WildcardScopeFilter::from_wildcards(wildcard_grants);
+    let mut wildcard_stats = WildcardInspectionStats {
+        configured_grants: wildcard_grants.len(),
+        configured_scopes: wildcard_scope_filter.len(),
+        ..WildcardInspectionStats::default()
+    };
     let mut inventory: BTreeMap<(ObjectType, String), BTreeSet<String>> = BTreeMap::new();
 
     if has_wildcards {
@@ -487,7 +500,6 @@ pub(crate) async fn fetch_privileges_with_wildcards(
             );
         }
     }
-
     // Run all the independent queries and collect results.
     // We use separate queries per object type rather than one giant UNION
     // because the NULL-ACL handling (acldefault) differs per type.
@@ -517,6 +529,7 @@ pub(crate) async fn fetch_privileges_with_wildcards(
                 .insert(row.object_name.clone());
         }
     }
+    wildcard_stats.inventory_objects = inventory.values().map(BTreeSet::len).sum();
 
     for row in all_rows {
         // Skip PUBLIC grantee (NULL)
@@ -568,13 +581,17 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     } else {
         Vec::new()
     };
+    wildcard_stats.unsatisfied_grants = unsatisfied_wildcards.len();
 
     let diagnostics = if unsatisfied_wildcards.is_empty() {
         Vec::new()
     } else {
         let executor = fetch_current_user(pool).await?;
         let grantability_filter = WildcardScopeFilter::from_wildcards(&unsatisfied_wildcards);
+        wildcard_stats.unsatisfied_scopes = grantability_filter.len();
         let grantability = fetch_wildcard_grantability(pool, &grantability_filter).await?;
+        wildcard_stats.grantability_queries = 1;
+        wildcard_stats.grantability_objects = grantability.len();
         detect_unsatisfiable_wildcards(&grants, &grantability, &unsatisfied_wildcards, &executor)
     };
 
@@ -587,6 +604,7 @@ pub(crate) async fn fetch_privileges_with_wildcards(
     Ok(PrivilegeInspectionResult {
         grants,
         diagnostics,
+        wildcard_stats,
     })
 }
 

--- a/crates/pgroles-operator/src/observability.rs
+++ b/crates/pgroles-operator/src/observability.rs
@@ -30,6 +30,10 @@ struct Metrics {
     reconcile_total: Counter<u64>,
     reconcile_duration_ms: Histogram<u64>,
     reconcile_inflight: UpDownCounter<i64>,
+    inspect_duration_ms: Histogram<u64>,
+    inspect_items_total: Counter<u64>,
+    wildcard_grantability_queries_total: Counter<u64>,
+    wildcard_unsatisfied_grants_total: Counter<u64>,
     plan_total: Counter<u64>,
     plan_changes_total: Counter<u64>,
     lock_contention_total: Counter<u64>,
@@ -114,6 +118,64 @@ impl OperatorObservability {
     pub fn record_invalid_spec(&self) {
         if let Some(metrics) = &self.metrics {
             metrics.invalid_spec_total.add(1, &[]);
+        }
+    }
+
+    pub fn record_inspection(&self, stats: &pgroles_inspect::InspectionStats) {
+        let Some(metrics) = &self.metrics else {
+            return;
+        };
+
+        for (phase, duration) in &stats.phase_durations {
+            metrics.inspect_duration_ms.record(
+                duration.as_millis() as u64,
+                &[KeyValue::new("phase", *phase)],
+            );
+        }
+
+        for (kind, count) in [
+            ("roles", stats.roles),
+            ("memberships", stats.memberships),
+            ("schemas", stats.schemas),
+            ("grants", stats.grants),
+            ("default_privileges", stats.default_privileges),
+            (
+                "wildcard_configured_grants",
+                stats.wildcard.configured_grants,
+            ),
+            (
+                "wildcard_configured_scopes",
+                stats.wildcard.configured_scopes,
+            ),
+            (
+                "wildcard_inventory_objects",
+                stats.wildcard.inventory_objects,
+            ),
+            (
+                "wildcard_unsatisfied_scopes",
+                stats.wildcard.unsatisfied_scopes,
+            ),
+            (
+                "wildcard_grantability_objects",
+                stats.wildcard.grantability_objects,
+            ),
+        ] {
+            if count > 0 {
+                metrics
+                    .inspect_items_total
+                    .add(count as u64, &[KeyValue::new("kind", kind)]);
+            }
+        }
+
+        if stats.wildcard.grantability_queries > 0 {
+            metrics
+                .wildcard_grantability_queries_total
+                .add(stats.wildcard.grantability_queries as u64, &[]);
+        }
+        if stats.wildcard.unsatisfied_grants > 0 {
+            metrics
+                .wildcard_unsatisfied_grants_total
+                .add(stats.wildcard.unsatisfied_grants as u64, &[]);
         }
     }
 
@@ -235,6 +297,23 @@ impl Metrics {
                 .i64_up_down_counter("pgroles.reconcile.inflight")
                 .with_description("In-flight reconciliations")
                 .build(),
+            inspect_duration_ms: meter
+                .u64_histogram("pgroles.inspect.duration")
+                .with_unit("ms")
+                .with_description("Database inspection phase duration in milliseconds")
+                .build(),
+            inspect_items_total: meter
+                .u64_counter("pgroles.inspect.items")
+                .with_description("Database inspection objects observed by kind")
+                .build(),
+            wildcard_grantability_queries_total: meter
+                .u64_counter("pgroles.wildcard.grantability_queries")
+                .with_description("Wildcard grantability catalog queries")
+                .build(),
+            wildcard_unsatisfied_grants_total: meter
+                .u64_counter("pgroles.wildcard.unsatisfied_grants")
+                .with_description("Wildcard grants missing privileges before grantability checks")
+                .build(),
             plan_total: meter
                 .u64_counter("pgroles.plan.total")
                 .with_description("Successful plan-mode reconciliations by result")
@@ -286,6 +365,7 @@ async fn readyz(State(observability): State<OperatorObservability>) -> impl Into
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use axum::extract::State;
     use axum::http::StatusCode;
@@ -329,18 +409,26 @@ mod tests {
     }
 
     fn u64_sum_value(metrics: &[ResourceMetrics], name: &str) -> Option<u64> {
-        metrics
+        let mut found = false;
+        let total = metrics
             .iter()
             .flat_map(|resource_metrics| resource_metrics.scope_metrics())
             .flat_map(|scope_metrics| scope_metrics.metrics())
-            .find(|metric| metric.name() == name)
-            .and_then(|metric| match metric.data() {
-                AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
-                    .data_points()
-                    .next()
-                    .map(|data_point| data_point.value()),
+            .filter(|metric| metric.name() == name)
+            .filter_map(|metric| match metric.data() {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                    found = true;
+                    Some(
+                        sum.data_points()
+                            .map(|data_point| data_point.value())
+                            .sum::<u64>(),
+                    )
+                }
                 _ => None,
             })
+            .sum();
+
+        found.then_some(total)
     }
 
     fn i64_sum_value(metrics: &[ResourceMetrics], name: &str) -> Option<i64> {
@@ -406,6 +494,28 @@ mod tests {
         observability.record_policy_conflict();
         observability.record_invalid_spec();
         observability.record_database_connection_failure();
+        observability.record_inspection(&pgroles_inspect::InspectionStats {
+            roles: 3,
+            memberships: 2,
+            schemas: 1,
+            grants: 5,
+            default_privileges: 1,
+            phase_durations: [
+                ("roles", Duration::from_millis(4)),
+                ("object_privileges", Duration::from_millis(12)),
+            ]
+            .into_iter()
+            .collect(),
+            wildcard: pgroles_inspect::WildcardInspectionStats {
+                configured_grants: 2,
+                configured_scopes: 1,
+                inventory_objects: 100,
+                unsatisfied_grants: 1,
+                unsatisfied_scopes: 1,
+                grantability_queries: 1,
+                grantability_objects: 3,
+            },
+        });
         observability.record_plan_result("drift");
         observability.record_planned_changes(2);
         observability.record_apply_result("success");
@@ -420,6 +530,16 @@ mod tests {
 
         assert!(metric_exists(&metrics, "pgroles.reconcile.total"));
         assert!(metric_exists(&metrics, "pgroles.reconcile.duration"));
+        assert!(metric_exists(&metrics, "pgroles.inspect.duration"));
+        assert_eq!(u64_sum_value(&metrics, "pgroles.inspect.items"), Some(119));
+        assert_eq!(
+            u64_sum_value(&metrics, "pgroles.wildcard.grantability_queries"),
+            Some(1)
+        );
+        assert_eq!(
+            u64_sum_value(&metrics, "pgroles.wildcard.unsatisfied_grants"),
+            Some(1)
+        );
         assert_eq!(u64_sum_value(&metrics, "pgroles.plan.total"), Some(1));
         assert_eq!(u64_sum_value(&metrics, "pgroles.plan.changes"), Some(2));
         assert_eq!(

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -887,6 +887,7 @@ async fn apply_under_lock(
                     .map(|retirement| retirement.role.clone()),
             );
     let inspection = pgroles_inspect::inspect_with_diagnostics(pool, &inspect_config).await?;
+    ctx.observability.record_inspection(&inspection.stats);
     if !inspection.diagnostics.is_empty() {
         return Err(ReconcileError::UnsatisfiableWildcardGrant(
             inspection.diagnostics.to_string(),

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -490,7 +490,7 @@ The exported metrics include reconcile, plan, apply, lock-contention, conflict, 
 | Metric | Labels | Meaning |
 | --- | --- | --- |
 | `pgroles.inspect.duration` | `phase` | Duration for each inspection phase, such as roles, memberships, object privileges, database privileges, and default privileges |
-| `pgroles.inspect.items` | `kind` | Counts of inspected roles, memberships, schemas, grants, default privileges, wildcard scopes, wildcard inventory objects, and grantability objects |
+| `pgroles.inspect.items` | `kind` | Counts of inspected roles, memberships, schemas, grants, default privileges, configured wildcard scopes, unsatisfied wildcard scopes, wildcard inventory objects, and grantability objects |
 | `pgroles.wildcard.grantability_queries` | - | Number of wildcard grantability catalog queries issued |
 | `pgroles.wildcard.unsatisfied_grants` | - | Number of wildcard grants missing privileges before grantability checks |
 

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -485,6 +485,15 @@ operator:
 
 The intended deployment model is operator -> OpenTelemetry Collector -> your metrics backend.
 
+The exported metrics include reconcile, plan, apply, lock-contention, conflict, and database-connection counters. They also include database inspection measurements for larger deployments:
+
+| Metric | Labels | Meaning |
+| --- | --- | --- |
+| `pgroles.inspect.duration` | `phase` | Duration for each inspection phase, such as roles, memberships, object privileges, database privileges, and default privileges |
+| `pgroles.inspect.items` | `kind` | Counts of inspected roles, memberships, schemas, grants, default privileges, wildcard scopes, wildcard inventory objects, and grantability objects |
+| `pgroles.wildcard.grantability_queries` | - | Number of wildcard grantability catalog queries issued |
+| `pgroles.wildcard.unsatisfied_grants` | - | Number of wildcard grants missing privileges before grantability checks |
+
 The operator also emits transition-based Kubernetes Events such as:
 
 - `ConflictDetected`


### PR DESCRIPTION
## Summary
- add OTLP inspection metrics for inspect phase durations, inspected object counts, wildcard inventory size, unsatisfied wildcard scopes, and grantability query/object counts
- document the new operator metrics
- bump workspace and Helm chart metadata to v0.7.2 and refresh release notes

## Validation
- cargo fmt --all -- --check
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- SQLX_OFFLINE=true cargo test --workspace
- DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test SQLX_OFFLINE=true cargo test -p pgroles-cli --test cli wildcard_ -- --ignored
- scripts/check-crd-drift.sh
- ./correctness/run-tlc.sh races/Convergence.tla races/Convergence.cfg

## Ops note
- Updated main branch protection required checks to replace stale `E2E Tests` with `E2E: Operator Scenarios`, `E2E: Load Tests`, and `E2E: Plan Lifecycle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OTLP metrics for database inspection cost analysis, including phase durations, object counts, and wildcard operation statistics.

* **Changed**
  * Wildcard diagnostics now skip unnecessary grantability scans when existing ACLs already satisfy requirements.

* **Fixed**
  * Unsatisfiable wildcard grants now fail with clear diagnostics, preventing repeated planning cycles.

* **Documentation**
  * Added metrics reference documentation for operator observability and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->