### PR TITLE
Add GCP Workload Identity auth for operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,8 +904,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -909,9 +917,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1142,6 +1152,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1627,6 +1638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2038,7 @@ dependencies = [
  "pgroles-core",
  "pgroles-inspect",
  "rand 0.10.1",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -2204,6 +2222,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,16 +2455,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2399,6 +2477,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2434,6 +2513,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2490,6 +2575,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3633,6 +3719,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # Async utilities
 futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 axum = "0.8.9"
 opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", features = ["metrics", "rt-tokio", "testing"] }

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -82,6 +82,36 @@
                         "description": "Structured connection parameters. Each field is either a plain string\nor a reference to a Secret key. Mutually exclusive with `secretRef`.",
                         "nullable": true,
                         "properties": {
+                          "auth": {
+                            "description": "Provider-backed authentication for connections that use short-lived\ncredentials instead of a static PostgreSQL password.",
+                            "nullable": true,
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "type"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "impersonateServiceAccount": {
+                                "description": "Target Google service account to impersonate before requesting the\nCloud SQL login token. Omit to use the pod's bound identity.",
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "scope": {
+                                "description": "OAuth scope requested for the access token.",
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": [
+                                  "gcp_workload_identity"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "dbname": {
                             "description": "Database name as a literal value.",
                             "nullable": true,

--- a/crates/pgroles-operator/Cargo.toml
+++ b/crates/pgroles-operator/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.22.1"
 sha2 = "0.11"
 percent-encoding = "2.3.2"
 flate2 = "1.1.5"
+reqwest = { workspace = true }
 
 [[bin]]
 name = "pgroles-operator"

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -2,14 +2,16 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
+use futures::future::{BoxFuture, FutureExt};
 use kube::runtime::events::Recorder;
-use std::time::Duration;
+use serde::{Deserialize, Serialize};
 
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tokio::sync::{Mutex, RwLock};
 
-use crate::crd::{ConnectionSpec, SecretKeySelector};
+use crate::crd::{ConnectionAuth, ConnectionSpec, SecretKeySelector};
 use crate::observability::OperatorObservability;
 
 /// Minimum pool size required for reconciliation.
@@ -24,12 +26,256 @@ const POOL_ACQUIRE_TIMEOUT_SECS: u64 = 10;
 
 const _: () = assert!(POOL_MAX_CONNECTIONS >= 2);
 
+const GCP_METADATA_TOKEN_ENDPOINT: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const GCP_IAM_CREDENTIALS_SCOPE: &str = "https://www.googleapis.com/auth/cloud-platform";
+const GCP_TOKEN_CACHE_SKEW_SECS: u64 = 300;
+const GCP_IMPERSONATED_TOKEN_LIFETIME_SECS: u64 = 3600;
+const GCP_AUTH_HTTP_TIMEOUT_SECS: u64 = 10;
+
 #[derive(Clone)]
 struct CachedPool {
     resource_version: Option<String>,
     /// Fingerprint of all referenced secrets' resourceVersions (params mode).
     secret_fingerprint: Option<String>,
+    /// Expiry for token-backed connection passwords.
+    token_expires_at: Option<SystemTime>,
     pool: PgPool,
+}
+
+struct ResolvedConnectionUrl {
+    database_url: String,
+    token_expires_at: Option<SystemTime>,
+}
+
+#[derive(Clone)]
+struct GcpAccessToken {
+    token: String,
+    expires_at: SystemTime,
+}
+
+trait GcpAccessTokenProvider: Send + Sync {
+    fn fetch_token<'a>(
+        &'a self,
+        auth: &'a ConnectionAuth,
+    ) -> BoxFuture<'a, Result<GcpAccessToken, ContextError>>;
+}
+
+#[derive(Clone)]
+struct MetadataGcpAccessTokenProvider {
+    client: reqwest::Client,
+}
+
+impl Default for MetadataGcpAccessTokenProvider {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(GCP_AUTH_HTTP_TIMEOUT_SECS))
+                .build()
+                .expect("GCP auth HTTP client should build"),
+        }
+    }
+}
+
+impl GcpAccessTokenProvider for MetadataGcpAccessTokenProvider {
+    fn fetch_token<'a>(
+        &'a self,
+        auth: &'a ConnectionAuth,
+    ) -> BoxFuture<'a, Result<GcpAccessToken, ContextError>> {
+        async move {
+            let scope = auth.gcp_scope();
+            if let Some(target) = auth.gcp_impersonate_service_account() {
+                self.fetch_impersonated_access_token(target, scope).await
+            } else {
+                self.fetch_metadata_access_token(scope).await
+            }
+        }
+        .boxed()
+    }
+}
+
+impl MetadataGcpAccessTokenProvider {
+    async fn fetch_metadata_access_token(
+        &self,
+        scope: &str,
+    ) -> Result<GcpAccessToken, ContextError> {
+        let response = self
+            .client
+            .get(GCP_METADATA_TOKEN_ENDPOINT)
+            .header("Metadata-Flavor", "Google")
+            .query(&[("scopes", scope)])
+            .send()
+            .await
+            .map_err(|source| ContextError::GcpAuthHttp {
+                endpoint: "metadata",
+                source,
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response_body_for_error(response).await;
+            return Err(ContextError::GcpAuthRejected {
+                endpoint: "metadata".to_string(),
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let body: MetadataTokenResponse =
+            response
+                .json()
+                .await
+                .map_err(|source| ContextError::GcpAuthHttp {
+                    endpoint: "metadata",
+                    source,
+                })?;
+
+        if body.access_token.trim().is_empty() {
+            return Err(ContextError::GcpAuthInvalidResponse {
+                detail: "metadata token response omitted access_token".to_string(),
+            });
+        }
+        if body.expires_in == 0 {
+            return Err(ContextError::GcpAuthInvalidResponse {
+                detail: "metadata token response had zero expires_in".to_string(),
+            });
+        }
+
+        Ok(GcpAccessToken {
+            token: body.access_token,
+            expires_at: SystemTime::now() + Duration::from_secs(body.expires_in),
+        })
+    }
+
+    async fn fetch_impersonated_access_token(
+        &self,
+        target_service_account: &str,
+        scope: &str,
+    ) -> Result<GcpAccessToken, ContextError> {
+        let source = self
+            .fetch_metadata_access_token(GCP_IAM_CREDENTIALS_SCOPE)
+            .await?;
+        let encoded_target = percent_encoding::utf8_percent_encode(
+            target_service_account,
+            percent_encoding::NON_ALPHANUMERIC,
+        )
+        .to_string();
+        let endpoint = format!(
+            "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{encoded_target}:generateAccessToken"
+        );
+        let request = GenerateAccessTokenRequest {
+            scope: vec![scope.to_string()],
+            lifetime: format!("{GCP_IMPERSONATED_TOKEN_LIFETIME_SECS}s"),
+        };
+
+        let response = self
+            .client
+            .post(&endpoint)
+            .bearer_auth(&source.token)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|source| ContextError::GcpAuthHttp {
+                endpoint: "iamcredentials",
+                source,
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response_body_for_error(response).await;
+            return Err(ContextError::GcpAuthRejected {
+                endpoint: "iamcredentials".to_string(),
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let body: GenerateAccessTokenResponse =
+            response
+                .json()
+                .await
+                .map_err(|source| ContextError::GcpAuthHttp {
+                    endpoint: "iamcredentials",
+                    source,
+                })?;
+
+        if body.access_token.trim().is_empty() {
+            return Err(ContextError::GcpAuthInvalidResponse {
+                detail: "IAMCredentials response omitted accessToken".to_string(),
+            });
+        }
+        let expires_at = parse_google_expire_time(&body.expire_time).ok_or_else(|| {
+            ContextError::GcpAuthInvalidResponse {
+                detail: format!(
+                    "IAMCredentials response had invalid expireTime {:?}",
+                    body.expire_time
+                ),
+            }
+        })?;
+
+        Ok(GcpAccessToken {
+            token: body.access_token,
+            expires_at,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct MetadataTokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+#[derive(Serialize)]
+struct GenerateAccessTokenRequest {
+    scope: Vec<String>,
+    lifetime: String,
+}
+
+#[derive(Deserialize)]
+struct GenerateAccessTokenResponse {
+    #[serde(rename = "accessToken")]
+    access_token: String,
+    #[serde(rename = "expireTime")]
+    expire_time: String,
+}
+
+async fn response_body_for_error(response: reqwest::Response) -> String {
+    match response.text().await {
+        Ok(body) => truncate_for_error(body),
+        Err(error) => format!("failed to read error body: {error}"),
+    }
+}
+
+fn truncate_for_error(mut body: String) -> String {
+    const MAX_ERROR_BODY_BYTES: usize = 512;
+    if body.len() <= MAX_ERROR_BODY_BYTES {
+        return body;
+    }
+    let mut end = MAX_ERROR_BODY_BYTES;
+    while !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    body.truncate(end);
+    body.push_str("...");
+    body
+}
+
+fn parse_google_expire_time(expire_time: &str) -> Option<SystemTime> {
+    expire_time
+        .parse::<jiff::Timestamp>()
+        .ok()
+        .map(SystemTime::from)
+}
+
+fn token_expires_after_skew(expires_at: Option<SystemTime>, now: SystemTime) -> bool {
+    let Some(expires_at) = expires_at else {
+        return true;
+    };
+    let Some(refresh_at) = now.checked_add(Duration::from_secs(GCP_TOKEN_CACHE_SKEW_SECS)) else {
+        return false;
+    };
+    expires_at > refresh_at
 }
 
 /// Guard returned by [`OperatorContext::try_lock_database`].
@@ -97,6 +343,9 @@ pub struct OperatorContext {
 
     /// Shared health/metrics state.
     pub observability: OperatorObservability,
+
+    /// Fetches short-lived provider-backed database passwords.
+    gcp_token_provider: Arc<dyn GcpAccessTokenProvider>,
 }
 
 impl OperatorContext {
@@ -112,6 +361,7 @@ impl OperatorContext {
             pool_cache: Arc::new(RwLock::new(HashMap::new())),
             observability,
             database_locks: Arc::new(Mutex::new(HashMap::new())),
+            gcp_token_provider: Arc::new(MetadataGcpAccessTokenProvider::default()),
         }
     }
 
@@ -167,14 +417,30 @@ impl OperatorContext {
         namespace: &str,
         connection: &ConnectionSpec,
     ) -> Result<String, ContextError> {
+        Ok(self
+            .resolve_connection_url_with_metadata(namespace, connection)
+            .await?
+            .database_url)
+    }
+
+    async fn resolve_connection_url_with_metadata(
+        &self,
+        namespace: &str,
+        connection: &ConnectionSpec,
+    ) -> Result<ResolvedConnectionUrl, ContextError> {
         if let Some(ref secret_ref) = connection.secret_ref {
             // URL mode — read the full connection URL from the Secret.
-            self.fetch_secret_value(
-                namespace,
-                &secret_ref.name,
-                connection.effective_secret_key(),
-            )
-            .await
+            let database_url = self
+                .fetch_secret_value(
+                    namespace,
+                    &secret_ref.name,
+                    connection.effective_secret_key(),
+                )
+                .await?;
+            Ok(ResolvedConnectionUrl {
+                database_url,
+                token_expires_at: None,
+            })
         } else if let Some(ref params) = connection.params {
             // Params mode — resolve each field and build the URL.
             let host = self
@@ -224,12 +490,18 @@ impl OperatorContext {
                 });
             }
 
-            let password = self
-                .resolve_param(namespace, &params.password, &params.password_secret)
-                .await?
-                .ok_or_else(|| ContextError::EmptyResolvedValue {
-                    field: "password".to_string(),
-                })?;
+            let (password, token_expires_at) = if let Some(auth) = &params.auth {
+                let token = self.gcp_token_provider.fetch_token(auth).await?;
+                (token.token, Some(token.expires_at))
+            } else {
+                let password = self
+                    .resolve_param(namespace, &params.password, &params.password_secret)
+                    .await?
+                    .ok_or_else(|| ContextError::EmptyResolvedValue {
+                        field: "password".to_string(),
+                    })?;
+                (password, None)
+            };
             if password.trim().is_empty() {
                 return Err(ContextError::EmptyResolvedValue {
                     field: "password".to_string(),
@@ -244,10 +516,11 @@ impl OperatorContext {
                 "postgresql://{encoded_username}:{encoded_password}@{host}:{port}/{dbname}"
             );
 
-            if let Some(ssl_mode) = self
+            let ssl_mode = self
                 .resolve_param(namespace, &params.ssl_mode, &params.ssl_mode_secret)
                 .await?
-            {
+                .or_else(|| params.auth.as_ref().map(|_| "require".to_string()));
+            if let Some(ssl_mode) = ssl_mode {
                 // Validate sslMode at runtime — CRD validation only catches
                 // literal values; a secret ref could resolve to anything.
                 if !crate::crd::VALID_SSL_MODES.contains(&ssl_mode.as_str()) {
@@ -257,7 +530,10 @@ impl OperatorContext {
                 url.push_str(&ssl_mode);
             }
 
-            Ok(url)
+            Ok(ResolvedConnectionUrl {
+                database_url: url,
+                token_expires_at,
+            })
         } else {
             Err(ContextError::SecretMissing {
                 name: "connection".to_string(),
@@ -340,13 +616,17 @@ impl OperatorContext {
                     (None, None) => true,
                     _ => false,
                 };
-                if version_matches && fingerprint_matches {
+                let token_fresh =
+                    token_expires_after_skew(cached.token_expires_at, SystemTime::now());
+                if version_matches && fingerprint_matches && token_fresh {
                     return Ok(cached.pool.clone());
                 }
             }
         }
 
-        let database_url = self.resolve_connection_url(namespace, connection).await?;
+        let resolved = self
+            .resolve_connection_url_with_metadata(namespace, connection)
+            .await?;
 
         // Create pool with explicit sizing. Reconciliation holds one dedicated
         // connection for PostgreSQL advisory locking and needs additional pool
@@ -354,7 +634,7 @@ impl OperatorContext {
         let pool = PgPoolOptions::new()
             .max_connections(POOL_MAX_CONNECTIONS)
             .acquire_timeout(Duration::from_secs(POOL_ACQUIRE_TIMEOUT_SECS))
-            .connect(&database_url)
+            .connect(&resolved.database_url)
             .await
             .map_err(|err| ContextError::DatabaseConnect { source: err })?;
 
@@ -366,6 +646,7 @@ impl OperatorContext {
                 CachedPool {
                     resource_version,
                     secret_fingerprint,
+                    token_expires_at: resolved.token_expires_at,
                     pool: pool.clone(),
                 },
             );
@@ -445,6 +726,22 @@ pub enum ContextError {
         "connection param sslMode resolved to invalid value \"{value}\" (expected one of: disable, allow, prefer, require, verify-ca, verify-full)"
     )]
     InvalidResolvedSslMode { value: String },
+
+    #[error("failed to fetch GCP auth token from {endpoint}: {source}")]
+    GcpAuthHttp {
+        endpoint: &'static str,
+        source: reqwest::Error,
+    },
+
+    #[error("GCP auth token endpoint {endpoint} returned HTTP {status}: {body}")]
+    GcpAuthRejected {
+        endpoint: String,
+        status: u16,
+        body: String,
+    },
+
+    #[error("GCP auth token response was invalid: {detail}")]
+    GcpAuthInvalidResponse { detail: String },
 }
 
 impl ContextError {
@@ -457,6 +754,14 @@ impl ContextError {
                 ..
             } if (400..500).contains(&response.code) && response.code != 429
         )
+    }
+
+    pub fn is_gcp_auth_non_transient(&self) -> bool {
+        matches!(
+            self,
+            ContextError::GcpAuthRejected { status, .. }
+                if (400..500).contains(status) && *status != 429
+        ) || matches!(self, ContextError::GcpAuthInvalidResponse { .. })
     }
 }
 
@@ -514,6 +819,63 @@ mod tests {
         };
 
         assert!(!error.is_secret_fetch_non_transient());
+    }
+
+    #[test]
+    fn gcp_auth_client_error_is_non_transient() {
+        let error = ContextError::GcpAuthRejected {
+            endpoint: "metadata".into(),
+            status: 403,
+            body: "forbidden".into(),
+        };
+
+        assert!(error.is_gcp_auth_non_transient());
+    }
+
+    #[test]
+    fn gcp_auth_rate_limit_remains_transient() {
+        let error = ContextError::GcpAuthRejected {
+            endpoint: "metadata".into(),
+            status: 429,
+            body: "rate limited".into(),
+        };
+
+        assert!(!error.is_gcp_auth_non_transient());
+    }
+
+    #[test]
+    fn token_expiry_uses_five_minute_refresh_skew() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        assert!(token_expires_after_skew(
+            Some(now + Duration::from_secs(GCP_TOKEN_CACHE_SKEW_SECS + 1)),
+            now
+        ));
+        assert!(!token_expires_after_skew(
+            Some(now + Duration::from_secs(GCP_TOKEN_CACHE_SKEW_SECS)),
+            now
+        ));
+    }
+
+    #[test]
+    fn parse_google_expire_time_accepts_rfc3339() {
+        let parsed =
+            parse_google_expire_time("2026-05-14T02:30:00Z").expect("expireTime should parse");
+        assert_eq!(
+            parsed
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+            1_778_725_800
+        );
+    }
+
+    #[test]
+    fn truncate_for_error_keeps_utf8_boundary() {
+        let body = "é".repeat(300);
+        let truncated = truncate_for_error(body);
+
+        assert!(truncated.ends_with("..."));
+        assert!(truncated.is_char_boundary(truncated.len() - 3));
     }
 
     #[tokio::test]

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -70,6 +70,7 @@ impl Default for MetadataGcpAccessTokenProvider {
     fn default() -> Self {
         Self {
             client: reqwest::Client::builder()
+                .no_proxy()
                 .timeout(Duration::from_secs(GCP_AUTH_HTTP_TIMEOUT_SECS))
                 .build()
                 .expect("GCP auth HTTP client should build"),

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -2468,14 +2468,14 @@ params:
   auth:
     type: gcp_workload_identity
     impersonateServiceAccount: target@other-project.iam.gserviceaccount.com
-    scope: https://www.googleapis.com/auth/sqlservice.login
+    scope: https://example.com/custom-scope
 "#;
         let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
         let params = conn.params.as_ref().unwrap();
         let auth = params.auth.as_ref().expect("auth should deserialize");
 
         assert!(params.password.is_none());
-        assert_eq!(auth.gcp_scope(), DEFAULT_GCP_CLOUD_SQL_LOGIN_SCOPE);
+        assert_eq!(auth.gcp_scope(), "https://example.com/custom-scope");
         assert_eq!(
             auth.gcp_impersonate_service_account(),
             Some("target@other-project.iam.gserviceaccount.com")

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -217,6 +217,9 @@ impl From<CrdReconciliationMode> for pgroles_core::diff::ReconciliationMode {
 ///     usernameSecret: { name: zalando-creds, key: username }
 ///     passwordSecret: { name: zalando-creds, key: password }
 /// ```
+///
+/// Params mode can also use provider-backed authentication instead of a static
+/// password, for example GKE Workload Identity to Cloud SQL IAM.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectionSpec {
@@ -310,6 +313,11 @@ impl ConnectionSpec {
         if let Some(ref params) = self.params {
             let user_part = field_identity_repr(&params.username, &params.username_secret);
             let pass_part = field_identity_repr(&params.password, &params.password_secret);
+            let auth_part = params
+                .auth
+                .as_ref()
+                .map(ConnectionAuth::cache_key)
+                .unwrap_or_default();
             let ssl_part = params
                 .ssl_mode
                 .as_ref()
@@ -322,7 +330,7 @@ impl ConnectionSpec {
                 })
                 .unwrap_or_default();
             format!(
-                "{namespace}/{}\0user={user_part}\0pass={pass_part}\0ssl={ssl_part}",
+                "{namespace}/{}\0user={user_part}\0pass={pass_part}\0auth={auth_part}\0ssl={ssl_part}",
                 self.identity_key()
             )
         } else {
@@ -344,6 +352,10 @@ fn field_identity_repr(literal: &Option<String>, secret: &Option<SecretKeySelect
         String::new()
     }
 }
+
+/// Default OAuth scope used for Cloud SQL IAM database login tokens.
+pub const DEFAULT_GCP_CLOUD_SQL_LOGIN_SCOPE: &str =
+    "https://www.googleapis.com/auth/sqlservice.login";
 
 /// Structured connection parameters for building a PostgreSQL connection URL.
 ///
@@ -403,12 +415,70 @@ pub struct ConnectionParams {
     #[serde(default)]
     pub password_secret: Option<SecretKeySelector>,
 
+    /// Provider-backed authentication for connections that use short-lived
+    /// credentials instead of a static PostgreSQL password.
+    #[serde(default)]
+    pub auth: Option<ConnectionAuth>,
+
     /// SSL mode as a literal value.
     #[serde(default)]
     pub ssl_mode: Option<String>,
     /// SSL mode from a Secret key.
     #[serde(default)]
     pub ssl_mode_secret: Option<SecretKeySelector>,
+}
+
+/// Provider-backed authentication for `connection.params`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum ConnectionAuth {
+    /// Fetch a Cloud SQL IAM database login token using the GKE metadata
+    /// server. `username` must be the Cloud SQL PostgreSQL IAM role name
+    /// (for service accounts, the email without `.gserviceaccount.com`).
+    #[serde(rename = "gcp_workload_identity", rename_all = "camelCase")]
+    GcpWorkloadIdentity {
+        /// Target Google service account to impersonate before requesting the
+        /// Cloud SQL login token. Omit to use the pod's bound identity.
+        #[serde(default)]
+        impersonate_service_account: Option<String>,
+        /// OAuth scope requested for the access token.
+        #[serde(default)]
+        scope: Option<String>,
+    },
+}
+
+impl ConnectionAuth {
+    pub fn gcp_scope(&self) -> &str {
+        match self {
+            Self::GcpWorkloadIdentity { scope, .. } => scope
+                .as_deref()
+                .unwrap_or(DEFAULT_GCP_CLOUD_SQL_LOGIN_SCOPE),
+        }
+    }
+
+    pub fn gcp_impersonate_service_account(&self) -> Option<&str> {
+        match self {
+            Self::GcpWorkloadIdentity {
+                impersonate_service_account,
+                ..
+            } => impersonate_service_account.as_deref(),
+        }
+    }
+
+    fn cache_key(&self) -> String {
+        match self {
+            Self::GcpWorkloadIdentity {
+                impersonate_service_account,
+                scope,
+            } => format!(
+                "gcp_workload_identity\0impersonate={}\0scope={}",
+                impersonate_service_account.as_deref().unwrap_or_default(),
+                scope
+                    .as_deref()
+                    .unwrap_or(DEFAULT_GCP_CLOUD_SQL_LOGIN_SCOPE)
+            ),
+        }
+    }
 }
 
 /// Reference to a specific key within a Kubernetes Secret.
@@ -618,6 +688,12 @@ pub enum ConnectionValidationError {
         "connection.params: only one of {field} or {field}Secret may be set, but both were provided"
     )]
     BothFieldsSet { field: String },
+
+    #[error("connection.params.auth: {field} must not be empty or whitespace-only")]
+    EmptyAuthField { field: String },
+
+    #[error("connection.params: password/passwordSecret are mutually exclusive with auth")]
+    AuthWithPassword,
 }
 
 /// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules:
@@ -1152,11 +1228,39 @@ impl PostgresPolicySpec {
                     Ok(())
                 }
 
-                // Required fields: host, dbname, username, password.
+                // Required fields: host, dbname, username. Password is only
+                // required for static-password auth.
                 validate_required_field("host", &params.host, &params.host_secret)?;
                 validate_required_field("dbname", &params.dbname, &params.dbname_secret)?;
                 validate_required_field("username", &params.username, &params.username_secret)?;
-                validate_required_field("password", &params.password, &params.password_secret)?;
+                if let Some(auth) = &params.auth {
+                    if params.password.is_some() || params.password_secret.is_some() {
+                        return Err(ConnectionValidationError::AuthWithPassword);
+                    }
+                    match auth {
+                        ConnectionAuth::GcpWorkloadIdentity {
+                            impersonate_service_account,
+                            scope,
+                        } => {
+                            if let Some(value) = impersonate_service_account
+                                && value.trim().is_empty()
+                            {
+                                return Err(ConnectionValidationError::EmptyAuthField {
+                                    field: "impersonateServiceAccount".to_string(),
+                                });
+                            }
+                            if let Some(value) = scope
+                                && value.trim().is_empty()
+                            {
+                                return Err(ConnectionValidationError::EmptyAuthField {
+                                    field: "scope".to_string(),
+                                });
+                            }
+                        }
+                    }
+                } else {
+                    validate_required_field("password", &params.password, &params.password_secret)?;
+                }
 
                 // Optional fields: port, sslMode.
                 // Port is u16 so we wrap it for the generic check.
@@ -1758,6 +1862,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass-a".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1776,6 +1881,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass-b".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1812,6 +1918,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1833,6 +1940,7 @@ mod tests {
                 }),
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1861,6 +1969,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1879,6 +1988,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: Some("require".into()),
                 ssl_mode_secret: None,
             }),
@@ -1907,6 +2017,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1935,6 +2046,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -1998,6 +2110,7 @@ mod tests {
                     name: "pg-creds".into(),
                     key: "password".into(),
                 }),
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -2036,6 +2149,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -2072,11 +2186,104 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: Some("invalid-mode".into()),
                 ssl_mode_secret: None,
             }),
         });
         assert!(spec.validate_connection_spec().is_err());
+    }
+
+    #[test]
+    fn validate_connection_accepts_gcp_workload_identity_without_password() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("10.0.0.5".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("discovery".into()),
+                dbname_secret: None,
+                username: Some("pgroles-operator@my-project.iam".into()),
+                username_secret: None,
+                password: None,
+                password_secret: None,
+                auth: Some(ConnectionAuth::GcpWorkloadIdentity {
+                    impersonate_service_account: None,
+                    scope: None,
+                }),
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
+
+        assert!(spec.validate_connection_spec().is_ok());
+        assert!(spec.referenced_secret_names("policy").is_empty());
+    }
+
+    #[test]
+    fn validate_connection_rejects_gcp_workload_identity_with_password() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("10.0.0.5".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("discovery".into()),
+                dbname_secret: None,
+                username: Some("pgroles-operator@my-project.iam".into()),
+                username_secret: None,
+                password: Some("static-password".into()),
+                password_secret: None,
+                auth: Some(ConnectionAuth::GcpWorkloadIdentity {
+                    impersonate_service_account: None,
+                    scope: None,
+                }),
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
+
+        assert!(matches!(
+            spec.validate_connection_spec(),
+            Err(ConnectionValidationError::AuthWithPassword)
+        ));
+    }
+
+    #[test]
+    fn validate_connection_rejects_empty_gcp_auth_fields() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(ConnectionParams {
+                host: Some("10.0.0.5".into()),
+                host_secret: None,
+                port: None,
+                port_secret: None,
+                dbname: Some("discovery".into()),
+                dbname_secret: None,
+                username: Some("pgroles-operator@my-project.iam".into()),
+                username_secret: None,
+                password: None,
+                password_secret: None,
+                auth: Some(ConnectionAuth::GcpWorkloadIdentity {
+                    impersonate_service_account: Some(" ".into()),
+                    scope: None,
+                }),
+                ssl_mode: None,
+                ssl_mode_secret: None,
+            }),
+        });
+
+        assert!(matches!(
+            spec.validate_connection_spec(),
+            Err(ConnectionValidationError::EmptyAuthField { ref field })
+                if field == "impersonateServiceAccount"
+        ));
     }
 
     #[test]
@@ -2103,6 +2310,7 @@ mod tests {
                     username_secret: None,
                     password: Some("pass".into()),
                     password_secret: None,
+                    auth: None,
                     ssl_mode: Some((*mode).into()),
                     ssl_mode_secret: None,
                 }),
@@ -2133,6 +2341,7 @@ mod tests {
                 }),
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -2159,6 +2368,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -2185,6 +2395,7 @@ mod tests {
                 username_secret: None,
                 password: Some("pass".into()),
                 password_secret: None,
+                auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
             }),
