### PR TITLE
fix(inspect): cast inventory object_name columns to text in UNION

### DIFF
--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -4370,4 +4370,97 @@ retirements:
             "#
         ));
     }
+
+    /// Regression for the wildcard EXECUTE flap on schemas containing functions
+    /// whose `proname || '(' || identity_args || ')'` signature exceeds 63
+    /// bytes.
+    ///
+    /// The inventory query UNION-ALLs `c.relname` / `t.typname` (PostgreSQL
+    /// `name`, 63-byte cap) with the text-typed function signature. PostgreSQL
+    /// resolves the result column to the common type — `name` — which silently
+    /// truncates long function signatures. The per-type privilege query
+    /// returns the full signature unaffected, so inventory's truncated key
+    /// fails to match the grant key in `normalize_wildcard_grants` and the
+    /// wildcard is treated as unsatisfied on every reconcile.
+    ///
+    /// This test creates a function with a long signature, applies a wildcard
+    /// EXECUTE grant, and asserts a follow-up diff converges to zero changes.
+    /// Before the inventory-column casts, the second diff would re-emit
+    /// `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA ... TO ...` forever.
+    #[test]
+    #[ignore]
+    fn wildcard_function_grant_converges_with_signature_longer_than_63_bytes() {
+        let schema = unique_name("wildfn_longsig");
+        let role = unique_name("wildfn_longsig_role");
+        // `proname || '(' || identity_args || ')'` is 74+ bytes; well past
+        // PostgreSQL's 63-byte `name` cap.
+        let function_body = format!(
+            r#"CREATE FUNCTION "{schema}".compute_thing(parameter_with_a_deliberately_long_identifier integer) RETURNS int LANGUAGE sql AS 'SELECT $1'"#
+        );
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{role}";
+            CREATE SCHEMA "{schema}";
+            {function_body};
+            REVOKE EXECUTE ON FUNCTION "{schema}".compute_thing(integer) FROM PUBLIC;
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+roles:
+  - name: {role}
+
+grants:
+  - role: {role}
+    privileges: [EXECUTE]
+    object: {{ type: function, schema: {schema}, name: "*" }}
+"#
+        ));
+
+        // Initial apply materialises the per-function grant.
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success();
+
+        assert!(
+            query_has_function_privilege(&role, &format!(r#""{schema}"."compute_thing"(integer)"#)),
+            "function should have EXECUTE after initial apply"
+        );
+
+        // The bug: before the inventory-column casts, the wildcard satisfaction
+        // check looks up the grant under a 63-byte-truncated function key that
+        // doesn't match the full key in the grant map, so the diff re-emits
+        // the wildcard GRANT on every reconcile. With the fix, the diff
+        // converges to zero changes.
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{role}";
+            "#
+        ));
+    }
 }

