### PR TITLE
Add validated multi-service PostgreSQL roles example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,42 @@ jobs:
             diff -f smoke-test.yaml --no-exit-code
 
   # ---------------------------------------------------------------------------
+  # Job 4b: Example smoke tests — verify executable examples against PostgreSQL
+  # ---------------------------------------------------------------------------
+  example-smoke:
+    name: Example Smoke Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: testpassword
+          POSTGRES_DB: pgroles_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      DATABASE_URL: "postgres://postgres:testpassword@localhost:5432/pgroles_test"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Run multi-service microservices example
+        run: scripts/test-microservices-example.sh
+
+  # ---------------------------------------------------------------------------
   # Job 5a: E2E — Operator Scenarios
   # ---------------------------------------------------------------------------
   e2e-operator:

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs-pages.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-pages.yml"
   workflow_dispatch:
 
 permissions:
@@ -55,6 +60,7 @@ jobs:
 
   deploy:
     name: Deploy docs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/src/pages/docs/adoption.md
+++ b/docs/src/pages/docs/adoption.md
@@ -82,7 +82,7 @@ This split is especially useful when platform owns schema creation/ownership, wh
 
 ## App-owned schemas
 
-Applications that create their own schemas via migrations (e.g. `app`, `analytics`) now have two viable patterns:
+Applications that create their own schemas via migrations (e.g. `app`, `analytics`) have two viable patterns:
 
 1. **Let pgroles manage the schema** — declare it under `schemas:` with an optional `owner`, and pgroles can create it before grants/default privileges are applied.
 2. **Let the application manage the schema** — keep using a two-stage manifest where migrations create the schema first, then pgroles applies schema/object grants afterward.

--- a/docs/src/pages/docs/alternatives.md
+++ b/docs/src/pages/docs/alternatives.md
@@ -81,13 +81,13 @@ Development effectively stopped around 2018. If you're starting fresh, pgroles c
 
 ## SQL migration scripts
 
-The most common approach is no dedicated tool at all — teams write `CREATE ROLE` and `GRANT` statements in migration files (Flyway, Alembic, plain SQL) or run them ad-hoc.
+The most common approach is no dedicated tool at all — teams write `CREATE ROLE` and `GRANT` statements in schema-change files or run them ad-hoc.
 
 This works for simple setups but breaks down as complexity grows:
 
 - **No convergence** — migrations are additive. Removing a grant from a migration file doesn't revoke it from the database.
 - **No drift detection** — if someone runs a manual `GRANT` in production, nothing catches it.
 - **No templating** — the same privilege pattern repeated across 10 schemas means 10 copies of the same SQL.
-- **Ordering headaches** — role drops require careful dependency management that migration tools don't help with.
+- **Ordering headaches** — role drops require careful dependency management that schema-change workflows don't help with.
 
 pgroles' `generate` command can bootstrap a manifest from an existing database managed this way, making adoption incremental.

--- a/docs/src/pages/docs/cli.md
+++ b/docs/src/pages/docs/cli.md
@@ -122,7 +122,7 @@ pgroles apply --bundle path/to/pgroles.bundle.yaml --database-url postgres://loc
 
 Before executing changes, `apply` detects the connecting role's privilege level — true superuser, cloud provider superuser (for the explicitly supported providers), or regular user — and warns about any planned changes that exceed the detected privileges (for example setting `SUPERUSER` or `BYPASSRLS` through a managed-service admin role).
 
-Provider-aware warning logic currently recognizes `rds_superuser`, `cloudsqlsuperuser`, `alloydbsuperuser`, and `azure_pg_admin`. Other PostgreSQL-compatible managed services, including Supabase and PlanetScale PostgreSQL, may still work, but privilege warnings will be generic rather than provider-specific.
+Provider-aware warning logic recognizes `rds_superuser`, `cloudsqlsuperuser`, `alloydbsuperuser`, and `azure_pg_admin`. Other PostgreSQL-compatible managed services, including Supabase and PlanetScale PostgreSQL, may still work, but privilege warnings are generic rather than provider-specific.
 
 ### Insufficient privileges
 

--- a/docs/src/pages/docs/default-privileges.md
+++ b/docs/src/pages/docs/default-privileges.md
@@ -9,7 +9,7 @@ Default privileges control what privileges are automatically granted when new ob
 
 ## Why default privileges?
 
-Wildcard grants like `GRANT SELECT ON ALL TABLES IN SCHEMA` only apply to objects that exist **right now**. When a migration creates a new table, existing roles won't have access to it unless you re-run the grant.
+Wildcard grants like `GRANT SELECT ON ALL TABLES IN SCHEMA` only apply to objects that exist when the grant runs. When a schema change creates a new table later, existing roles won't have access to it unless you re-run the grant.
 
 `ALTER DEFAULT PRIVILEGES` solves this by configuring automatic grants for future objects.
 
@@ -44,7 +44,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "app_owner"
 
 ## Owner context
 
-The `owner` field specifies which role's object creation triggers the default grant. This is typically the role that runs migrations or creates tables (e.g. `app_migrator`, `app_owner`).
+The `owner` field specifies which role's object creation triggers the default grant. This is typically the role that creates tables, such as `app_migrator` or `app_owner`.
 
 If `owner` is omitted on a default privilege entry, the top-level `default_owner` is used. If neither is set, it falls back to `postgres`.
 
@@ -74,5 +74,5 @@ It's good practice to pair wildcard grants (`name: "*"`) with matching default p
 {% /callout %}
 
 {% callout title="Tables are not enough" %}
-If a role writes to tables created by migrations, check whether it also needs sequence and function defaults. Identity/serial-backed inserts typically need sequence access, and trigger-driven schemas often need `EXECUTE` on functions too.
+If a role writes to tables created after pgroles runs, check whether it also needs sequence and function defaults. Identity/serial-backed inserts typically need sequence access, and trigger-driven schemas often need `EXECUTE` on functions too.
 {% /callout %}