@@ -2244,6 +2455,35 @@ params:
         assert!(params.username_secret.is_some());
         assert_eq!(params.username_secret.as_ref().unwrap().name, "creds");
         assert_eq!(params.ssl_mode.as_deref(), Some("require"));
+    }
+
+    #[test]
+    fn connection_spec_params_mode_deserializes_gcp_workload_identity_auth() {
+        let yaml = r#"
+params:
+  host: 10.0.0.5
+  port: 5432
+  dbname: discovery
+  username: pgroles-operator@my-project.iam
+  auth:
+    type: gcp_workload_identity
+    impersonateServiceAccount: target@other-project.iam.gserviceaccount.com
+    scope: https://www.googleapis.com/auth/sqlservice.login
+"#;
+        let conn: ConnectionSpec = serde_yaml::from_str(yaml).unwrap();
+        let params = conn.params.as_ref().unwrap();
+        let auth = params.auth.as_ref().expect("auth should deserialize");
+
+        assert!(params.password.is_none());
+        assert_eq!(auth.gcp_scope(), DEFAULT_GCP_CLOUD_SQL_LOGIN_SCOPE);
+        assert_eq!(
+            auth.gcp_impersonate_service_account(),
+            Some("target@other-project.iam.gserviceaccount.com")
+        );
+        assert!(conn.cache_key("prod").contains("gcp_workload_identity"));
+
+        let spec = spec_with_connection(conn);
+        assert!(spec.validate_connection_spec().is_ok());
     }
 
     #[test]

