### PR TITLE
[codex] add validated docs for manifests, tooling, and operator plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Full documentation is published at [hardbyte.github.io/pgroles](https://hardbyte
 
 - [Quick start](https://hardbyte.github.io/pgroles/docs/quick-start/)
 - [Installation](https://hardbyte.github.io/pgroles/docs/installation/)
-- [Manifest format](https://hardbyte.github.io/pgroles/docs/manifest-format/)
+- [Manifest guide](https://hardbyte.github.io/pgroles/docs/manifest-format/)
 - [CLI reference](https://hardbyte.github.io/pgroles/docs/cli/)
 - [Kubernetes operator](https://hardbyte.github.io/pgroles/docs/operator/)
 - [Operator architecture](https://hardbyte.github.io/pgroles/docs/operator-architecture/)

--- a/crates/pgroles-cli/README.md
+++ b/crates/pgroles-cli/README.md
@@ -31,4 +31,4 @@ cargo install pgroles-cli
 
 - Project README: <https://github.com/hardbyte/pgroles>
 - CLI docs: <https://github.com/hardbyte/pgroles/tree/main/docs/src/pages/docs/cli.md>
-- Manifest reference: <https://github.com/hardbyte/pgroles/tree/main/docs/src/pages/docs/manifest-format.md>
+- Manifest reference: <https://github.com/hardbyte/pgroles/tree/main/docs/src/pages/docs/manifest-reference.md>

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -2955,7 +2955,7 @@ grants:
         ));
     }
 
-    /// Reproduces the partly-dev15 reconcile flap (May 2026): a manifest
+    /// Reproduces a production reconcile flap: a manifest
     /// with `function name: "*"` should converge in a single apply even when
     /// one of the functions in the schema has been DROPped+CREATEd between
     /// reconciles (resetting its proacl to NULL). Before the fix, the

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -1940,7 +1940,7 @@ memberships:
         }
     }
 
-    /// Reproduces the partly-dev15 reconcile flap (May 2026): when the desired
+    /// Reproduces a production reconcile flap: when the desired
     /// graph has a wildcard grant `(role, schema, type, "*")` and `current`
     /// has only per-name entries (because the inspector's wildcard collapse
     /// failed — typically because at least one inventory object lacks the

--- a/docs/src/components/Layout.jsx
+++ b/docs/src/components/Layout.jsx
@@ -24,7 +24,7 @@ const navigation = [
         title: 'User Guide',
         links: [
             {title: 'Installation', href: '/docs/installation'},
-            {title: 'Manifest format', href: '/docs/manifest-format'},
+            {title: 'Manifest guide', href: '/docs/manifest-format'},
             {title: 'Profiles & schemas', href: '/docs/profiles'},
             {title: 'Grants & privileges', href: '/docs/grants'},
             {title: 'Default privileges', href: '/docs/default-privileges'},
@@ -35,6 +35,7 @@ const navigation = [
         title: 'Deployment',
         links: [
             {title: 'CI/CD integration', href: '/docs/ci-cd'},
+            {title: 'App & migration tools', href: '/docs/tooling'},
             {title: 'Google Cloud SQL', href: '/docs/google-cloud-sql'},
             {title: 'AWS RDS & Aurora', href: '/docs/aws-rds'},
             {title: 'Staged adoption', href: '/docs/adoption'},
@@ -47,6 +48,7 @@ const navigation = [
         links: [
             {title: 'CLI commands', href: '/docs/cli'},
             {title: 'Architecture', href: '/docs/architecture'},
+            {title: 'Manifest reference', href: '/docs/manifest-reference'},
         ],
     },
 ]

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -82,7 +82,7 @@ This split is especially useful when platform owns schema creation/ownership, wh
 
 ## App-owned schemas
 
-Applications that create their own schemas via migrations (e.g. `awa`, `analytics`) now have two viable patterns:
+Applications that create their own schemas via migrations (e.g. `app`, `analytics`) now have two viable patterns:
 
 1. **Let pgroles manage the schema** — declare it under `schemas:` with an optional `owner`, and pgroles can create it before grants/default privileges are applied.
 2. **Let the application manage the schema** — keep using a two-stage manifest where migrations create the schema first, then pgroles applies schema/object grants afterward.

--- a/docs/src/pages/docs/alternatives.md
+++ b/docs/src/pages/docs/alternatives.md
@@ -18,7 +18,7 @@ Terraform is great at creating infrastructure — the database instance, VPC, IA
 - **Convergence** — Terraform manages what's in your `.tf` files. If someone manually adds a `GRANT` via psql, Terraform doesn't know about it and won't revoke it. pgroles treats the manifest as the entire desired state and revokes anything not declared.
 - **Profiles vs combinatorial resources** — 3 schemas × 2 profiles requires 18+ Terraform resources with `depends_on` wiring. In pgroles, define profiles once and bind them to schemas.
 - **Default privileges** — Terraform's `postgresql_grant` only covers *existing* tables at plan time. pgroles pairs wildcard grants with default privileges so future tables are covered too.
-- **Role removal** — Terraform's `postgresql_role` can't cleanly drop a role that owns objects. pgroles has explicit [retirements](/docs/manifest-format) with `reassign_owned_to`, `drop_owned`, and `terminate_sessions`.
+- **Role removal** — Terraform's `postgresql_role` can't cleanly drop a role that owns objects. pgroles has explicit [retirements](/docs/manifest-reference#retirements) with `reassign_owned_to`, `drop_owned`, and `terminate_sessions`.
 - **Managed PostgreSQL awareness** — Terraform's PostgreSQL provider doesn't know about cloud provider limitations. pgroles detects `rds_superuser`, `cloudsqlsuperuser`, and `azure_pg_admin` and warns when your manifest requests unsupported attributes.
 
 **Choose Terraform alone if:** you manage a handful of roles with straightforward grants and no repeating schema patterns.

--- a/docs/src/pages/docs/default-privileges.md
+++ b/docs/src/pages/docs/default-privileges.md
@@ -44,7 +44,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "app_owner"
 
 ## Owner context
 
-The `owner` field specifies which role's object creation triggers the default grant. This is typically the role that runs migrations or creates tables (e.g. `pgloader_pg`, `app_owner`).
+The `owner` field specifies which role's object creation triggers the default grant. This is typically the role that runs migrations or creates tables (e.g. `app_migrator`, `app_owner`).
 
 If `owner` is omitted on a default privilege entry, the top-level `default_owner` is used. If neither is set, it falls back to `postgres`.
 

--- a/docs/src/pages/docs/manifest-format.md
+++ b/docs/src/pages/docs/manifest-format.md
@@ -1,229 +1,137 @@
 ---
-title: Manifest format
-description: Complete reference for the pgroles YAML manifest schema.
+title: Manifest guide
+description: How pgroles manifest sections fit together when designing a policy.
 ---
 
-A pgroles manifest is a YAML file that declares the desired state of your PostgreSQL roles, schemas, grants, default privileges, and memberships. {% .lead %}
+A pgroles manifest declares the desired state of PostgreSQL access control: who can log in, which group roles exist, what they can access, and what future objects should inherit. {% .lead %}
 
 ---
 
-## Top-level fields
+## The shape of a manifest
+
+Most manifests combine four ideas:
+
+- `roles` define PostgreSQL roles and login attributes
+- `grants` define access to current database objects
+- `default_privileges` define access for objects created later
+- `memberships` connect login roles to group roles
+
+For larger databases, `profiles` and `schemas` remove repetition by expanding one privilege template across many schemas. For field-by-field details, use the [manifest reference](/docs/manifest-reference).
+
+## A complete application example
 
 ```yaml
-default_owner: pgloader_pg       # Owner for ALTER DEFAULT PRIVILEGES
-auth_providers: []                # Cloud IAM provider declarations
-profiles: {}                      # Reusable privilege templates
-schemas: []                       # Managed schemas and schema-profile bindings
-roles: []                         # Role definitions
-grants: []                        # Object privilege grants
-default_privileges: []            # Default privilege rules
-memberships: []                   # Role membership edges
-```
+default_owner: app_migrator
 
-All fields are optional. A minimal manifest might only define `roles` and `grants`.
-
-## Bundle mode
-
-The CLI can also compose a **bundle** from one root file plus multiple scoped policy documents:
-
-```yaml
-# pgroles.bundle.yaml
-shared:
-  default_owner: app_owner
-  profiles:
-    editor:
-      grants:
-        - privileges: [USAGE]
-          object: { type: schema }
-sources:
-  - file: platform.yaml
-  - file: app.yaml
-```
-
-Each source file is a `PolicyFragment`:
-
-```yaml
-# platform.yaml
-policy:
-  name: platform
-scope:
-  roles: [app_owner]
-  schemas:
-    - name: inventory
-      facets: [owner]
-
-roles:
-  - name: app_owner
-
-schemas:
-  - name: inventory
-    owner: app_owner
-```
-
-```yaml
-# app.yaml
-policy:
-  name: app
-scope:
-  schemas:
-    - name: inventory
-      facets: [bindings]
-
-schemas:
-  - name: inventory
-    profiles: [editor]
-```
-
-Bundle composition is currently a CLI/core feature. The Kubernetes operator still reconciles a single `PostgresPolicy` resource.
-
-### Shared bundle fields
-
-| Field | Description |
-|---|---|
-| `shared.default_owner` | Default owner context shared across source documents |
-| `shared.auth_providers` | Shared auth provider metadata |
-| `shared.profiles` | Shared profile registry used by source documents |
-| `sources` | Relative file paths to policy documents that will be composed together |
-
-### Policy fragment fields
-
-Each source document adds two fields on top of the normal manifest content:
-
-| Field | Description |
-|---|---|
-| `policy.name` | Human-readable source label used in conflict and plan output |
-| `scope` | The ownership boundary this document is allowed to manage |
-
-### Scoped schema facets
-
-Schema scope is split into explicit facets:
-
-| Facet | Description |
-|---|---|
-| `owner` | Manage schema creation and ownership convergence |
-| `bindings` | Manage profile expansion, grants, and default privileges tied to the schema |
-
-Two source documents may reference the same schema only when they manage disjoint facets. If two documents claim the same role, grant, default-privilege rule, membership selector, or schema facet, composition fails before any database inspection begins.
-
-## auth_providers
-
-Declare cloud authentication providers to document how IAM-mapped roles connect to the database. This is currently informational metadata used for validation and documentation purposes.
-
-```yaml
-auth_providers:
-  - type: cloud_sql_iam
-    project: my-gcp-project
-  - type: alloydb_iam
-    project: my-gcp-project
-    cluster: analytics-prod
-  - type: rds_iam
-    region: us-east-1
-  - type: azure_ad
-    tenant_id: "00000000-0000-0000-0000-000000000000"
-  - type: supabase
-    project_ref: abcd1234
-  - type: planet_scale
-    organization: my-org
-```
-
-Supported provider types:
-
-| Type | Description |
-|---|---|
-| `cloud_sql_iam` | Google Cloud SQL IAM authentication. Optional `project` field. |
-| `alloydb_iam` | Google AlloyDB IAM authentication. Optional `project` and `cluster` fields. |
-| `rds_iam` | AWS RDS/Aurora IAM authentication. Optional `region` field. |
-| `azure_ad` | Azure Active Directory authentication. Optional `tenant_id` field. |
-| `supabase` | Supabase PostgreSQL metadata. Optional `project_ref` field. |
-| `planet_scale` | PlanetScale PostgreSQL metadata. Optional `organization` field. |
-
-{% callout type="note" title="Managed service metadata is intentionally narrow" %}
-The `auth_providers` block models the provider types listed above, but not every variant has provider-specific runtime behavior yet. Today the privilege-warning path has explicit detection for RDS/Aurora, Cloud SQL, AlloyDB, and Azure. Supabase and PlanetScale PostgreSQL entries are currently documentation and validation metadata.
-{% /callout %}
-
-## default_owner
-
-The `default_owner` field specifies which role is used as the owner context for `ALTER DEFAULT PRIVILEGES` statements. This is typically the role that creates objects in your database (e.g. a migration runner or loader role).
-
-```yaml
-default_owner: pgloader_pg
-```
-
-Individual schemas can override this with their own `owner` field.
-
-## profiles
-
-Profiles are reusable templates that expand into concrete roles, grants, and default privileges when bound to schemas.
-
-```yaml
 profiles:
-  editor:
-    login: false
-    inherit: false
+  app_writer:
     grants:
       - privileges: [USAGE]
         object: { type: schema }
       - privileges: [SELECT, INSERT, UPDATE, DELETE]
         object: { type: table, name: "*" }
+      - privileges: [USAGE, SELECT, UPDATE]
+        object: { type: sequence, name: "*" }
     default_privileges:
       - privileges: [SELECT, INSERT, UPDATE, DELETE]
         on_type: table
+      - privileges: [USAGE, SELECT, UPDATE]
+        on_type: sequence
+
+  readonly:
+    grants:
+      - privileges: [USAGE]
+        object: { type: schema }
+      - privileges: [SELECT]
+        object: { type: table, name: "*" }
+    default_privileges:
+      - privileges: [SELECT]
+        on_type: table
+
+schemas:
+  - name: app
+    owner: app_migrator
+    profiles: [app_writer, readonly]
+
+roles:
+  - name: app_migrator
+    login: true
+  - name: app_runtime
+    login: true
+  - name: analyst
+    login: true
+
+memberships:
+  - role: app-app_writer
+    members:
+      - name: app_runtime
+  - role: app-readonly
+    members:
+      - name: analyst
 ```
 
-### Profile fields
+This produces two schema-scoped group roles:
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `login` | bool | `false` | Login attribute for generated roles |
-| `inherit` | bool | `true` | Inherit attribute for generated roles |
-| `grants` | list[grant template] | `[]` | Grants expanded into each bound schema |
-| `default_privileges` | list[default privilege template] | `[]` | Default privileges expanded into each bound schema |
+- `app-app_writer`, with read/write table access and sequence access in the `app` schema
+- `app-readonly`, with read-only table access in the `app` schema
 
-The generated role attributes apply only to roles created from `schema x profile` expansion. One-off roles under `roles:` still declare their own attributes directly.
+The login roles (`app_runtime`, `analyst`) get access through memberships rather than direct grants. This keeps runtime connection strings stable while letting you change profile grants in one place.
 
-## schemas
+## How the sections connect
 
-The `schemas` section serves two related purposes:
+| Section | Defines | Referenced by |
+|---|---|---|
+| [`default_owner`](/docs/manifest-reference#default_owner) | Default object-creator role for future grants | `default_privileges`, `profiles`, `schemas` |
+| [`profiles`](/docs/manifest-reference#profiles) | Reusable schema-relative grant templates | `schemas[].profiles` |
+| [`schemas`](/docs/manifest-reference#schemas) | Managed schemas and profile bindings | `profiles`, generated roles, generated grants |
+| [`roles`](/docs/manifest-reference#roles) | Explicit PostgreSQL roles | `grants`, `memberships`, `default_privileges` |
+| [`grants`](/docs/manifest-reference#grants) | Current object privileges | role names and object targets |
+| [`default_privileges`](/docs/manifest-reference#default_privileges) | Future object privileges | owner roles, grantee roles, schemas |
+| [`memberships`](/docs/manifest-reference#memberships) | Role inheritance edges | parent roles and member roles |
+| [`retirements`](/docs/manifest-reference#retirements) | Safe role removal workflow | roles omitted from desired state |
 
-- declare schemas pgroles should manage
-- bind profiles to those schemas so profile-generated roles and grants are expanded
+## Choosing direct grants or profiles
+
+Use direct top-level `grants` for one-off roles or database-level privileges:
 
 ```yaml
-schemas:
-  - name: inventory
-    owner: app_owner
-    profiles: [editor, viewer]
+roles:
+  - name: analytics
+    login: true
 
-  - name: cdc
-    owner: cdc_owner
-    profiles: []
+grants:
+  - role: analytics
+    privileges: [CONNECT]
+    object: { type: database, name: mydb }
+  - role: analytics
+    privileges: [USAGE]
+    object: { type: schema, name: reporting }
+  - role: analytics
+    privileges: [SELECT]
+    object: { type: table, schema: reporting, name: "*" }
 ```
 
-### Schema fields
+Use profiles when the same access shape repeats across schemas:
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `name` | string | *required* | Schema name |
-| `profiles` | list[string] | `[]` | Profiles to expand for this schema |
-| `owner` | string | `default_owner` | Desired schema owner; if omitted and `default_owner` is unset, pgroles only ensures the schema exists |
-| `role_pattern` | string | `"{schema}-{profile}"` | Naming pattern for profile-generated roles |
+```yaml
+profiles:
+  reader:
+    grants:
+      - privileges: [USAGE]
+        object: { type: schema }
+      - privileges: [SELECT]
+        object: { type: table, name: "*" }
 
-### Schema ownership and creation
+schemas:
+  - name: inventory
+    profiles: [reader]
+  - name: catalog
+    profiles: [reader]
+```
 
-When a schema is declared under `schemas:`:
+## Declared vs referenced schemas
 
-- pgroles can create it if it does not exist
-- pgroles can converge its owner with `ALTER SCHEMA ... OWNER TO ...`
-- pgroles does not manage dropping schemas
-- pgroles does not reassign ownership of objects inside the schema
-
-If a schema is only referenced from top-level `grants:` or `default_privileges:` and is not declared under `schemas:`, it must already exist.
-
-{% callout type="note" title="Additive mode and schema bindings" %}
-In `additive` mode, pgroles still creates missing generated roles and grants, but it does not rewrite attributes or comments on pre-existing roles. If a generated role already exists with different attributes, additive mode leaves it unchanged until you switch to a mode that allows full convergence.
-{% /callout %}
-
-### Declared vs referenced example
+Declared schemas can be created and have their owner converged by pgroles. Referenced-only schemas must already exist:
 
 ```yaml
 schemas:
@@ -246,152 +154,15 @@ In this example:
 - `app_managed` is declared under `schemas:`, so pgroles can create it and set its owner.
 - `existing_warehouse` is only referenced from a top-level grant, so it must already exist before `apply` runs.
 
-## roles
+## Wildcard grants and future objects
 
-Each role definition specifies a PostgreSQL role and its attributes:
+Use `name: "*"` to grant on all current objects of a type in a schema. pgroles expands relation wildcards safely by object type, so `table`, `view`, and `materialized_view` privileges do not bleed across each other.
 
-```yaml
-roles:
-  - name: analytics
-    login: true
-    comment: "Analytics read-only role"
-  - name: app-service
-    login: true
-    createdb: false
-    connection_limit: 10
-    password:
-      from_env: APP_SERVICE_PASSWORD
-    password_valid_until: "2026-12-31T00:00:00Z"
-```
+Pair wildcard grants with `default_privileges` when the same role should access future objects created by the migration or owner role. Wildcards cover existing objects at reconcile time; default privileges cover objects created later.
 
-### Supported attributes
-
-| Attribute | Type | Default | Description |
-|---|---|---|---|
-| `name` | string | *required* | Role name |
-| `login` | bool | `false` | Can the role log in? |
-| `superuser` | bool | `false` | Superuser privileges |
-| `createdb` | bool | `false` | Can create databases |
-| `createrole` | bool | `false` | Can create other roles |
-| `inherit` | bool | `true` | Inherits privileges of granted roles |
-| `replication` | bool | `false` | Can initiate replication |
-| `bypassrls` | bool | `false` | Bypasses row-level security |
-| `connection_limit` | int | `-1` (unlimited) | Max concurrent connections |
-| `comment` | string | *none* | Comment on the role |
-| `password` | object | *none* | Password source (see below) |
-| `password_valid_until` | string | *none* | Password expiration (ISO 8601) |
-
-Unspecified attributes use PostgreSQL defaults.
-
-### Passwords
-
-Roles with `login: true` can declare a password source. The password value is never stored in the manifest — it is resolved at apply time from an environment variable (CLI) or a Kubernetes Secret (operator).
-
-```yaml
-roles:
-  - name: app-service
-    login: true
-    password:
-      from_env: APP_SERVICE_PASSWORD   # CLI: read from this env var
-    password_valid_until: "2026-12-31T00:00:00Z"
-```
-
-- `password.from_env` — the environment variable name containing the password (CLI mode).
-- `password_valid_until` — an ISO 8601 timestamp (e.g. `"2025-12-31T00:00:00Z"`) that sets the PostgreSQL `VALID UNTIL` attribute on the role. The timestamp must include a date, time, and timezone indicator.
-
-Only `login: true` roles may have a password. Declaring a password on a non-login role is a validation error.
-
-{% callout type="note" title="Passwords and drift detection" %}
-Because PostgreSQL does not expose password hashes for comparison, password changes always appear in the plan. The `diff --exit-code` flag treats password-only changes as non-structural — they will **not** trigger exit code 2.
+{% callout type="note" title="Managed owners still need declared privileges" %}
+If the role that owns tables or functions is also inside pgroles' managed role set, declare the privileges you want that owner role to keep. PostgreSQL owners effectively have broad privileges on their own objects, and pgroles treats undeclared current privileges as drift in `authoritative` mode.
 {% /callout %}
-
-{% callout type="warning" title="Password values are never logged" %}
-pgroles redacts password values in all log output, dry-run SQL, and operator status fields. The actual password is only used in the `ALTER ROLE ... PASSWORD` statement sent to PostgreSQL inside the apply transaction.
-{% /callout %}
-
-## grants
-
-Grants define object privileges:
-
-```yaml
-grants:
-  - role: analytics
-    privileges: [SELECT]
-    object: { type: table, schema: public, name: "*" }
-  - role: analytics
-    privileges: [USAGE]
-    object: { type: schema, name: public }
-  - role: analytics
-    privileges: [CONNECT]
-    object: { type: database, name: mydb }
-```
-
-### Object target
-
-The `object` field specifies the grant target:
-
-| Field | Description |
-|---|---|
-| `type` | Object type (see below) |
-| `schema` | Schema name (required for most types except `schema` and `database`) |
-| `name` | Object name, `"*"` for all objects, or omit for schema-level grants |
-
-pgroles also accepts a quoted legacy `"on"` key when parsing older manifests, but `object` is the supported spelling for new manifests and generated output.
-
-### Object types
-
-Supported values for `type`: `table`, `view`, `materialized_view`, `sequence`, `function`, `schema`, `database`, `type`.
-
-### Wildcard grants
-
-Use `name: "*"` to grant on all current objects of a type in a schema. pgroles
-expands relation wildcards safely by object type, so `table`, `view`, and
-`materialized_view` privileges do not bleed across each other.
-
-Wildcard grants are strict: every matching current object must either already
-have the requested privilege or be grantable by the database user running
-pgroles. If a matching object is missing the privilege and the executor lacks
-the corresponding `WITH GRANT OPTION`, `diff`, `plan`, and `apply` stop with an
-`UnsatisfiableWildcardGrant` diagnostic instead of emitting a repeating wildcard
-`GRANT`.
-
-## default_privileges
-
-Default privileges configure what happens when new objects are created:
-
-```yaml
-default_privileges:
-  - owner: pgloader_pg
-    schema: public
-    grant:
-      - role: analytics
-        privileges: [SELECT]
-        on_type: table
-      - role: analytics
-        privileges: [USAGE, SELECT]
-        on_type: sequence
-```
-
-If `owner` is omitted, the top-level `default_owner` is used.
-
-## memberships
-
-Memberships declare which roles are members of other roles:
-
-```yaml
-memberships:
-  - role: editors
-    members:
-      - name: "user@example.com"
-        inherit: true
-      - name: "admin@example.com"
-        admin: true
-```
-
-| Field | Default | Description |
-|---|---|---|
-| `inherit` | `true` | Member inherits the role's privileges (optional, omit for default) |
-| `admin` | `false` | Member can administer the role (optional, omit for default) |
 
 ## Convergent model
 
@@ -399,25 +170,4 @@ memberships:
 The manifest represents the **entire desired state**. Roles, grants, default privileges, and memberships that exist in the database but are absent from the manifest will be dropped or revoked. Declared schemas are created and their owner may be converged, but schemas are not dropped automatically. Only declare roles and schemas that pgroles should manage.
 {% /callout %}
 
-## retirements
-
-When removing a role that owns objects, declare a retirement workflow so pgroles can safely clean up before dropping it:
-
-```yaml
-retirements:
-  - role: legacy_app
-    reassign_owned_to: app_owner
-    drop_owned: true
-    terminate_sessions: true
-```
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `role` | string | *required* | The role to retire and ultimately drop |
-| `reassign_owned_to` | string | *none* | Successor role for `REASSIGN OWNED BY ... TO ...` |
-| `drop_owned` | bool | `false` | Run `DROP OWNED BY` before dropping the role |
-| `terminate_sessions` | bool | `false` | Terminate other active sessions for the role before dropping it |
-
-Retired roles are included in the inspection scope even though they are absent from the desired role list. The generated plan inserts session termination, `REASSIGN OWNED`, and/or `DROP OWNED` immediately before the `DROP ROLE` statement.
-
-A retirement entry cannot reference a role that is also listed in `roles` (that would be contradictory), and a role cannot reassign ownership to itself.
+Next: use the [manifest reference](/docs/manifest-reference) for exact field names, defaults, and bundle-mode details.

--- a/docs/src/pages/docs/manifest-reference.md
+++ b/docs/src/pages/docs/manifest-reference.md
@@ -1,0 +1,327 @@
+---
+title: Manifest reference
+description: Complete reference for the pgroles YAML manifest schema.
+---
+
+Complete field reference for pgroles manifests and CLI bundle files. {% .lead %}
+
+---
+
+## Top-level fields
+
+All top-level manifest fields are optional:
+
+```yaml
+default_owner: app_migrator      # Owner for ALTER DEFAULT PRIVILEGES
+auth_providers: []                # Cloud IAM provider declarations
+profiles: {}                      # Reusable privilege templates
+schemas: []                       # Managed schemas and schema-profile bindings
+roles: []                         # Role definitions
+grants: []                        # Object privilege grants
+default_privileges: []            # Default privilege rules
+memberships: []                   # Role membership edges
+retirements: []                   # Safe role removal workflows
+```
+
+## auth_providers
+
+Declare cloud authentication providers to document how IAM-mapped roles connect to the database. This is currently informational metadata used for validation and documentation purposes.
+
+```yaml
+auth_providers:
+  - type: cloud_sql_iam
+    project: my-gcp-project
+  - type: alloydb_iam
+    project: my-gcp-project
+    cluster: analytics-prod
+  - type: rds_iam
+    region: us-east-1
+  - type: azure_ad
+    tenant_id: "00000000-0000-0000-0000-000000000000"
+  - type: supabase
+    project_ref: abcd1234
+  - type: planet_scale
+    organization: my-org
+```
+
+| Type | Description |
+|---|---|
+| `cloud_sql_iam` | Google Cloud SQL IAM authentication. Optional `project` field. |
+| `alloydb_iam` | Google AlloyDB IAM authentication. Optional `project` and `cluster` fields. |
+| `rds_iam` | AWS RDS/Aurora IAM authentication. Optional `region` field. |
+| `azure_ad` | Azure Active Directory authentication. Optional `tenant_id` field. |
+| `supabase` | Supabase PostgreSQL metadata. Optional `project_ref` field. |
+| `planet_scale` | PlanetScale PostgreSQL metadata. Optional `organization` field. |
+
+{% callout type="note" title="Managed service metadata is intentionally narrow" %}
+The `auth_providers` block models the provider types listed above, but not every variant has provider-specific runtime behavior yet. Today the privilege-warning path has explicit detection for RDS/Aurora, Cloud SQL, AlloyDB, and Azure. Supabase and PlanetScale PostgreSQL entries are currently documentation and validation metadata.
+{% /callout %}
+
+## default_owner
+
+The `default_owner` field specifies which role is used as the owner context for `ALTER DEFAULT PRIVILEGES` statements. This is typically the role that creates objects in your database.
+
+```yaml
+default_owner: app_migrator
+```
+
+Individual schemas can override this with their own `owner` field.
+
+## profiles
+
+Profiles are reusable templates that expand into concrete roles, grants, and default privileges when bound to schemas.
+
+```yaml
+profiles:
+  editor:
+    login: false
+    inherit: false
+    grants:
+      - privileges: [USAGE]
+        object: { type: schema }
+      - privileges: [SELECT, INSERT, UPDATE, DELETE]
+        object: { type: table, name: "*" }
+    default_privileges:
+      - privileges: [SELECT, INSERT, UPDATE, DELETE]
+        on_type: table
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `login` | bool | `false` | Login attribute for generated roles |
+| `inherit` | bool | `true` | Inherit attribute for generated roles |
+| `grants` | list[grant template] | `[]` | Grants expanded into each bound schema |
+| `default_privileges` | list[default privilege template] | `[]` | Default privileges expanded into each bound schema |
+
+The generated role attributes apply only to roles created from `schema x profile` expansion. One-off roles under `roles:` still declare their own attributes directly.
+
+## schemas
+
+The `schemas` section declares schemas pgroles should manage and binds profiles to those schemas.
+
+```yaml
+schemas:
+  - name: inventory
+    owner: app_owner
+    profiles: [editor, viewer]
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | *required* | Schema name |
+| `profiles` | list[string] | `[]` | Profiles to expand for this schema |
+| `owner` | string | `default_owner` | Desired schema owner; if omitted and `default_owner` is unset, pgroles only ensures the schema exists |
+| `role_pattern` | string | `"{schema}-{profile}"` | Naming pattern for profile-generated roles |
+
+When a schema is declared under `schemas:`, pgroles can create it if it does not exist and can converge its owner with `ALTER SCHEMA ... OWNER TO ...`. pgroles does not drop schemas or reassign ownership of objects inside the schema.
+
+## roles
+
+Each role definition specifies a PostgreSQL role and its attributes:
+
+```yaml
+roles:
+  - name: analytics
+    login: true
+    comment: "Analytics read-only role"
+  - name: app-service
+    login: true
+    createdb: false
+    connection_limit: 10
+    password:
+      from_env: APP_SERVICE_PASSWORD
+    password_valid_until: "2026-12-31T00:00:00Z"
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | *required* | Role name |
+| `login` | bool | `false` | Can the role log in? |
+| `superuser` | bool | `false` | Superuser privileges |
+| `createdb` | bool | `false` | Can create databases |
+| `createrole` | bool | `false` | Can create other roles |
+| `inherit` | bool | `true` | Inherits privileges of granted roles |
+| `replication` | bool | `false` | Can initiate replication |
+| `bypassrls` | bool | `false` | Bypasses row-level security |
+| `connection_limit` | int | `-1` (unlimited) | Max concurrent connections |
+| `comment` | string | *none* | Comment on the role |
+| `password` | object | *none* | Password source |
+| `password_valid_until` | string | *none* | Password expiration (ISO 8601) |
+
+Roles with `login: true` can declare a password source. The password value is never stored in the manifest; it is resolved at apply time from an environment variable in CLI mode or from a Kubernetes Secret in operator mode.
+
+Only `login: true` roles may have a password. Declaring a password on a non-login role is a validation error.
+
+{% callout type="note" title="Passwords and drift detection" %}
+Because PostgreSQL does not expose password hashes for comparison, password changes always appear in the plan. The `diff --exit-code` flag treats password-only changes as non-structural; they do not trigger exit code 2.
+{% /callout %}
+
+## grants
+
+Grants define object privileges:
+
+```yaml
+grants:
+  - role: analytics
+    privileges: [SELECT]
+    object: { type: table, schema: public, name: "*" }
+  - role: analytics
+    privileges: [USAGE]
+    object: { type: schema, name: public }
+  - role: analytics
+    privileges: [CONNECT]
+    object: { type: database, name: mydb }
+```
+
+The `object` field specifies the grant target:
+
+| Field | Description |
+|---|---|
+| `type` | Object type |
+| `schema` | Schema name; required for most types except `schema` and `database` |
+| `name` | Object name, `"*"` for all objects, or omit for schema-level grants |
+
+Supported object `type` values: `table`, `view`, `materialized_view`, `sequence`, `function`, `schema`, `database`, `type`.
+
+pgroles also accepts a quoted legacy `"on"` key when parsing older manifests, but `object` is the supported spelling for new manifests and generated output.
+
+## default_privileges
+
+Default privileges configure what happens when new objects are created:
+
+```yaml
+default_privileges:
+  - owner: app_migrator
+    schema: app
+    grant:
+      - role: app_migrator
+        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
+        on_type: table
+      - role: app_migrator
+        privileges: [USAGE, SELECT, UPDATE]
+        on_type: sequence
+      - role: analytics
+        privileges: [SELECT]
+        on_type: table
+```
+
+If `owner` is omitted, the top-level `default_owner` is used.
+
+## memberships
+
+Memberships declare which roles are members of other roles:
+
+```yaml
+memberships:
+  - role: editors
+    members:
+      - name: "user@example.com"
+        inherit: true
+      - name: "admin@example.com"
+        admin: true
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `inherit` | `true` | Member inherits the role's privileges; omit for PostgreSQL default behavior |
+| `admin` | `false` | Member can administer the role |
+
+## retirements
+
+When removing a role that owns objects, declare a retirement workflow so pgroles can safely clean up before dropping it:
+
+```yaml
+retirements:
+  - role: legacy_app
+    reassign_owned_to: app_owner
+    drop_owned: true
+    terminate_sessions: true
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `role` | string | *required* | The role to retire and ultimately drop |
+| `reassign_owned_to` | string | *none* | Successor role for `REASSIGN OWNED BY ... TO ...` |
+| `drop_owned` | bool | `false` | Run `DROP OWNED BY` before dropping the role |
+| `terminate_sessions` | bool | `false` | Terminate other active sessions for the role before dropping it |
+
+Retired roles are included in the inspection scope even though they are absent from the desired role list. The generated plan inserts session termination, `REASSIGN OWNED`, and/or `DROP OWNED` immediately before the `DROP ROLE` statement.
+
+## Bundle mode
+
+The CLI can compose a bundle from one root file plus multiple scoped policy documents. Use this when different teams own different parts of the same database policy.
+
+```yaml
+# pgroles.bundle.yaml
+shared:
+  default_owner: app_owner
+  profiles:
+    editor:
+      grants:
+        - privileges: [USAGE]
+          object: { type: schema }
+sources:
+  - file: platform.yaml
+  - file: app.yaml
+```
+
+Each source file is a `PolicyFragment`:
+
+```yaml
+# platform.yaml
+policy:
+  name: platform
+scope:
+  roles: [app_owner]
+  schemas:
+    - name: inventory
+      facets: [owner]
+
+roles:
+  - name: app_owner
+
+schemas:
+  - name: inventory
+    owner: app_owner
+```
+
+```yaml
+# app.yaml
+policy:
+  name: app
+scope:
+  schemas:
+    - name: inventory
+      facets: [bindings]
+
+schemas:
+  - name: inventory
+    profiles: [editor]
+```
+
+Bundle composition is currently a CLI/core feature. The Kubernetes operator still reconciles a single `PostgresPolicy` resource.
+
+### Shared bundle fields
+
+| Field | Description |
+|---|---|
+| `shared.default_owner` | Default owner context shared across source documents |
+| `shared.auth_providers` | Shared auth provider metadata |
+| `shared.profiles` | Shared profile registry used by source documents |
+| `sources` | Relative file paths to policy documents that will be composed together |
+
+### Policy fragment fields
+
+| Field | Description |
+|---|---|
+| `policy.name` | Human-readable source label used in conflict and plan output |
+| `scope` | The ownership boundary this document is allowed to manage |
+
+Schema scope is split into explicit facets:
+
+| Facet | Description |
+|---|---|
+| `owner` | Manage schema creation and ownership convergence |
+| `bindings` | Manage profile expansion, grants, and default privileges tied to the schema |
+
+Two source documents may reference the same schema only when they manage disjoint facets. If two documents claim the same role, grant, default-privilege rule, membership selector, or schema facet, composition fails before any database inspection begins.

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -120,7 +120,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 
 **Scale and HA:**
 
-- The largest tested workload is 200 roles / 100 schemas / 5 policies (scheduled CI, not PR CI).
+- Validate reconcile performance at your target object count before relying on the operator for large role and schema inventories.
 - Advisory locks enable multi-replica deployment, but there is no documented HA pattern, replica guidance, or failure-mode analysis.
 
 **Password drift visibility:**
@@ -129,7 +129,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 
 **Managed provider validation:**
 
-- RDS, Cloud SQL, AlloyDB, and Azure detection is implemented but not validated against live managed instances.
+- Treat managed-provider detection as environment-specific. Verify behavior against your target RDS, Cloud SQL, AlloyDB, or Azure PostgreSQL instance before relying on provider-specific SQL planning.
 
 **Deployment security:**
 
@@ -432,18 +432,127 @@ spec:
 
 Plan mode is useful when you want the operator to stay in-cluster but you are not ready to trust it with PostgreSQL mutations yet.
 
-Current behavior in `plan` mode:
+In `plan` mode:
 
 - the operator connects to the database and computes the full diff normally
 - no PostgreSQL SQL is executed
 - `status.change_summary` records the pending changes
 - `status.planned_sql` stores the rendered SQL, truncated if needed for status size safety
+- `status.current_plan_ref.name` points at the generated `PostgresPolicyPlan`
 - `Ready=True` with reason `Planned`
 - `Drifted=True` when changes are pending, `Drifted=False` when the database is already in sync
-- for `password.generate`, the controller may still create or recreate the generated Kubernetes Secret while resolving password inputs for the plan
-- for password-managed roles, `Drifted=False` is only possible after a prior successful `apply` recorded the password source version; a plan-only policy cannot prove an existing database password already matches its Secret
+- for `password.generate`, the controller does not create or recreate the generated Kubernetes Secret while running in `plan` mode
+- for password-managed roles, `Drifted=False` is only possible after a prior successful `apply` recorded the password source version; a plan-only policy cannot prove an existing database password already matches the configured source
+
+Example `kubectl get` output:
+
+```text
+NAME          READY   MODE   DRIFT   CHANGES   LAST RECONCILE   AGE
+plan-policy   True    plan   True    2         2s               2s
+```
+
+Example status fields:
+
+```yaml
+status:
+  change_summary:
+    grants_added: 1
+    roles_created: 1
+    total: 2
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: Planned
+      message: Plan computed; 2 change(s) pending
+    - type: Drifted
+      status: "True"
+      reason: DriftDetected
+      message: 2 planned change(s) pending review
+  current_plan_ref:
+    name: plan-policy-plan-20260512-090308-118e50e437c9
+  last_reconcile_mode: plan
+  planned_sql: |-
+    CREATE ROLE "plan-preview-user" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
+    COMMENT ON ROLE "plan-preview-user" IS 'Preview-only role';
+    GRANT CONNECT ON DATABASE "postgres" TO "plan-preview-user";
+  planned_sql_truncated: false
+```
 
 Use `suspend` when you want the controller to stop reconciling entirely. Use `plan` when you want it to keep inspecting and showing you what it would do.
+
+### Plan approval resources
+
+When `spec.approval: manual` is used with `mode: apply`, the operator creates a `PostgresPolicyPlan` and waits for approval instead of immediately executing the SQL.
+
+```yaml
+spec:
+  connection:
+    secretRef:
+      name: postgres-credentials
+  mode: apply
+  approval: manual
+```
+
+A generated plan looks like this:
+
+```text
+NAME                                                     POLICY                 MODE            APPROVED   CHANGES   PHASE     AGE
+plan-approval-policy-plan-20260512-090318-454373251739   plan-approval-policy   authoritative   False      2         Pending   3s
+```
+
+Approve it by annotating the plan:
+
+```shell
+kubectl annotate pgplan plan-approval-policy-plan-20260512-090318-454373251739 \
+  pgroles.io/approved=true --overwrite
+```
+
+After approval, the plan moves to `Applied`:
+
+```text
+NAME                                                     POLICY                 MODE            APPROVED   CHANGES   PHASE     AGE
+plan-approval-policy-plan-20260512-090318-454373251739   plan-approval-policy   authoritative   True       2         Applied   5s
+```
+
+The plan status included:
+
+```yaml
+status:
+  appliedAt: "2026-05-12T09:03:21Z"
+  changeSummary:
+    grants_added: 1
+    roles_created: 1
+    total: 2
+  conditions:
+    - type: Computed
+      status: "True"
+      reason: PlanComputed
+      message: Plan computed with 2 change(s)
+    - type: Approved
+      status: "True"
+      reason: Approved
+      message: Plan approved and executed
+  phase: Applied
+  sqlHash: 454373251739fdfbe188ae07358b01d9e0465eb47011fe2d4f386fa34ef7de1b
+  sqlInline: |-
+    CREATE ROLE "approval_test_user" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
+    GRANT CONNECT ON DATABASE "postgres" TO "approval_test_user";
+  sqlStatements: 2
+  sqlTruncated: false
+```
+
+With `spec.approval: auto`, the operator creates a `PostgresPolicyPlan` and applies it immediately:
+
+```text
+NAME                                                     POLICY                 MODE            APPROVED   CHANGES   PHASE     AGE
+auto-approval-policy-plan-20260512-090329-11a6ca1d7c09   auto-approval-policy   authoritative   True       2         Applied   2s
+```
+
+The corresponding database role is present after reconcile:
+
+```text
+auto_approved_user
+```
 
 ### Reconciliation mode
 

--- a/docs/src/pages/docs/tooling.md
+++ b/docs/src/pages/docs/tooling.md
@@ -1,0 +1,174 @@
+---
+title: Application and migration tools
+description: How pgroles fits beside ORMs, SQL migration tools, and PostgreSQL client libraries.
+---
+
+Use pgroles as the access-control layer next to your existing schema and application tooling. {% .lead %}
+
+Most PostgreSQL stacks already have something that creates tables, indexes, functions, and application metadata. Keep using that tool for schema changes. Let pgroles own roles, memberships, grants, default privileges, and role retirement.
+
+---
+
+## The boundary
+
+pgroles is intentionally not a schema migration framework. It does not create tables, rewrite indexes, manage row-level security policies, or replace an ORM's migration history.
+
+The clean split is:
+
+| Layer | Typical tools | Owner |
+| --- | --- | --- |
+| Infrastructure | Terraform, Pulumi, cloud consoles | Database instances, networking, IAM |
+| Schema migrations | Alembic/SQLAlchemy | Tables, views, functions, types, extensions |
+| Access control | pgroles | Roles, memberships, grants, default privileges, passwords, retirements |
+| Runtime queries | SQLAlchemy, PostgreSQL client connections | Application reads and writes |
+
+This avoids the common failure mode where every migration tool, app bootstrap script, and operator tries to issue `GRANT` statements independently.
+
+## Recommended order
+
+For each environment, run access control after the database exists and before application traffic relies on new privileges:
+
+```shell
+# 1. Apply schema migrations
+alembic upgrade head
+
+# 2. Apply role and privilege policy
+pgroles diff -f pgroles.yaml --database-url "$DATABASE_URL"
+pgroles apply -f pgroles.yaml --database-url "$DATABASE_URL"
+
+# 3. Deploy or restart application workloads
+```
+
+If a migration creates new tables in an already-managed schema, pgroles usually has two safety nets:
+
+- wildcard grants cover objects that already exist when pgroles runs
+- default privileges cover future objects created by the configured owner
+
+If a migration needs a brand-new schema, either declare that schema in pgroles so pgroles creates it and converges its PostgreSQL owner, or run the migration first and then apply the pgroles policy that grants access to the existing schema.
+
+## Migration tools
+
+### Validated DDL-owning tools
+
+Some PostgreSQL libraries run DDL even though they are not ORMs. Treat these like schema owners, not like ordinary application clients.
+
+Concrete DDL-owning patterns:
+
+| Pattern | Behavior | pgroles guidance |
+| --- | --- | --- |
+| pg-boss queue schema | pg-boss can create a custom schema and queue through an installer role. A separate worker role can run with `migrate: false` after receiving schema/table/sequence/function grants. | Run pg-boss schema setup with an installer role, then use pgroles for worker access. Disable runtime migrations for narrow worker credentials. |
+| Graphile Worker schema install | `graphile-worker --schema-only` creates the `graphile_worker` schema, tables, sequences, functions, and `jobs` view. A naive split worker with ordinary grants is not enough because Graphile applies its own row-level security policy to private tables such as `_private_tasks`. | Let Graphile Worker own and migrate its schema. Do not assume ordinary grants are enough for a separate runtime role; use the owner role or validate Graphile's restricted-role setup yourself. |
+| Webhook-style table triggers | PostgreSQL table triggers and trigger functions are schema DDL. In `supabase/postgres`, a trigger function can call `net.http_post(...)` and be attached to a table trigger. | Install trigger functions and triggers through the migration/admin path. Use pgroles for the roles that access the source tables and any approved helper functions. |
+| Logical-replication publication | PostgreSQL accepts publication DDL for application tables, but actual logical replication requires server WAL configuration such as `wal_level=logical`. | Manage publication setup outside pgroles. Use pgroles for replication/read roles only after validating the server's WAL configuration. |
+| PostgREST-style cache reload trigger | A `ddl_command_end` event trigger can run a function that emits `NOTIFY pgrst, 'reload schema'`. | Event triggers are DDL and should be installed by an admin/migration path, not by pgroles. |
+| Supabase pgmq | In `supabase/postgres`, `pgmq` is available, must be installed in schema `pgmq`, and can create queues that send and read messages. | Treat `pgmq` as extension-owned. Use pgroles for consumer access after the extension and queues exist. |
+| Supabase pg_net | In `supabase/postgres`, `pg_net` is available and trigger functions can call `net.http_post(...)`. | Treat `pg_net` webhook triggers as migration-owned DDL. Use pgroles for surrounding privileges, not trigger creation. |
+
+The safe pattern is:
+
+1. Give the tool's installer or migrator role enough privilege to create and upgrade its own objects.
+2. Let the tool create or migrate its schema.
+3. Use pgroles to grant narrower runtime roles access to those objects.
+4. Include default privileges for the tool-owned schema if future upgrades create new tables, sequences, or functions.
+
+For example, a pg-boss deployment can use a schema installed by `queue_migrator`, while workers connect as `queue_worker`:
+
+```yaml
+default_owner: queue_migrator
+
+schemas:
+  - name: queue_demo
+    owner: queue_migrator
+
+roles:
+  - name: queue_migrator
+    login: true
+  - name: queue_worker
+    login: true
+
+grants:
+  - role: queue_migrator
+    privileges: [CONNECT]
+    object: { type: database, name: appdb }
+  - role: queue_migrator
+    privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
+    object: { type: table, schema: queue_demo, name: "*" }
+  - role: queue_migrator
+    privileges: [USAGE, SELECT, UPDATE]
+    object: { type: sequence, schema: queue_demo, name: "*" }
+  - role: queue_migrator
+    privileges: [EXECUTE]
+    object: { type: function, schema: queue_demo, name: "*" }
+  - role: queue_worker
+    privileges: [CONNECT]
+    object: { type: database, name: appdb }
+  - role: queue_worker
+    privileges: [USAGE]
+    object: { type: schema, name: queue_demo }
+  - role: queue_worker
+    privileges: [SELECT, INSERT, UPDATE, DELETE]
+    object: { type: table, schema: queue_demo, name: "*" }
+  - role: queue_worker
+    privileges: [USAGE, SELECT, UPDATE]
+    object: { type: sequence, schema: queue_demo, name: "*" }
+  - role: queue_worker
+    privileges: [EXECUTE]
+    object: { type: function, schema: queue_demo, name: "*" }
+
+default_privileges:
+  - owner: queue_migrator
+    schema: queue_demo
+    grant:
+      - role: queue_migrator
+        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
+        on_type: table
+      - role: queue_migrator
+        privileges: [USAGE, SELECT, UPDATE]
+        on_type: sequence
+      - role: queue_migrator
+        privileges: [EXECUTE]
+        on_type: function
+      - role: queue_worker
+        privileges: [SELECT, INSERT, UPDATE, DELETE]
+        on_type: table
+      - role: queue_worker
+        privileges: [USAGE, SELECT, UPDATE]
+        on_type: sequence
+      - role: queue_worker
+        privileges: [EXECUTE]
+        on_type: function
+```
+
+Do not point pgroles at a tool-managed schema and expect it to understand that tool's internal invariants. pgroles manages privileges around those objects; the tool still owns its upgrade path.
+
+If the installer role is managed by pgroles in `authoritative` mode, declare the privileges that role should keep on its own schema too. Otherwise pgroles may correctly identify those owner-visible privileges as undeclared drift and plan revocations.
+
+### Alembic and SQLAlchemy
+
+Use a migrator role such as `app_migrator` for Alembic schema changes, then let pgroles grant narrower application roles such as `app_runtime` and `app_readonly`. The runtime role should receive the table, sequence, and function privileges it needs; the read-only role should receive only read privileges.
+
+Alembic creates a version table. If your migrator role does not have `CREATE` on `public`, configure Alembic to put that version table in the application schema, or create a dedicated migration metadata schema. Avoid granting broad `CREATE` on `public` just to satisfy the default.
+
+## Runtime client libraries
+
+Runtime clients should connect as application roles managed by pgroles, not as migration or installer roles.
+
+Prefer separate roles for distinct duties:
+
+| Role | Purpose |
+| --- | --- |
+| `app_migrator` | Runs schema migrations and owns created objects |
+| `app_runtime` | Serves normal application traffic |
+| `app_readonly` | Read-only workers, analytics jobs, or support tools |
+| `pgroles_admin` | Runs pgroles with enough grant/admin authority |
+
+This makes privilege boundaries visible in one manifest instead of scattering them across connection strings and migration scripts.
+
+## Anti-patterns
+
+- Do not run pgroles before migrations that create referenced schemas or objects, unless pgroles is responsible for creating those schemas.
+- Do not grant broad privileges to the application runtime role just because migrations need them. Split migrator and runtime credentials.
+- Do not forget that authoritative mode revokes undeclared bootstrap privileges. If a migrator needs permanent `CREATE ON DATABASE`, declare it explicitly; otherwise use it only for initial schema creation and let pgroles remove it.
+- Do not keep permanent `GRANT` policy in old migration files and also manage the same grants with pgroles. Pick pgroles as the source of truth once adopted.
+- Do not depend on `PUBLIC` grants for application access. pgroles does not manage `PUBLIC`, so those privileges stay outside the manifest.
+- Do not give CI or code generation jobs superuser access when read-only catalog/schema access is sufficient.

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -30,7 +30,7 @@ Built for platform teams, DBAs, and anyone managing more than a handful of Postg
 
 {% quick-link title="Quick start" icon="installation" href="/docs/quick-start" description="Install pgroles and run your first diff against a live database." /%}
 
-{% quick-link title="Manifest format" icon="presets" href="/docs/manifest-format" description="Learn the full YAML manifest schema for defining roles and privileges." /%}
+{% quick-link title="Manifest guide" icon="presets" href="/docs/manifest-format" description="Learn how manifest sections fit together when designing a policy." /%}
 
 {% quick-link title="Profiles & schemas" icon="plugins" href="/docs/profiles" description="Use profiles to define reusable privilege templates across schemas." /%}
 


### PR DESCRIPTION
## Summary

- Rework the manifest reference into a progressive manifest guide with section links and a complete application example.
- Add validated application/tooling guidance based only on local smoke tests, including Alembic, pg-boss, Graphile Worker, trigger/publication/event-trigger patterns, and Supabase pg_net/pgmq.
- Expand operator docs with actual kind-observed PostgresPolicy and PostgresPolicyPlan output for plan mode, manual approval, and auto approval.
- Remove work-specific identifiers from docs/comments.

## Validation

- `cargo fmt --all`
- `npm run build` in `docs/`
- Local PostgreSQL 16 smoke tests for Alembic, pg-boss, trigger/publication/event-trigger patterns
- Local `supabase/postgres:15.8.1.060` smoke tests for `pg_net` and `pgmq`
- kind cluster experiment with built `pgroles-operator:docs`, real CRDs, dev PostgreSQL, plan mode, manual approval, and auto approval
- Identifier sweep for `partly`, `dev15`, `pgloader`, and `awa`
- Non-validated tooling-name sweep in `docs/src/pages/docs/tooling.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized manifest docs into a high‑level "Manifest guide" and a new comprehensive "Manifest reference".
  * Added a "Tooling" guide covering integration with migration/ORMs and safe workflows.
  * Enhanced Operator docs with reconcile performance validation and plan/approval workflows.
  * Updated various docs and README link labels, navigation, examples, and guidance (manifest, adoption, defaults, alternatives).

* **Tests**
  * Updated test/comment wording (no behavioral changes).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->