### PR TITLE
Prepare v0.7.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.6] - 2026-05-14
+
+### Fixed
+
+- **Wildcard `GRANT EXECUTE` no longer flaps on schemas that contain procedures.** PostgreSQL's `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA ...` does not cover procedures, but the inspector includes procedures in routine inventory. Function wildcard grants now render as `ALL ROUTINES`, and specific function/procedure grant and revoke targets render as `ROUTINE`, so manifests using `object.type: function` remain backward-compatible while converging on schemas with extension-installed procedures. (#113, #114)
+
 ## [0.7.5] - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-cli"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "base64",
  "hmac 0.13.0",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-inspect"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "pgroles-core",
  "sqlx",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-operator"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 authors = ["Brian Thorne <brian@thorne.link>"]
 license = "MIT"
@@ -55,8 +55,8 @@ k8s-openapi = { version = "0.27.1", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Internal crates
-pgroles-core = { path = "crates/pgroles-core", version = "0.7.5" }
-pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.5" }
+pgroles-core = { path = "crates/pgroles-core", version = "0.7.6" }
+pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.6" }
 
 [profile.release]
 strip = "symbols"

--- a/charts/pgroles-operator/Chart.yaml
+++ b/charts/pgroles-operator/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Define roles, memberships, grants, and default privileges in YAML
   and let the operator converge your database to the desired state.
 type: application
-version: 0.7.5
-appVersion: "0.7.5"
+version: 0.7.6
+appVersion: "0.7.6"
 icon: https://raw.githubusercontent.com/hardbyte/pgroles/main/docs/public/logo.svg
 sources:
   - https://github.com/hardbyte/pgroles
@@ -16,10 +16,8 @@ maintainers:
     url: https://hardbyte.nz
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: 'Operator connection params can now use native GKE Workload Identity for Cloud SQL IAM authentication via `connection.params.auth.type: gcp_workload_identity`, including optional Google service account impersonation and token-aware pool refresh.'
-    - kind: changed
-      description: 'Operator and manifest documentation now include validated tooling guidance, a dedicated manifest reference, and native Cloud SQL IAM examples.'
+    - kind: fixed
+      description: 'Wildcard EXECUTE grants now converge on schemas that contain PostgreSQL procedures by rendering schema-wide function grants as ALL ROUTINES and specific function targets as ROUTINE.'
   artifacthub.io/category: database
   artifacthub.io/operator: "true"
   artifacthub.io/prerelease: "false"


### PR DESCRIPTION
## Summary
- bump workspace and Helm chart metadata to 0.7.6
- add changelog and Artifact Hub notes for the routine wildcard convergence fix

## Validation
- cargo fmt --all -- --check
- git diff --check
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- cargo test --workspace
- scripts/check-crd-drift.sh