--- a/docs/src/pages/docs/grants.md
+++ b/docs/src/pages/docs/grants.md
@@ -126,4 +126,4 @@ This is equivalent to granting `SELECT, INSERT, UPDATE` on all tables.
 
 ## Convergent revocation
 
-Privileges present in the database but absent from the manifest are revoked. If a role currently has `DELETE` on a table but your manifest only grants `SELECT`, pgroles will generate a `REVOKE DELETE` statement.
+Privileges present in the database but absent from the manifest are revoked. If a role has `DELETE` on a table but your manifest only grants `SELECT`, pgroles will generate a `REVOKE DELETE` statement.

--- a/docs/src/pages/docs/manifest-reference.md
+++ b/docs/src/pages/docs/manifest-reference.md
@@ -25,7 +25,7 @@ retirements: []                   # Safe role removal workflows
 
 ## auth_providers
 
-Declare cloud authentication providers to document how IAM-mapped roles connect to the database. This is currently informational metadata used for validation and documentation purposes.
+Declare cloud authentication providers to document how IAM-mapped roles connect to the database. This metadata is used for validation and documentation.
 
 ```yaml
 auth_providers:
@@ -54,7 +54,7 @@ auth_providers:
 | `planet_scale` | PlanetScale PostgreSQL metadata. Optional `organization` field. |
 
 {% callout type="note" title="Managed service metadata is intentionally narrow" %}
-The `auth_providers` block models the provider types listed above, but not every variant has provider-specific runtime behavior yet. Today the privilege-warning path has explicit detection for RDS/Aurora, Cloud SQL, AlloyDB, and Azure. Supabase and PlanetScale PostgreSQL entries are currently documentation and validation metadata.
+The `auth_providers` block models the provider types listed above, but only RDS/Aurora, Cloud SQL, AlloyDB, and Azure have provider-specific privilege-warning behavior. Supabase and PlanetScale PostgreSQL entries are documentation and validation metadata.
 {% /callout %}
 
 ## default_owner

--- a/docs/src/pages/docs/operator-architecture.md
+++ b/docs/src/pages/docs/operator-architecture.md
@@ -149,7 +149,7 @@ For object-local debugging, the controller also emits transition-based Kubernete
 - Events: notable transitions visible in `kubectl describe`
 - OTLP metrics: fleet-level trends and alerting
 
-## Current CI coverage
+## CI coverage
 
 CI covers:
 
@@ -169,7 +169,7 @@ CI covers:
 
 Further hardening work:
 
-- broader scale and long-run validation beyond the current scheduled workflow profile
+- broader scale and long-run validation beyond the scheduled workflow profile
 
 ## Relationship to the CLI
 

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -116,7 +116,7 @@ The operator's safety model — serialized reconciliation, conflict detection, f
 **API stability:**
 
 - The CRD is `v1alpha1`. There is no conversion webhook, no migration tooling, and no documented upgrade path between versions.
-- Controller semantics that should be part of the API contract are currently implementation-only conventions.
+- Controller semantics that should be part of the API contract are implementation-only conventions.
 
 **Scale and HA:**
 

--- a/docs/src/pages/docs/quick-start.md
+++ b/docs/src/pages/docs/quick-start.md
@@ -11,7 +11,7 @@ Get up and running with pgroles in a few minutes. {% .lead %}
 
 - **PostgreSQL 14+** (pgroles adapts membership SQL to the server version at runtime)
 - **PostgreSQL 16+** recommended for full per-membership `INHERIT` support
-- CI coverage currently runs integration tests on PostgreSQL **16, 17, and 18**
+- CI runs integration tests on PostgreSQL **16, 17, and 18**
 - **Rust toolchain** (for building from source)
 
 ## Installation

--- a/docs/src/pages/docs/tooling.md
+++ b/docs/src/pages/docs/tooling.md
@@ -1,174 +1,133 @@
 ---
-title: Application and migration tools
-description: How pgroles fits beside ORMs, SQL migration tools, and PostgreSQL client libraries.
+title: Application access patterns
+description: How pgroles fits beside schema ownership, service roles, team roles, and multi-file bundles.
 ---
 
-Use pgroles as the access-control layer next to your existing schema and application tooling. {% .lead %}
+Use pgroles as the PostgreSQL access-control layer next to your existing application and schema lifecycle. {% .lead %}
 
-Most PostgreSQL stacks already have something that creates tables, indexes, functions, and application metadata. Keep using that tool for schema changes. Let pgroles own roles, memberships, grants, default privileges, and role retirement.
+Most stacks already have a way to create tables, indexes, functions, and application metadata. Keep that path responsible for schema DDL. Let pgroles own PostgreSQL roles, memberships, grants, default privileges, passwords, and retirements.
 
 ---
 
 ## The boundary
 
-pgroles is intentionally not a schema migration framework. It does not create tables, rewrite indexes, manage row-level security policies, or replace an ORM's migration history.
+pgroles is intentionally not a schema migration framework. It does not create tables, rewrite indexes, manage row-level security policies, or replace application migration history.
 
 The clean split is:
 
-| Layer | Typical tools | Owner |
-| --- | --- | --- |
-| Infrastructure | Terraform, Pulumi, cloud consoles | Database instances, networking, IAM |
-| Schema migrations | Alembic/SQLAlchemy | Tables, views, functions, types, extensions |
-| Access control | pgroles | Roles, memberships, grants, default privileges, passwords, retirements |
-| Runtime queries | SQLAlchemy, PostgreSQL client connections | Application reads and writes |
+| Layer | Owner |
+| --- | --- |
+| Database infrastructure | Instance, networking, database creation, platform IAM |
+| Schema lifecycle | Tables, views, functions, types, extensions, triggers, queues, event triggers |
+| Access control | Roles, memberships, grants, default privileges, passwords, retirements |
+| Runtime connections | Service-specific login roles with only the privileges they need |
 
-This avoids the common failure mode where every migration tool, app bootstrap script, and operator tries to issue `GRANT` statements independently.
+This avoids the common failure mode where application bootstrap scripts, deployment jobs, and operators all issue their own `GRANT` statements.
 
 ## Recommended order
 
-For each environment, run access control after the database exists and before application traffic relies on new privileges:
+For each environment, converge access control after the database exists and before application traffic relies on new privileges:
 
 ```shell