--- a/crates/pgroles-operator/src/events.rs
+++ b/crates/pgroles-operator/src/events.rs
@@ -290,6 +290,7 @@ fn noteworthy_failure_reason(
         "InvalidSpec" => "InvalidSpec",
         "SecretMissing" | "SecretFetchFailed" => "SecretFetchFailed",
         "DatabaseConnectionFailed" => "DatabaseConnectionFailed",
+        "GcpAuthFailed" => "GcpAuthFailed",
         "InsufficientPrivileges" => "InsufficientPrivileges",
         "UnsafeRoleDrops" => "UnsafeRoleDropsBlocked",
         _ => return None,

--- a/crates/pgroles-operator/src/events.rs
+++ b/crates/pgroles-operator/src/events.rs
@@ -432,6 +432,24 @@ mod tests {
     }
 
     #[test]
+    fn emits_gcp_auth_failed_on_failure_transition() {
+        let mut old_status = PostgresPolicyStatus::default();
+        old_status.set_condition(ready_condition(true, "Reconciled", "All changes applied"));
+
+        let mut new_status = PostgresPolicyStatus::default();
+        new_status.set_condition(ready_condition(
+            false,
+            "GcpAuthFailed",
+            "token request rejected",
+        ));
+
+        let events = derive_status_events(Some(&old_status), &new_status);
+        assert_eq!(reasons(&events), vec!["GcpAuthFailed"]);
+        assert!(matches!(events[0].type_, EventType::Warning));
+        assert_eq!(events[0].note.as_deref(), Some("token request rejected"));
+    }
+
+    #[test]
     fn emits_drift_detected_for_plan_mode_with_pending_changes() {
         let mut status = PostgresPolicyStatus::default();
         status.set_condition(ready_condition(true, "Planned", "Plan computed"));

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -3504,13 +3504,17 @@ mod tests {
         assert_eq!(retry_class(&error), RetryClass::Slow);
     }
 
-    #[test]
-    fn retry_classifies_gcp_auth_http_error_as_transient() {
+    #[tokio::test]
+    async fn retry_classifies_gcp_auth_http_error_as_transient() {
+        let source = reqwest::Client::new()
+            .get("http://")
+            .send()
+            .await
+            .expect_err("invalid URL should produce a reqwest error");
         let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
-            crate::context::ContextError::GcpAuthRejected {
-                endpoint: "metadata".to_string(),
-                status: 503,
-                body: "unavailable".to_string(),
+            crate::context::ContextError::GcpAuthHttp {
+                endpoint: "metadata",
+                source,
             },
         )));
         assert_eq!(retry_class(&error), RetryClass::Transient);

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -375,6 +375,14 @@ fn retry_class_for_reconcile_error(error: &ReconcileError) -> RetryClass {
                     RetryClass::Transient
                 }
             }
+            ContextError::GcpAuthRejected { .. } | ContextError::GcpAuthInvalidResponse { .. } => {
+                if context.is_gcp_auth_non_transient() {
+                    RetryClass::Slow
+                } else {
+                    RetryClass::Transient
+                }
+            }
+            ContextError::GcpAuthHttp { .. } => RetryClass::Transient,
             ContextError::DatabaseConnect { .. } => RetryClass::Transient,
             ContextError::EmptyResolvedValue { .. }
             | ContextError::InvalidResolvedSslMode { .. } => RetryClass::Slow,
@@ -2087,6 +2095,9 @@ impl ReconcileError {
             ReconcileError::Context(context) => match context.as_ref() {
                 ContextError::SecretFetch { .. } => "SecretFetchFailed",
                 ContextError::SecretMissing { .. } => "SecretMissing",
+                ContextError::GcpAuthHttp { .. }
+                | ContextError::GcpAuthRejected { .. }
+                | ContextError::GcpAuthInvalidResponse { .. } => "GcpAuthFailed",
                 ContextError::DatabaseConnect { .. } => "DatabaseConnectionFailed",
                 ContextError::EmptyResolvedValue { .. } => "InvalidConnectionParams",
                 ContextError::InvalidResolvedSslMode { .. } => "InvalidConnectionParams",
@@ -3479,6 +3490,41 @@ mod tests {
             },
         ));
         assert_eq!(err.reason(), "InvalidConnectionParams");
+    }
+
+    #[test]
+    fn retry_classifies_gcp_auth_permission_error_as_slow() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
+            crate::context::ContextError::GcpAuthRejected {
+                endpoint: "metadata".to_string(),
+                status: 403,
+                body: "forbidden".to_string(),
+            },
+        )));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
+    }
+
+    #[test]
+    fn retry_classifies_gcp_auth_http_error_as_transient() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
+            crate::context::ContextError::GcpAuthRejected {
+                endpoint: "metadata".to_string(),
+                status: 503,
+                body: "unavailable".to_string(),
+            },
+        )));
+        assert_eq!(retry_class(&error), RetryClass::Transient);
+    }
+
+    #[test]
+    fn error_reason_gcp_auth_failure() {
+        let err =
+            ReconcileError::Context(Box::new(crate::context::ContextError::GcpAuthRejected {
+                endpoint: "metadata".to_string(),
+                status: 403,
+                body: "forbidden".to_string(),
+            }));
+        assert_eq!(err.reason(), "GcpAuthFailed");
     }
 
     #[test]