--- a/crates/pgroles-inspect/src/privileges.rs
+++ b/crates/pgroles-inspect/src/privileges.rs
@@ -251,7 +251,7 @@ pub async fn fetch_object_inventory(
             NULL::text AS grantee,
             '' AS privilege_type,
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             CASE c.relkind
                 WHEN 'r' THEN 'table'
                 WHEN 'p' THEN 'table'
@@ -269,7 +269,7 @@ pub async fn fetch_object_inventory(
             NULL::text AS grantee,
             '' AS privilege_type,
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             'sequence' AS obj_type
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -294,7 +294,7 @@ pub async fn fetch_object_inventory(
             NULL::text AS grantee,
             '' AS privilege_type,
             n.nspname AS schema_name,
-            t.typname AS object_name,
+            t.typname::text AS object_name,
             'type' AS obj_type
         FROM pg_type t
         JOIN pg_namespace n ON n.oid = t.typnamespace
@@ -369,7 +369,7 @@ async fn fetch_object_inventory_for_wildcards(
             NULL::text AS grantee,
             '' AS privilege_type,
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             CASE c.relkind
                 WHEN 'r' THEN 'table'
                 WHEN 'p' THEN 'table'
@@ -395,7 +395,7 @@ async fn fetch_object_inventory_for_wildcards(
             NULL::text AS grantee,
             '' AS privilege_type,
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             'sequence' AS obj_type
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -426,7 +426,7 @@ async fn fetch_object_inventory_for_wildcards(
             NULL::text AS grantee,
             '' AS privilege_type,
             n.nspname AS schema_name,
-            t.typname AS object_name,
+            t.typname::text AS object_name,
             'type' AS obj_type
         FROM pg_type t
         JOIN pg_namespace n ON n.oid = t.typnamespace
@@ -712,7 +712,7 @@ async fn fetch_wildcard_grantability(
         )
         SELECT
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             pg_get_userbyid(c.relowner) AS owner_name,
             CASE c.relkind
                 WHEN 'r' THEN 'table'
@@ -763,7 +763,7 @@ async fn fetch_wildcard_grantability(
 
         SELECT
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             pg_get_userbyid(c.relowner) AS owner_name,
             'sequence' AS obj_type,
             CASE WHEN owner_grant.can_grant_as_owner THEN scope.need_select
@@ -824,7 +824,7 @@ async fn fetch_wildcard_grantability(
 
         SELECT
             n.nspname AS schema_name,
-            t.typname AS object_name,
+            t.typname::text AS object_name,
             pg_get_userbyid(t.typowner) AS owner_name,
             'type' AS obj_type,
             false AS can_select,
@@ -1102,7 +1102,7 @@ async fn fetch_relation_privileges(
             grantee.rolname AS grantee,
             acl.privilege_type,
             n.nspname AS schema_name,
-            c.relname AS object_name,
+            c.relname::text AS object_name,
             CASE c.relkind
                 WHEN 'r' THEN 'table'
                 WHEN 'p' THEN 'table'
@@ -1141,7 +1141,7 @@ async fn fetch_schema_privileges(
             grantee.rolname AS grantee,
             acl.privilege_type,
             NULL::text AS schema_name,
-            n.nspname AS object_name,
+            n.nspname::text AS object_name,
             'schema' AS obj_type
         FROM pg_namespace n
         CROSS JOIN LATERAL aclexplode(n.nspacl) AS acl
@@ -1208,7 +1208,7 @@ async fn fetch_type_privileges(
             grantee.rolname AS grantee,
             acl.privilege_type,
             n.nspname AS schema_name,
-            t.typname AS object_name,
+            t.typname::text AS object_name,
             'type' AS obj_type
         FROM pg_type t
         JOIN pg_namespace n ON n.oid = t.typnamespace
@@ -1241,7 +1241,7 @@ pub async fn fetch_database_privileges(
             grantee.rolname AS grantee,
             acl.privilege_type,
             NULL::text AS schema_name,
-            db.datname AS object_name,
+            db.datname::text AS object_name,
             'database' AS obj_type
         FROM pg_database db
         CROSS JOIN LATERAL aclexplode(db.datacl) AS acl


### PR DESCRIPTION
## Summary

The wildcard inventory queries (`fetch_object_inventory` and `fetch_object_inventory_for_wildcards`) use `UNION ALL` to assemble per-type rows from `pg_class` / `pg_proc` / `pg_type` / `pg_namespace` / `pg_database`. All branches except the function one project `object_name` as a `name`-typed column (`c.relname`, `t.typname`, `n.nspname`, `db.datname`). The function branch projects
`p.proname || '(' || pg_get_function_identity_arguments(p.oid) || ')'`
which is text.

PostgreSQL resolves the UNION result column to the common type — `name`, capped at 63 bytes — and silently truncates the text-typed function signatures. The per-type privilege queries (`fetch_function_privileges` etc.) are not UNIONed and return the full signature unaffected.

The wildcard satisfaction check in `normalize_wildcard_grants` then iterates inventory (truncated keys) and looks up entries in the grant map (full keys). For any function whose `proname(args)` exceeds 63 bytes, the inventory key is `proname(arg_..._truncate_at_63b` and the grant key is the full signature → no match → `shared_privileges.clear()` → wildcard considered unsatisfied → diff re-emits `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA \"X\" TO \"Y\"` on every reconcile.

This presents as a steady wildcard EXECUTE flap on schemas containing functions with long signatures (overloaded snapshot helpers, functions with multi-arg signatures, functions with custom-typed arguments where the type name is schema-qualified, extension functions like `pg_stat_statements`/`partman`, etc.). The 0.7.2 `UnsatisfiableWildcardGrant` diagnostic doesn't fire because the executor can grant — the grants land successfully, they just aren't recognised as covering the wildcard on the next inspection.

## Reproduction

```sql
CREATE SCHEMA flap;
CREATE FUNCTION flap.compute_thing(parameter_with_a_deliberately_long_identifier integer)
  RETURNS int LANGUAGE sql AS 'SELECT \$1';
REVOKE EXECUTE ON FUNCTION flap.compute_thing(integer) FROM PUBLIC;
CREATE ROLE flap_reader;
```

Manifest:
```yaml
roles:
  - name: flap_reader
grants:
  - role: flap_reader
    privileges: [EXECUTE]
    object: { type: function, schema: flap, name: \"*\" }
```

Before the fix:
```
$ pgroles apply -f manifest.yaml --database-url ...
... 1 grant added
$ pgroles diff -f manifest.yaml --database-url ...
Plan: 1 change(s)
  1 grant(s) to add
GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA \"flap\" TO \"flap_reader\";
```
(Repeats indefinitely — the diff never converges.)

After the fix: the second diff returns `No changes needed`.

## Fix

Cast each `name`-typed `object_name` column to `text` explicitly so the UNION result is uniformly `text`. Four casts across the inventory queries:

- `c.relname → c.relname::text` (×2 in `fetch_object_inventory`, ×2 in `fetch_object_inventory_for_wildcards`)
- `t.typname → t.typname::text`
- `n.nspname → n.nspname::text`
- `db.datname → db.datname::text`

No behavioural change for short identifiers; long function signatures now survive the UNION intact.

## Why this also closes #105's residual

The dev/prod wildcard-flap pattern referenced in #105 has been bounded by 0.7.2's slow-retry path but not converged. On a real database with non-trivial function inventories (custom-typed args, overloaded helpers, extension PUBLIC defaults), the underlying cause is this truncation. Verified locally on a 35-schema database: wildcard EXECUTE flap count drops from 6 (one re-emit per schema) to 0 after a single converging apply.

## Test

Adds `wildcard_function_grant_converges_with_signature_longer_than_63_bytes` to the CLI integration suite (gated on `--ignored` like the other live-DB tests). Creates a function with a 74-byte `proname(identity_args)` signature, applies a wildcard EXECUTE grant, asserts `diff --format summary` returns `No changes needed`.

Without the fix, the assertion fails (the diff still wants to re-emit the wildcard).

## Validation

- `cargo fmt --all -- --check`
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- `SQLX_OFFLINE=true cargo build --workspace`
- New test asserted to fail on `main` and pass on this branch (manual run against a local Postgres)
- Inspected against a 35-schema production-scale database: 6 → 0 wildcard re-emits per reconcile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for wildcard function EXECUTE grant convergence with function signatures exceeding PostgreSQL name limits.

* **Bug Fixes**
  * Updated SQL queries to properly cast object names, ensuring correct type handling across schema, type, and database introspection operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/109)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->