-# 1. Apply schema migrations
-alembic upgrade head
+# 1. Apply schema changes with the service's schema-owner role.
+./service-migrate
 
-# 2. Apply role and privilege policy
+# 2. Preview and apply role and privilege policy.
 pgroles diff -f pgroles.yaml --database-url "$DATABASE_URL"
 pgroles apply -f pgroles.yaml --database-url "$DATABASE_URL"
 
-# 3. Deploy or restart application workloads
+# 3. Deploy or restart application workloads.
 ```
 
-If a migration creates new tables in an already-managed schema, pgroles usually has two safety nets:
+If schema changes create new objects in an already-managed schema, pgroles has two safety nets:
 
 - wildcard grants cover objects that already exist when pgroles runs
 - default privileges cover future objects created by the configured owner
 
-If a migration needs a brand-new schema, either declare that schema in pgroles so pgroles creates it and converges its PostgreSQL owner, or run the migration first and then apply the pgroles policy that grants access to the existing schema.
+If schema changes need a brand-new schema, either declare that schema in pgroles so pgroles creates it and converges its PostgreSQL owner, or create the schema first and then apply the pgroles policy that grants access to it.
 
-## Migration tools
-
-### Validated DDL-owning tools
-
-Some PostgreSQL libraries run DDL even though they are not ORMs. Treat these like schema owners, not like ordinary application clients.
-
-Concrete DDL-owning patterns:
-
-| Pattern | Behavior | pgroles guidance |
-| --- | --- | --- |
-| pg-boss queue schema | pg-boss can create a custom schema and queue through an installer role. A separate worker role can run with `migrate: false` after receiving schema/table/sequence/function grants. | Run pg-boss schema setup with an installer role, then use pgroles for worker access. Disable runtime migrations for narrow worker credentials. |
-| Graphile Worker schema install | `graphile-worker --schema-only` creates the `graphile_worker` schema, tables, sequences, functions, and `jobs` view. A naive split worker with ordinary grants is not enough because Graphile applies its own row-level security policy to private tables such as `_private_tasks`. | Let Graphile Worker own and migrate its schema. Do not assume ordinary grants are enough for a separate runtime role; use the owner role or validate Graphile's restricted-role setup yourself. |
-| Webhook-style table triggers | PostgreSQL table triggers and trigger functions are schema DDL. In `supabase/postgres`, a trigger function can call `net.http_post(...)` and be attached to a table trigger. | Install trigger functions and triggers through the migration/admin path. Use pgroles for the roles that access the source tables and any approved helper functions. |
-| Logical-replication publication | PostgreSQL accepts publication DDL for application tables, but actual logical replication requires server WAL configuration such as `wal_level=logical`. | Manage publication setup outside pgroles. Use pgroles for replication/read roles only after validating the server's WAL configuration. |
-| PostgREST-style cache reload trigger | A `ddl_command_end` event trigger can run a function that emits `NOTIFY pgrst, 'reload schema'`. | Event triggers are DDL and should be installed by an admin/migration path, not by pgroles. |
-| Supabase pgmq | In `supabase/postgres`, `pgmq` is available, must be installed in schema `pgmq`, and can create queues that send and read messages. | Treat `pgmq` as extension-owned. Use pgroles for consumer access after the extension and queues exist. |
-| Supabase pg_net | In `supabase/postgres`, `pg_net` is available and trigger functions can call `net.http_post(...)`. | Treat `pg_net` webhook triggers as migration-owned DDL. Use pgroles for surrounding privileges, not trigger creation. |
-
-The safe pattern is:
-
-1. Give the tool's installer or migrator role enough privilege to create and upgrade its own objects.
-2. Let the tool create or migrate its schema.
-3. Use pgroles to grant narrower runtime roles access to those objects.
-4. Include default privileges for the tool-owned schema if future upgrades create new tables, sequences, or functions.
-
-For example, a pg-boss deployment can use a schema installed by `queue_migrator`, while workers connect as `queue_worker`:
-
-```yaml
-default_owner: queue_migrator
-
-schemas:
-  - name: queue_demo
-    owner: queue_migrator
-
-roles:
-  - name: queue_migrator
-    login: true
-  - name: queue_worker
-    login: true
-
-grants:
-  - role: queue_migrator
-    privileges: [CONNECT]
-    object: { type: database, name: appdb }
-  - role: queue_migrator
-    privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
-    object: { type: table, schema: queue_demo, name: "*" }
-  - role: queue_migrator
-    privileges: [USAGE, SELECT, UPDATE]
-    object: { type: sequence, schema: queue_demo, name: "*" }
-  - role: queue_migrator
-    privileges: [EXECUTE]
-    object: { type: function, schema: queue_demo, name: "*" }
-  - role: queue_worker
-    privileges: [CONNECT]
-    object: { type: database, name: appdb }
-  - role: queue_worker
-    privileges: [USAGE]
-    object: { type: schema, name: queue_demo }
-  - role: queue_worker
-    privileges: [SELECT, INSERT, UPDATE, DELETE]
-    object: { type: table, schema: queue_demo, name: "*" }
-  - role: queue_worker
-    privileges: [USAGE, SELECT, UPDATE]
-    object: { type: sequence, schema: queue_demo, name: "*" }
-  - role: queue_worker
-    privileges: [EXECUTE]
-    object: { type: function, schema: queue_demo, name: "*" }
-
-default_privileges:
-  - owner: queue_migrator
-    schema: queue_demo
-    grant:
-      - role: queue_migrator
-        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
-        on_type: table
-      - role: queue_migrator
-        privileges: [USAGE, SELECT, UPDATE]
-        on_type: sequence
-      - role: queue_migrator
-        privileges: [EXECUTE]
-        on_type: function
-      - role: queue_worker
-        privileges: [SELECT, INSERT, UPDATE, DELETE]
-        on_type: table
-      - role: queue_worker
-        privileges: [USAGE, SELECT, UPDATE]
-        on_type: sequence
-      - role: queue_worker
-        privileges: [EXECUTE]
-        on_type: function
-```
-
-Do not point pgroles at a tool-managed schema and expect it to understand that tool's internal invariants. pgroles manages privileges around those objects; the tool still owns its upgrade path.
-
-If the installer role is managed by pgroles in `authoritative` mode, declare the privileges that role should keep on its own schema too. Otherwise pgroles may correctly identify those owner-visible privileges as undeclared drift and plan revocations.
-
-### Alembic and SQLAlchemy
-
-Use a migrator role such as `app_migrator` for Alembic schema changes, then let pgroles grant narrower application roles such as `app_runtime` and `app_readonly`. The runtime role should receive the table, sequence, and function privileges it needs; the read-only role should receive only read privileges.
-
-Alembic creates a version table. If your migrator role does not have `CREATE` on `public`, configure Alembic to put that version table in the application schema, or create a dedicated migration metadata schema. Avoid granting broad `CREATE` on `public` just to satisfy the default.
-
-## Runtime client libraries
-
-Runtime clients should connect as application roles managed by pgroles, not as migration or installer roles.
+## Role model
 
 Prefer separate roles for distinct duties:
 
-| Role | Purpose |
+| Role type | Purpose |
 | --- | --- |
-| `app_migrator` | Runs schema migrations and owns created objects |
-| `app_runtime` | Serves normal application traffic |
-| `app_readonly` | Read-only workers, analytics jobs, or support tools |
-| `pgroles_admin` | Runs pgroles with enough grant/admin authority |
+| Schema-owner role | Runs schema changes and owns created objects |
+| Runtime role | Serves normal application traffic |
+| Worker role | Performs a narrower background-processing task |
+| Read-only role | Reporting, analytics, support, or debugging |
+| Team role | Grants human access through membership rather than direct grants |
+| pgroles administrator | Runs pgroles with enough authority to converge the declared policy |
 
-This makes privilege boundaries visible in one manifest instead of scattering them across connection strings and migration scripts.
+This makes privilege boundaries visible in one manifest instead of scattering them across connection strings and setup scripts.
+
+## Schema-owned systems
+
+Some PostgreSQL-backed libraries and platform features create their own tables, functions, triggers, queues, publications, or metadata schemas. Treat those as schema-owned systems:
+
+1. give the owner or installer role enough privilege to create and upgrade its own objects
+2. let that owner path create or upgrade the schema objects
+3. use pgroles to grant narrower runtime and team roles access to the resulting objects
+4. include default privileges for the owner/schema pair if future upgrades create more tables, sequences, or functions
+
+Do not point pgroles at an internally managed schema and expect it to understand that system's upgrade invariants. pgroles manages privileges around those objects; the schema-owning system still owns its DDL.
+
+If the owner role is also managed by pgroles in `authoritative` mode, declare the privileges that role should keep on its own schema. PostgreSQL owners effectively have broad access to their objects, and pgroles treats undeclared visible privileges as drift.
+
+## Bundles for teams
+
+For one application, a single manifest is often enough. For a shared database with multiple teams, use bundle mode so each team owns a scoped fragment:
+
+```shell
+pgroles validate --bundle pgroles.bundle.yaml
+pgroles diff --bundle pgroles.bundle.yaml --database-url "$DATABASE_URL"
+pgroles apply --bundle pgroles.bundle.yaml --database-url "$DATABASE_URL"
+```
+
+Bundle composition gives each fragment an explicit ownership boundary. If two fragments both try to manage the same role, schema facet, grant, default privilege, or membership selector, pgroles rejects the bundle before it connects to PostgreSQL.
+
+Use bundle fragments for ownership boundaries such as:
+
+- platform-owned team roles and human memberships
+- one service-owned schema, migrator role, and runtime roles per service
+- shared read-only roles or reporting access owned by the team that grants it
+
+## Multi-service example
+
+The repository includes an executable [multi-service bundle example](https://github.com/hardbyte/pgroles/tree/main/examples/microservices) for a shared database with separate `billing` and `shipping` services.
+
+It demonstrates the recommended split:
+
+- `platform.yaml` owns team roles and human memberships
+- `billing.yaml` owns billing roles, billing schema ownership, and billing grants
+- `shipping.yaml` owns shipping roles, shipping schema ownership, and shipping grants
+- each service has a migration role that owns its schema objects
+- each service has separate runtime roles for API, worker, or reporting access
+- human users inherit read access from team roles such as `team_payments` and `team_fulfillment`
+- CI verifies that each runtime role can access its own schema and is denied access to the other service's schema
+
+| Principal | Connects as | Scope |
+| --- | --- | --- |
+| Billing migrations | `billing_migrator` | Owns and migrates the `billing` schema |
+| Billing API | `billing_api` | Reads, inserts, and updates billing tables |
+| Billing worker | `billing_worker` | Reads and updates billing invoices, but cannot insert |
+| Shipping migrations | `shipping_migrator` | Owns and migrates the `shipping` schema |
+| Shipping API | `shipping_api` | Reads, inserts, and updates shipping tables |
+| Shipping reports | `shipping_reports` | Read-only access to shipping tables |
+| Payments engineers | `team_payments` membership | Read-only access to billing tables |
+| Fulfillment engineers | `team_fulfillment` membership | Read-only access to shipping tables |
+
+Run the example locally against a disposable database:
+
+```shell
+export DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test
+./scripts/test-microservices-example.sh
+```
 
 ## Anti-patterns
 
-- Do not run pgroles before migrations that create referenced schemas or objects, unless pgroles is responsible for creating those schemas.
-- Do not grant broad privileges to the application runtime role just because migrations need them. Split migrator and runtime credentials.
-- Do not forget that authoritative mode revokes undeclared bootstrap privileges. If a migrator needs permanent `CREATE ON DATABASE`, declare it explicitly; otherwise use it only for initial schema creation and let pgroles remove it.
-- Do not keep permanent `GRANT` policy in old migration files and also manage the same grants with pgroles. Pick pgroles as the source of truth once adopted.
+- Do not grant broad runtime privileges just because schema changes need them. Split schema-owner and runtime credentials.
+- Do not keep permanent `GRANT` policy in old setup scripts and also manage the same grants with pgroles. Pick pgroles as the source of truth once adopted.
 - Do not depend on `PUBLIC` grants for application access. pgroles does not manage `PUBLIC`, so those privileges stay outside the manifest.
 - Do not give CI or code generation jobs superuser access when read-only catalog/schema access is sufficient.
+- Do not use one bundle fragment per file unless the scope boundary is real. Bundle files should reflect ownership, not just directory layout.

--- a/examples/microservices/README.md
+++ b/examples/microservices/README.md
@@ -1,0 +1,28 @@
+# Multi-service teams example
+
+This example models a shared PostgreSQL database used by multiple teams and services:
+
+- `billing` is owned by the payments team.
+- `shipping` is owned by the fulfillment team.
+- each service has a migration role that owns its schema objects.
+- each service has tightly scoped runtime roles for API and worker/reporting access.
+- human users receive read access through team roles instead of one-off grants.
+
+The example is intentionally small, but it exercises the same split used in production deployments:
+
+1. `pgroles.bootstrap.yaml` creates only the migration roles and service schemas needed to run the first migrations.
+2. `pgroles.bundle.yaml` composes platform, billing, and shipping policy fragments into the full desired policy.
+3. pgroles rejects overlapping ownership before it connects to PostgreSQL.
+4. pgroles creates login roles, team roles, schemas, grants, default privileges, and memberships.
+5. service migrations run with the service-specific migrator role.
+6. application connections use service-specific runtime roles.
+7. team users inherit team-level read access without receiving migration or write privileges.
+
+Run it against a disposable local database:
+
+```shell
+export DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test
+./scripts/test-microservices-example.sh
+```
+
+The script applies the bootstrap bundle, runs the billing migration, applies the full bundle once billing tables exist, runs the shipping migration with its cross-service foreign key, reapplies the full bundle so wildcard/default privileges converge over shipping objects, and then verifies positive and negative access checks for every app and team role.

--- a/examples/microservices/migrations/billing.sql
+++ b/examples/microservices/migrations/billing.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS billing.customers (
+  id integer generated always as identity primary key,
+  email text not null unique
+);
+
+CREATE TABLE IF NOT EXISTS billing.invoices (
+  id integer generated always as identity primary key,
+  customer_id integer not null references billing.customers(id),
+  amount_cents integer not null check (amount_cents > 0),
+  status text not null default 'open'
+);
+

--- a/examples/microservices/migrations/shipping.sql
+++ b/examples/microservices/migrations/shipping.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS shipping.shipments (
+  id integer generated always as identity primary key,
+  billing_invoice_id integer not null references billing.invoices(id),
+  destination text not null,
+  status text not null default 'pending'
+);

--- a/examples/microservices/pgroles.bootstrap.yaml
+++ b/examples/microservices/pgroles.bootstrap.yaml
@@ -1,0 +1,7 @@
+# Bootstrap roles and schemas so service-owned migrations can run before
+# object-level grants are available.
+
+sources:
+  - file: policies/billing-bootstrap.yaml
+  - file: policies/shipping-bootstrap.yaml
+

--- a/examples/microservices/pgroles.bundle.yaml
+++ b/examples/microservices/pgroles.bundle.yaml
@@ -1,0 +1,11 @@
+# Bundle root for a shared database owned by multiple teams.
+#
+# Each source file declares its own management scope. pgroles composes the
+# fragments, rejects overlapping ownership, and then diffs/applies one desired
+# database policy.
+
+sources:
+  - file: policies/platform.yaml
+  - file: policies/billing.yaml
+  - file: policies/shipping.yaml
+

--- a/examples/microservices/policies/billing-bootstrap.yaml
+++ b/examples/microservices/policies/billing-bootstrap.yaml
@@ -1,0 +1,27 @@
+policy:
+  name: billing-bootstrap
+
+scope:
+  roles:
+    - billing_migrator
+  schemas:
+    - name: billing
+      facets: [owner, bindings]
+
+roles:
+  - name: billing_migrator
+    login: true
+    password: { from_env: BILLING_MIGRATOR_PASSWORD }
+    comment: "Runs billing service migrations and owns billing objects"
+
+schemas:
+  - name: billing
+    owner: billing_migrator
+
+grants:
+  - role: billing_migrator
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: billing_migrator
+    privileges: [USAGE, CREATE]
+    object: { type: schema, name: billing }

--- a/examples/microservices/policies/billing.yaml
+++ b/examples/microservices/policies/billing.yaml
@@ -1,0 +1,103 @@
+policy:
+  name: billing
+
+scope:
+  roles:
+    - billing_migrator
+    - billing_api
+    - billing_worker
+  schemas:
+    - name: billing
+      facets: [owner, bindings]
+
+roles:
+  - name: billing_migrator
+    login: true
+    password: { from_env: BILLING_MIGRATOR_PASSWORD }
+    comment: "Runs billing service migrations and owns billing objects"
+  - name: billing_api
+    login: true
+    password: { from_env: BILLING_API_PASSWORD }
+    connection_limit: 20
+    comment: "Billing HTTP API runtime role"
+  - name: billing_worker
+    login: true
+    password: { from_env: BILLING_WORKER_PASSWORD }
+    connection_limit: 10
+    comment: "Billing async worker runtime role"
+
+schemas:
+  - name: billing
+    owner: billing_migrator
+
+grants:
+  - role: billing_migrator
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: billing_api
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: billing_worker
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: team_payments
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+
+  - role: billing_migrator
+    privileges: [USAGE, CREATE]
+    object: { type: schema, name: billing }
+  - role: billing_migrator
+    privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
+    object: { type: table, schema: billing, name: "*" }
+  - role: billing_migrator
+    privileges: [USAGE, SELECT, UPDATE]
+    object: { type: sequence, schema: billing, name: "*" }
+  - role: billing_migrator
+    privileges: [EXECUTE]
+    object: { type: function, schema: billing, name: "*" }
+
+  - role: billing_api
+    privileges: [USAGE]
+    object: { type: schema, name: billing }
+  - role: billing_api
+    privileges: [SELECT, INSERT, UPDATE]
+    object: { type: table, schema: billing, name: "*" }
+  - role: billing_api
+    privileges: [USAGE, SELECT]
+    object: { type: sequence, schema: billing, name: "*" }
+
+  - role: billing_worker
+    privileges: [USAGE]
+    object: { type: schema, name: billing }
+  - role: billing_worker
+    privileges: [SELECT, UPDATE]
+    object: { type: table, schema: billing, name: invoices }
+
+  - role: shipping_migrator
+    privileges: [USAGE]
+    object: { type: schema, name: billing }
+  - role: shipping_migrator
+    privileges: [REFERENCES]
+    object: { type: table, schema: billing, name: invoices }
+
+  - role: team_payments
+    privileges: [USAGE]
+    object: { type: schema, name: billing }
+  - role: team_payments
+    privileges: [SELECT]
+    object: { type: table, schema: billing, name: "*" }
+
+default_privileges:
+  - owner: billing_migrator
+    schema: billing
+    grant:
+      - role: billing_api
+        privileges: [SELECT, INSERT, UPDATE]
+        on_type: table
+      - role: billing_api
+        privileges: [USAGE, SELECT]
+        on_type: sequence
+      - role: team_payments
+        privileges: [SELECT]
+        on_type: table

--- a/examples/microservices/policies/platform.yaml
+++ b/examples/microservices/policies/platform.yaml
@@ -1,0 +1,35 @@
+policy:
+  name: platform
+
+scope:
+  roles:
+    - team_payments
+    - team_fulfillment
+    - alice_payments
+    - bob_fulfillment
+
+roles:
+  - name: team_payments
+    login: false
+    comment: "Payments team access role"
+  - name: team_fulfillment
+    login: false
+    comment: "Fulfillment team access role"
+
+  - name: alice_payments
+    login: true
+    password: { from_env: ALICE_PAYMENTS_PASSWORD }
+    comment: "Payments engineer; inherits team_payments"
+  - name: bob_fulfillment
+    login: true
+    password: { from_env: BOB_FULFILLMENT_PASSWORD }
+    comment: "Fulfillment engineer; inherits team_fulfillment"
+
+memberships:
+  - role: team_payments
+    members:
+      - name: alice_payments
+  - role: team_fulfillment
+    members:
+      - name: bob_fulfillment
+

--- a/examples/microservices/policies/shipping-bootstrap.yaml
+++ b/examples/microservices/policies/shipping-bootstrap.yaml
@@ -1,0 +1,27 @@
+policy:
+  name: shipping-bootstrap
+
+scope:
+  roles:
+    - shipping_migrator
+  schemas:
+    - name: shipping
+      facets: [owner, bindings]
+
+roles:
+  - name: shipping_migrator
+    login: true
+    password: { from_env: SHIPPING_MIGRATOR_PASSWORD }
+    comment: "Runs shipping service migrations and owns shipping objects"
+
+schemas:
+  - name: shipping
+    owner: shipping_migrator
+
+grants:
+  - role: shipping_migrator
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: shipping_migrator
+    privileges: [USAGE, CREATE]
+    object: { type: schema, name: shipping }

--- a/examples/microservices/policies/shipping.yaml
+++ b/examples/microservices/policies/shipping.yaml
@@ -1,0 +1,100 @@
+policy:
+  name: shipping
+
+scope:
+  roles:
+    - shipping_migrator
+    - shipping_api
+    - shipping_reports
+  schemas:
+    - name: shipping
+      facets: [owner, bindings]
+
+roles:
+  - name: shipping_migrator
+    login: true
+    password: { from_env: SHIPPING_MIGRATOR_PASSWORD }
+    comment: "Runs shipping service migrations and owns shipping objects"
+  - name: shipping_api
+    login: true
+    password: { from_env: SHIPPING_API_PASSWORD }
+    connection_limit: 20
+    comment: "Shipping API runtime role"
+  - name: shipping_reports
+    login: true
+    password: { from_env: SHIPPING_REPORTS_PASSWORD }
+    connection_limit: 5
+    comment: "Shipping read-only reporting runtime role"
+
+schemas:
+  - name: shipping
+    owner: shipping_migrator
+
+grants:
+  - role: shipping_migrator
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: shipping_api
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: shipping_reports
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+  - role: team_fulfillment
+    privileges: [CONNECT]
+    object: { type: database, name: pgroles_test }
+
+  - role: shipping_migrator
+    privileges: [USAGE, CREATE]
+    object: { type: schema, name: shipping }
+  - role: shipping_migrator
+    privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER]
+    object: { type: table, schema: shipping, name: "*" }
+  - role: shipping_migrator
+    privileges: [USAGE, SELECT, UPDATE]
+    object: { type: sequence, schema: shipping, name: "*" }
+  - role: shipping_migrator
+    privileges: [EXECUTE]
+    object: { type: function, schema: shipping, name: "*" }
+
+  - role: shipping_api
+    privileges: [USAGE]
+    object: { type: schema, name: shipping }
+  - role: shipping_api
+    privileges: [SELECT, INSERT, UPDATE]
+    object: { type: table, schema: shipping, name: "*" }
+  - role: shipping_api
+    privileges: [USAGE, SELECT]
+    object: { type: sequence, schema: shipping, name: "*" }
+
+  - role: shipping_reports
+    privileges: [USAGE]
+    object: { type: schema, name: shipping }
+  - role: shipping_reports
+    privileges: [SELECT]
+    object: { type: table, schema: shipping, name: "*" }
+
+  - role: team_fulfillment
+    privileges: [USAGE]
+    object: { type: schema, name: shipping }
+  - role: team_fulfillment
+    privileges: [SELECT]
+    object: { type: table, schema: shipping, name: "*" }
+
+default_privileges:
+  - owner: shipping_migrator
+    schema: shipping
+    grant:
+      - role: shipping_api
+        privileges: [SELECT, INSERT, UPDATE]
+        on_type: table
+      - role: shipping_api
+        privileges: [USAGE, SELECT]
+        on_type: sequence
+      - role: shipping_reports
+        privileges: [SELECT]
+        on_type: table
+      - role: team_fulfillment
+        privileges: [SELECT]
+        on_type: table
+

--- a/scripts/test-microservices-example.sh
+++ b/scripts/test-microservices-example.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BOOTSTRAP_BUNDLE="$ROOT_DIR/examples/microservices/pgroles.bootstrap.yaml"
+BUNDLE="$ROOT_DIR/examples/microservices/pgroles.bundle.yaml"
+
+: "${DATABASE_URL:?DATABASE_URL must point at a disposable PostgreSQL database}"
+
+export ALICE_PAYMENTS_PASSWORD="${ALICE_PAYMENTS_PASSWORD:-alice-payments-pass}"
+export BOB_FULFILLMENT_PASSWORD="${BOB_FULFILLMENT_PASSWORD:-bob-fulfillment-pass}"
+export BILLING_MIGRATOR_PASSWORD="${BILLING_MIGRATOR_PASSWORD:-billing-migrator-pass}"
+export BILLING_API_PASSWORD="${BILLING_API_PASSWORD:-billing-api-pass}"
+export BILLING_WORKER_PASSWORD="${BILLING_WORKER_PASSWORD:-billing-worker-pass}"
+export SHIPPING_MIGRATOR_PASSWORD="${SHIPPING_MIGRATOR_PASSWORD:-shipping-migrator-pass}"
+export SHIPPING_API_PASSWORD="${SHIPPING_API_PASSWORD:-shipping-api-pass}"
+export SHIPPING_REPORTS_PASSWORD="${SHIPPING_REPORTS_PASSWORD:-shipping-reports-pass}"
+
+PGROLES_BIN="${PGROLES_BIN:-cargo run -q -p pgroles-cli --}"
+
+service_url() {
+  local user="$1"
+  local password="$2"
+  python3 - "$DATABASE_URL" "$user" "$password" <<'PY'
+import sys
+from urllib.parse import urlsplit, urlunsplit, quote
+
+url, user, password = sys.argv[1:4]
+parts = urlsplit(url)
+host = parts.hostname or ""
+if ":" in host and not host.startswith("["):
+    host = f"[{host}]"
+netloc = f"{quote(user)}:{quote(password)}@{host}"
+if parts.port:
+    netloc += f":{parts.port}"
+print(urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment)))
+PY
+}
+
+psql_as() {
+  local user="$1"
+  local password="$2"
+  shift 2
+  psql "$(service_url "$user" "$password")" -v ON_ERROR_STOP=1 -v VERBOSITY=verbose "$@"
+}
+
+expect_sqlstate() {
+  local expected_sqlstate="$1"
+  local description="$2"
+  shift 2
+
+  local stdout stderr status
+  stdout="$(mktemp "${TMPDIR:-/tmp}/pgroles-stdout.XXXXXX")"
+  stderr="$(mktemp "${TMPDIR:-/tmp}/pgroles-stderr.XXXXXX")"
+
+  set +e
+  "$@" >"$stdout" 2>"$stderr"
+  status=$?
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "::error::Expected SQLSTATE $expected_sqlstate: $description"
+    cat "$stdout"
+    cat "$stderr"
+    rm -f "$stdout" "$stderr"
+    exit 1
+  fi
+
+  if ! grep -Eq "(^ERROR: +$expected_sqlstate:|SQLSTATE $expected_sqlstate|(^|[^0-9])$expected_sqlstate([^0-9]|$))" "$stderr"; then
+    echo "::error::Expected SQLSTATE $expected_sqlstate: $description"
+    echo "Command exited with status $status instead"
+    cat "$stdout"
+    cat "$stderr"
+    rm -f "$stdout" "$stderr"
+    exit 1
+  fi
+
+  rm -f "$stdout" "$stderr"
+  echo "SQLSTATE $expected_sqlstate as expected: $description"
+}
+
+expect_denied() {
+  local description="$1"
+  shift
+  expect_sqlstate 42501 "$description" "$@"
+}
+
+echo "Validating bundles"
+$PGROLES_BIN validate --bundle "$BOOTSTRAP_BUNDLE"
+$PGROLES_BIN validate --bundle "$BUNDLE"
+
+echo "Bootstrapping migration roles and schemas"
+$PGROLES_BIN apply --bundle "$BOOTSTRAP_BUNDLE" --database-url "$DATABASE_URL"
+
+echo "Running billing migration with the billing migrator role"
+psql_as billing_migrator "$BILLING_MIGRATOR_PASSWORD" -f "$ROOT_DIR/examples/microservices/migrations/billing.sql"
+
+echo "Applying full policy after billing objects exist"
+$PGROLES_BIN apply --bundle "$BUNDLE" --database-url "$DATABASE_URL"
+
+echo "Running shipping migration with the shipping migrator role"
+psql_as shipping_migrator "$SHIPPING_MIGRATOR_PASSWORD" -f "$ROOT_DIR/examples/microservices/migrations/shipping.sql"
+
+echo "Reapplying full policy after shipping objects exist"
+$PGROLES_BIN apply --bundle "$BUNDLE" --database-url "$DATABASE_URL"
+
+echo "Verifying billing API can write billing data"
+psql_as billing_api "$BILLING_API_PASSWORD" -c "INSERT INTO billing.customers (email) VALUES ('buyer@example.com');"
+psql_as billing_api "$BILLING_API_PASSWORD" -c "INSERT INTO billing.invoices (customer_id, amount_cents) VALUES (1, 4200);"
+psql_as billing_api "$BILLING_API_PASSWORD" -c "UPDATE billing.invoices SET status = 'sent' WHERE id = 1;"
+psql_as billing_api "$BILLING_API_PASSWORD" -c "SELECT count(*) FROM billing.invoices;"
+
+echo "Verifying billing worker can update but not insert"
+psql_as billing_worker "$BILLING_WORKER_PASSWORD" -c "UPDATE billing.invoices SET status = 'paid' WHERE id = 1;"
+expect_denied "billing_worker cannot update customers" \
+  psql_as billing_worker "$BILLING_WORKER_PASSWORD" -c "UPDATE billing.customers SET email = 'worker@example.com' WHERE id = 1;"
+expect_denied "billing_worker cannot insert invoices" \
+  psql_as billing_worker "$BILLING_WORKER_PASSWORD" -c "INSERT INTO billing.invoices (customer_id, amount_cents) VALUES (1, 1000);"
+
+echo "Verifying shipping API can write shipping data"
+psql_as shipping_api "$SHIPPING_API_PASSWORD" -c "INSERT INTO shipping.shipments (billing_invoice_id, destination) VALUES (1, 'Auckland');"
+expect_sqlstate 23503 "shipping_api cannot create shipment for a missing invoice" \
+  psql_as shipping_api "$SHIPPING_API_PASSWORD" -c "INSERT INTO shipping.shipments (billing_invoice_id, destination) VALUES (999999, 'No linked invoice');"
+psql_as shipping_api "$SHIPPING_API_PASSWORD" -c "UPDATE shipping.shipments SET status = 'packed' WHERE id = 1;"
+psql_as shipping_api "$SHIPPING_API_PASSWORD" -c "SELECT count(*) FROM shipping.shipments;"
+
+echo "Verifying shipping reports are read-only"
+psql_as shipping_reports "$SHIPPING_REPORTS_PASSWORD" -c "SELECT count(*) FROM shipping.shipments;"
+expect_denied "shipping_reports cannot insert shipments" \
+  psql_as shipping_reports "$SHIPPING_REPORTS_PASSWORD" -c "INSERT INTO shipping.shipments (billing_invoice_id, destination) VALUES (1, 'Wellington');"
+
+echo "Verifying team memberships and cross-team isolation"
+psql_as alice_payments "$ALICE_PAYMENTS_PASSWORD" -c "SELECT count(*) FROM billing.invoices;"
+expect_denied "alice_payments cannot read shipping" \
+  psql_as alice_payments "$ALICE_PAYMENTS_PASSWORD" -c "SELECT count(*) FROM shipping.shipments;"
+expect_denied "alice_payments cannot write billing" \
+  psql_as alice_payments "$ALICE_PAYMENTS_PASSWORD" -c "UPDATE billing.invoices SET status = 'void' WHERE id = 1;"
+
+psql_as bob_fulfillment "$BOB_FULFILLMENT_PASSWORD" -c "SELECT count(*) FROM shipping.shipments;"
+expect_denied "bob_fulfillment cannot read billing" \
+  psql_as bob_fulfillment "$BOB_FULFILLMENT_PASSWORD" -c "SELECT count(*) FROM billing.invoices;"
+expect_denied "bob_fulfillment cannot write shipping" \
+  psql_as bob_fulfillment "$BOB_FULFILLMENT_PASSWORD" -c "UPDATE shipping.shipments SET status = 'delivered' WHERE id = 1;"
+
+echo "Verifying cross-service isolation"
+expect_denied "billing_api cannot read shipping" \
+  psql_as billing_api "$BILLING_API_PASSWORD" -c "SELECT count(*) FROM shipping.shipments;"
+expect_denied "shipping_api cannot read billing" \
+  psql_as shipping_api "$SHIPPING_API_PASSWORD" -c "SELECT count(*) FROM billing.invoices;"
+
+echo "Microservices example passed"


### PR DESCRIPTION
## Summary
- add an executable multi-service example with billing and shipping services, team roles, migrator roles, and tightly scoped app roles
- add a CI example smoke test that applies the manifest, runs migrations as service migrators, and verifies allowed/denied PostgreSQL access for each role
- document the example in the tooling guide and run docs builds on docs PRs while keeping Pages deploy push-only

## Validation
- DATABASE_URL=postgres://postgres:testpassword@localhost:55432/pgroles_test ./scripts/test-microservices-example.sh
- npm run build (docs)
- SQLX_OFFLINE=true cargo test --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a comprehensive microservices example demonstrating multi-service permission management with role-based access control across shared database schemas.

* **Documentation**
  * Expanded tooling docs with bundle mode guidance, role model patterns, and schema ownership boundaries.
  * Clarified default privileges behavior, convergent revocation mechanics, and operator reconciliation.
  * Updated deployment guidance with service-specific role and cross-team access examples.

* **Tests**
  * Added automated validation for the microservices example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/112)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->