### PR TITLE
Use ALL ROUTINES for function wildcard grants

### DIFF
--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -3142,6 +3142,38 @@ grants:
             .success()
             .stdout(predicate::str::contains("No changes needed"));
 
+        let removed_manifest_file = write_temp_manifest(&format!(
+            r#"
+roles:
+  - name: {role}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                removed_manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success();
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                removed_manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
         execute_sql(&format!(
             r#"
             DROP SCHEMA IF EXISTS "{schema}" CASCADE;
@@ -4449,7 +4481,7 @@ retirements:
     /// This test creates a function with a long signature, applies a wildcard
     /// EXECUTE grant, and asserts a follow-up diff converges to zero changes.
     /// Before the inventory-column casts, the second diff would re-emit
-    /// `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA ... TO ...` forever.
+    /// `GRANT EXECUTE ON ALL ROUTINES IN SCHEMA ... TO ...` forever.
     #[test]
     #[ignore]
     fn wildcard_function_grant_converges_with_signature_longer_than_63_bytes() {

--- a/crates/pgroles-cli/tests/cli.rs
+++ b/crates/pgroles-cli/tests/cli.rs
@@ -3089,6 +3089,69 @@ grants:
 
     #[test]
     #[ignore]
+    fn wildcard_function_grant_converges_with_procedures_in_schema() {
+        let schema = unique_name("wildfn_proc_schema");
+        let role = unique_name("wildfn_proc_role");
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{role}";
+            CREATE SCHEMA "{schema}";
+            CREATE FUNCTION "{schema}".do_thing() RETURNS int LANGUAGE sql AS 'SELECT 1';
+            CREATE PROCEDURE "{schema}".run_something() LANGUAGE sql AS 'SELECT 1';
+            REVOKE EXECUTE ON FUNCTION "{schema}".do_thing() FROM PUBLIC;
+            REVOKE EXECUTE ON PROCEDURE "{schema}".run_something() FROM PUBLIC;
+            "#
+        ));
+
+        let manifest_file = write_temp_manifest(&format!(
+            r#"
+roles:
+  - name: {role}
+
+grants:
+  - role: {role}
+    privileges: [EXECUTE]
+    object: {{ type: function, schema: {schema}, name: "*" }}
+"#
+        ));
+
+        pgroles_cmd()
+            .args([
+                "apply",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+            ])
+            .assert()
+            .success();
+
+        pgroles_cmd()
+            .args([
+                "diff",
+                "--file",
+                manifest_file.path().to_str().unwrap(),
+                "--database-url",
+                &database_url(),
+                "--format",
+                "summary",
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("No changes needed"));
+
+        execute_sql(&format!(
+            r#"
+            DROP SCHEMA IF EXISTS "{schema}" CASCADE;
+            DROP ROLE IF EXISTS "{role}";
+            "#
+        ));
+    }
+
+    #[test]
+    #[ignore]
     fn wildcard_function_grant_fails_before_partial_apply_when_object_not_grantable() {
         let schema = unique_name("wildfn_mixed_owner_schema");
         let executor = unique_name("wildfn_executor");
@@ -3153,7 +3216,7 @@ grants:
             .stderr(predicate::str::contains("UnsatisfiableWildcardGrant"))
             .stderr(predicate::str::contains("f2()"))
             .stderr(predicate::str::contains(&definer))
-            .stderr(predicate::str::contains("GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA").not());
+            .stderr(predicate::str::contains("GRANT EXECUTE ON ALL ROUTINES IN SCHEMA").not());
 
         pgroles_cmd()
             .args([

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -1947,7 +1947,7 @@ memberships:
     /// privilege, e.g. a function that was DROPped+CREATEd between reconciles
     /// resetting its proacl to NULL), `diff()` must NOT emit per-name REVOKEs
     /// for objects covered by the desired wildcard. Otherwise apply order
-    /// (GRANTs before REVOKEs) re-grants on ALL FUNCTIONS and then strips
+    /// (GRANTs before REVOKEs) re-grants on ALL ROUTINES and then strips
     /// privileges from the previously-granted set, producing a permanent
     /// oscillation between two stable states.
     #[test]

--- a/crates/pgroles-core/src/sql.rs
+++ b/crates/pgroles-core/src/sql.rs
@@ -512,14 +512,14 @@ fn format_function_target(schema: Option<&str>, function_name: &str) -> String {
             let base_name = &function_name[..paren_idx];
             let args = &function_name[paren_idx..];
             format!(
-                "FUNCTION {}.{}{}",
+                "ROUTINE {}.{}{}",
                 quote_ident(schema_name),
                 quote_ident(base_name),
                 args
             )
         }
         _ => format!(
-            "FUNCTION {}.{}",
+            "ROUTINE {}.{}",
             quote_ident(schema_name),
             quote_ident(function_name)
         ),
@@ -533,7 +533,7 @@ fn sql_object_type_keyword(object_type: ObjectType) -> &'static str {
         ObjectType::View => "TABLE", // PostgreSQL treats views as tables for GRANT
         ObjectType::MaterializedView => "TABLE", // Same
         ObjectType::Sequence => "SEQUENCE",
-        ObjectType::Function => "FUNCTION",
+        ObjectType::Function => "ROUTINE",
         ObjectType::Schema => "SCHEMA",
         ObjectType::Database => "DATABASE",
         ObjectType::Type => "TYPE",
@@ -545,7 +545,7 @@ fn sql_object_type_plural(object_type: ObjectType) -> &'static str {
     match object_type {
         ObjectType::Table | ObjectType::View | ObjectType::MaterializedView => "TABLES",
         ObjectType::Sequence => "SEQUENCES",
-        ObjectType::Function => "FUNCTIONS",
+        ObjectType::Function => "ROUTINES",
         // PostgreSQL has no ALL TYPES IN SCHEMA syntax. Type grants should use
         // specific object names, not wildcards. If we get here the manifest is
         // likely misconfigured, but produce the closest valid SQL anyway.
@@ -889,7 +889,23 @@ mod tests {
         let sql = render(&change);
         assert_eq!(
             sql,
-            "GRANT EXECUTE ON FUNCTION \"public\".\"refresh_users\"(integer, text) TO \"r1\";"
+            "GRANT EXECUTE ON ROUTINE \"public\".\"refresh_users\"(integer, text) TO \"r1\";"
+        );
+    }
+
+    #[test]
+    fn render_revoke_specific_routine_for_function_object() {
+        let change = Change::Revoke {
+            role: "r1".to_string(),
+            privileges: BTreeSet::from([Privilege::Execute]),
+            object_type: ObjectType::Function,
+            schema: Some("public".to_string()),
+            name: Some("run_something()".to_string()),
+        };
+        let sql = render(&change);
+        assert_eq!(
+            sql,
+            "REVOKE EXECUTE ON ROUTINE \"public\".\"run_something\"() FROM \"r1\";"
         );
     }
 
@@ -953,7 +969,7 @@ mod tests {
         let sql = render(&change);
         assert_eq!(
             sql,
-            "ALTER DEFAULT PRIVILEGES FOR ROLE \"app_owner\" IN SCHEMA \"inventory\" REVOKE EXECUTE ON FUNCTIONS FROM \"inventory-editor\";"
+            "ALTER DEFAULT PRIVILEGES FOR ROLE \"app_owner\" IN SCHEMA \"inventory\" REVOKE EXECUTE ON ROUTINES FROM \"inventory-editor\";"
         );
     }
 

--- a/crates/pgroles-core/src/sql.rs
+++ b/crates/pgroles-core/src/sql.rs
@@ -469,7 +469,7 @@ fn format_object_target(
         ObjectType::Function => match name {
             Some("*") => {
                 let schema_name = schema.unwrap_or("public");
-                format!("ALL FUNCTIONS IN SCHEMA {}", quote_ident(schema_name))
+                format!("ALL ROUTINES IN SCHEMA {}", quote_ident(schema_name))
             }
             Some(function_name) => format_function_target(schema, function_name),
             None => {
@@ -890,6 +890,22 @@ mod tests {
         assert_eq!(
             sql,
             "GRANT EXECUTE ON FUNCTION \"public\".\"refresh_users\"(integer, text) TO \"r1\";"
+        );
+    }
+
+    #[test]
+    fn render_grant_all_routines_for_function_wildcard() {
+        let change = Change::Grant {
+            role: "inventory-editor".to_string(),
+            privileges: BTreeSet::from([Privilege::Execute]),
+            object_type: ObjectType::Function,
+            schema: Some("inventory".to_string()),
+            name: Some("*".to_string()),
+        };
+        let sql = render(&change);
+        assert_eq!(
+            sql,
+            "GRANT EXECUTE ON ALL ROUTINES IN SCHEMA \"inventory\" TO \"inventory-editor\";"
         );
     }
 

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -2783,7 +2783,7 @@ mod tests {
                 ..Default::default()
             }),
             planned_sql: Some(
-                "GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA \"app\" TO \"reader\";".into(),
+                "GRANT EXECUTE ON ALL ROUTINES IN SCHEMA \"app\" TO \"reader\";".into(),
             ),
             planned_sql_truncated: true,
             last_error: None,


### PR DESCRIPTION
## Summary

- Render `function: "*"` wildcard grants/revokes as `ALL ROUTINES IN SCHEMA` so PostgreSQL procedures are covered alongside functions.
- Keep the existing manifest object type name for compatibility while aligning SQL emission with the `pg_proc` inventory inspected during wildcard normalization.
- Add a live CLI regression covering a schema with one function and one procedure, asserting apply followed by summary diff converges.

## Validation

- `cargo fmt --all -- --check`
- `SQLX_OFFLINE=true cargo test -p pgroles-core`
- `SQLX_OFFLINE=true cargo test -p pgroles-inspect`
- `cargo test -p pgroles-operator reconciler::tests::unsatisfiable_wildcard_status_is_degraded_without_plan_reference`
- `DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test cargo test -p pgroles-cli --test cli wildcard_function_grant_converges_with_procedures_in_schema -- --ignored --nocapture`
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SQL generation for function grants/revokes now uses "ALL ROUTINES IN SCHEMA" and "ROUTINE ..." wording for better PostgreSQL correctness.

* **Tests**
  * Added a reconciliation test covering wildcard grants when procedures and functions coexist.
  * Updated test assertions to match the new SQL output.

* **Documentation**
  * Clarified wildcard-grant regression comments to reference "ALL ROUTINES" terminology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/113)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->