--- a/docs/src/pages/docs/google-cloud-sql.md
+++ b/docs/src/pages/docs/google-cloud-sql.md
@@ -110,4 +110,18 @@ kubectl create secret generic mydb-credentials \
   --from-literal=DATABASE_URL='postgres://postgres:PASSWORD@127.0.0.1:5432/mydb'
 ```
 
-With [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), run the [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) as a sidecar or standalone Deployment in the same namespace. See the [operator docs](/docs/operator) for the full `PostgresPolicy` CRD reference.
+With [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), the operator can authenticate directly to Cloud SQL IAM without a Cloud SQL Auth Proxy sidecar:
+
+```yaml
+spec:
+  connection:
+    params:
+      host: 10.0.0.5
+      port: 5432
+      dbname: mydb
+      username: pgroles-operator@my-project.iam
+      auth:
+        type: gcp_workload_identity
+```
+
+The operator fetches a short-lived Cloud SQL login token from the GKE metadata server and uses it as the PostgreSQL password. If `sslMode` is omitted, the operator uses `require`. A Cloud SQL Auth Proxy sidecar or standalone Deployment is still supported when you prefer proxy-managed connectivity. See the [operator docs](/docs/operator) for the full `PostgresPolicy` CRD reference.

--- a/docs/src/pages/docs/operator.md
+++ b/docs/src/pages/docs/operator.md
@@ -305,12 +305,34 @@ Each connection field supports a literal value and a `*Secret` variant:
 | `port` / `portSecret` | Integer (default 5432) | SecretKeySelector | No |
 | `dbname` / `dbnameSecret` | Database name | SecretKeySelector | Yes (exactly one) |
 | `username` / `usernameSecret` | Username string | SecretKeySelector | Yes (exactly one) |
-| `password` / `passwordSecret` | Password string | SecretKeySelector | Yes (exactly one) |
+| `password` / `passwordSecret` | Password string | SecretKeySelector | Yes unless `auth` is set |
+| `auth` | Provider-backed auth config | n/a | No |
 | `sslMode` / `sslModeSecret` | SSL mode string | SecretKeySelector | No |
 
 Valid `sslMode` values: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.
 
 For required fields, exactly one of the literal or Secret variant must be set. For optional fields, at most one may be set. When a Secret referenced by `params` changes, the operator detects the `resourceVersion` change and reconnects automatically.
+
+#### GKE Workload Identity for Cloud SQL IAM
+
+Use `connection.params.auth.type: gcp_workload_identity` when the operator pod runs on GKE with Workload Identity and connects to Cloud SQL using IAM database authentication. The operator fetches a short-lived OAuth token from the GKE metadata server and uses it as the PostgreSQL password. `password` and `passwordSecret` must be omitted. If `sslMode` is omitted, the operator uses `require`.
+
+```yaml
+connection:
+  params:
+    host: 10.0.0.5
+    port: 5432
+    dbname: discovery
+    username: pgroles-operator@my-project.iam
+    auth:
+      type: gcp_workload_identity
+      # Optional: impersonate a different GCP service account.
+      impersonateServiceAccount: target-sa@other-project.iam.gserviceaccount.com
+      # Optional: defaults to https://www.googleapis.com/auth/sqlservice.login
+      scope: https://www.googleapis.com/auth/sqlservice.login
+```
+
+The Kubernetes ServiceAccount used by the operator must be annotated for Workload Identity, and the Google service account must have Cloud SQL IAM database login permissions for the target instance.
 
 {% callout type="note" title="Host resolution" %}
 The `host` must be reachable from the operator pod. For an in-cluster database in a different namespace, use the fully qualified service name (e.g. `my-postgres.my-namespace.svc`). For a database outside the cluster, use the external hostname or IP directly (e.g. `db.example.com` or `10.0.1.50`).

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -82,6 +82,36 @@
                         "description": "Structured connection parameters. Each field is either a plain string\nor a reference to a Secret key. Mutually exclusive with `secretRef`.",
                         "nullable": true,
                         "properties": {
+                          "auth": {
+                            "description": "Provider-backed authentication for connections that use short-lived\ncredentials instead of a static PostgreSQL password.",
+                            "nullable": true,
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "type"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "impersonateServiceAccount": {
+                                "description": "Target Google service account to impersonate before requesting the\nCloud SQL login token. Omit to use the pod's bound identity.",
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "scope": {
+                                "description": "OAuth scope requested for the access token.",
+                                "nullable": true,
+                                "type": "string"
+                              },
+                              "type": {
+                                "enum": [
+                                  "gcp_workload_identity"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
                           "dbname": {
                             "description": "Database name as a literal value.",
                             "nullable": true,


### PR DESCRIPTION
## Summary

- add `connection.params.auth.type: gcp_workload_identity` for operator params-mode connections
- fetch Cloud SQL IAM login tokens from GKE metadata, with optional IAMCredentials service account impersonation
- refresh cached pools before token expiry and surface `GcpAuthFailed` retry/status reasons
- regenerate CRDs and document the native Cloud SQL IAM flow

Closes #114.

## Validation

- `cargo fmt --all -- --check`
- `scripts/check-crd-drift.sh`
- `cargo test --workspace`
- `cargo test -p pgroles-operator --lib`
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- `cargo deny check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GCP Workload Identity authentication support via `connection.params.auth.type: gcp_workload_identity` for short-lived token-based Cloud SQL connections.
  * SSL mode automatically defaults to `"require"` when GCP authentication is configured.

* **Documentation**
  * Updated GKE and Cloud SQL operator documentation with Workload Identity setup examples and configuration guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->