### PR TITLE
Add connection.params.setRole for per-pool SET ROLE

### DIFF
--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -211,6 +211,11 @@
                             ],
                             "type": "object"
                           },
+                          "setRole": {
+                            "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes. The value must be a simple PostgreSQL identifier\n(`^[A-Za-z_][A-Za-z0-9_$-]*$`).",
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "sslMode": {
                             "description": "SSL mode as a literal value.",
                             "nullable": true,

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -214,6 +214,7 @@
                           "setRole": {
                             "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes. The value must be a simple PostgreSQL identifier\n(`^[A-Za-z_][A-Za-z0-9_$-]*$`).",
                             "nullable": true,
+                            "pattern": "^[A-Za-z_][A-Za-z0-9_$-]*$",
                             "type": "string"
                           },
                           "sslMode": {

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -212,7 +212,7 @@
                             "type": "object"
                           },
                           "setRole": {
-                            "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes. The value must be a simple PostgreSQL identifier\n(`^[A-Za-z_][A-Za-z0-9_$-]*$`).",
+                            "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes.\n\nMust be a simple PostgreSQL identifier matching\n`^[A-Za-z_][A-Za-z0-9_$-]*$`. The pattern intentionally excludes `@`\nand `.` — `setRole` is for switching to a privileged *group* role\n(e.g. `cloudsqlsuperuser`), not an IAM-style principal like\n`pgroles-operator@project.iam`, which has no extra attributes to\ninherit via `SET ROLE`.",
                             "nullable": true,
                             "pattern": "^[A-Za-z_][A-Za-z0-9_$-]*$",
                             "type": "string"

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -46,6 +46,20 @@ struct CachedPool {
 struct ResolvedConnectionUrl {
     database_url: String,
     token_expires_at: Option<SystemTime>,
+    /// Optional role to `SET ROLE` to on every pooled connection. The value
+    /// has already passed CRD-level identifier validation; the after-connect
+    /// hook re-quotes defensively before interpolating it into SQL.
+    set_role: Option<String>,
+}
+
+/// Build the `SET ROLE` SQL statement for the given identifier.
+///
+/// `SET ROLE` does not accept bind parameters, so the value is interpolated.
+/// CRD admission already restricts the identifier to
+/// `^[A-Za-z_][A-Za-z0-9_$-]*$`; the embedded `"` doubling here is defence
+/// in depth for the connection-pool path.
+pub fn build_set_role_stmt(role: &str) -> String {
+    format!("SET ROLE \"{}\"", role.replace('"', "\"\""))
 }
 
 #[derive(Clone)]
@@ -441,6 +455,7 @@ impl OperatorContext {
             Ok(ResolvedConnectionUrl {
                 database_url,
                 token_expires_at: None,
+                set_role: None,
             })
         } else if let Some(ref params) = connection.params {
             // Params mode — resolve each field and build the URL.
@@ -534,6 +549,7 @@ impl OperatorContext {
             Ok(ResolvedConnectionUrl {
                 database_url: url,
                 token_expires_at,
+                set_role: params.set_role.clone(),
             })
         } else {
             Err(ContextError::SecretMissing {
@@ -632,9 +648,20 @@ impl OperatorContext {
         // Create pool with explicit sizing. Reconciliation holds one dedicated
         // connection for PostgreSQL advisory locking and needs additional pool
         // capacity for inspection/apply queries.
+        let set_role = resolved.set_role.clone();
         let pool = PgPoolOptions::new()
             .max_connections(POOL_MAX_CONNECTIONS)
             .acquire_timeout(Duration::from_secs(POOL_ACQUIRE_TIMEOUT_SECS))
+            .after_connect(move |conn, _meta| {
+                let set_role = set_role.clone();
+                Box::pin(async move {
+                    if let Some(role) = set_role {
+                        let stmt = build_set_role_stmt(&role);
+                        sqlx::Executor::execute(&mut *conn, stmt.as_str()).await?;
+                    }
+                    Ok(())
+                })
+            })
             .connect(&resolved.database_url)
             .await
             .map_err(|err| ContextError::DatabaseConnect { source: err })?;
@@ -769,6 +796,22 @@ impl ContextError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_set_role_stmt_quotes_identifier() {
+        assert_eq!(
+            build_set_role_stmt("cloudsqlsuperuser"),
+            "SET ROLE \"cloudsqlsuperuser\"",
+        );
+    }
+
+    #[test]
+    fn build_set_role_stmt_doubles_embedded_quote() {
+        // CRD validation rejects identifiers containing `"`. This test pins
+        // the defensive quoting in the connection-pool path anyway, so a
+        // future relaxation of the validator can't silently allow injection.
+        assert_eq!(build_set_role_stmt("a\"b"), "SET ROLE \"a\"\"b\"",);
+    }
 
     #[test]
     fn pool_cache_key_format() {

--- a/crates/pgroles-operator/src/context.rs
+++ b/crates/pgroles-operator/src/context.rs
@@ -55,11 +55,37 @@ struct ResolvedConnectionUrl {
 /// Build the `SET ROLE` SQL statement for the given identifier.
 ///
 /// `SET ROLE` does not accept bind parameters, so the value is interpolated.
-/// CRD admission already restricts the identifier to
-/// `^[A-Za-z_][A-Za-z0-9_$-]*$`; the embedded `"` doubling here is defence
-/// in depth for the connection-pool path.
+/// CRD admission already restricts the identifier to the
+/// [`crate::crd::SET_ROLE_PATTERN`] regex; the embedded `"` doubling here is
+/// defence in depth for the connection-pool path.
 pub fn build_set_role_stmt(role: &str) -> String {
     format!("SET ROLE \"{}\"", role.replace('"', "\"\""))
+}
+
+/// Marker prefix used to flag SET-ROLE failures from the `after_connect`
+/// hook so they can be distinguished from other connect-time errors.
+const SET_ROLE_FAILURE_MARKER: &str = "pgroles:set-role-failed:";
+
+/// Wrap a SET-ROLE failure in [`sqlx::Error::Protocol`] with a marker so
+/// the outer `connect()` error can be classified as
+/// [`ContextError::SetRoleFailed`] instead of a generic database connect
+/// failure.
+fn wrap_set_role_failure(role: &str, source: sqlx::Error) -> sqlx::Error {
+    sqlx::Error::Protocol(format!("{SET_ROLE_FAILURE_MARKER}{role}: {source}"))
+}
+
+/// Classify a pool-level connect error, surfacing SET-ROLE hook failures
+/// distinctly from genuine database-connect failures.
+fn classify_pool_connect_error(set_role: Option<&str>, err: sqlx::Error) -> ContextError {
+    if let (Some(role), sqlx::Error::Protocol(msg)) = (set_role, &err)
+        && msg.starts_with(SET_ROLE_FAILURE_MARKER)
+    {
+        return ContextError::SetRoleFailed {
+            role: role.to_string(),
+            source: err,
+        };
+    }
+    ContextError::DatabaseConnect { source: err }
 }
 
 #[derive(Clone)]
@@ -657,14 +683,16 @@ impl OperatorContext {
                 Box::pin(async move {
                     if let Some(role) = set_role {
                         let stmt = build_set_role_stmt(&role);
-                        sqlx::Executor::execute(&mut *conn, stmt.as_str()).await?;
+                        sqlx::Executor::execute(&mut *conn, stmt.as_str())
+                            .await
+                            .map_err(|err| wrap_set_role_failure(&role, err))?;
                     }
                     Ok(())
                 })
             })
             .connect(&resolved.database_url)
             .await
-            .map_err(|err| ContextError::DatabaseConnect { source: err })?;
+            .map_err(|err| classify_pool_connect_error(resolved.set_role.as_deref(), err))?;
 
         // Cache it (write lock).
         {
@@ -747,6 +775,9 @@ pub enum ContextError {
     #[error("failed to connect to database: {source}")]
     DatabaseConnect { source: sqlx::Error },
 
+    #[error("failed to apply SET ROLE \"{role}\" on pooled connection: {source}")]
+    SetRoleFailed { role: String, source: sqlx::Error },
+
     #[error("connection param \"{field}\" resolved to an empty or whitespace-only value")]
     EmptyResolvedValue { field: String },
 
@@ -803,6 +834,35 @@ mod tests {
             build_set_role_stmt("cloudsqlsuperuser"),
             "SET ROLE \"cloudsqlsuperuser\"",
         );
+    }
+
+    #[test]
+    fn classify_pool_connect_error_surfaces_set_role_failure_with_role() {
+        let raw = wrap_set_role_failure(
+            "cloudsqlsuperuser",
+            sqlx::Error::Protocol("permission denied".to_string()),
+        );
+        let classified = classify_pool_connect_error(Some("cloudsqlsuperuser"), raw);
+        assert!(matches!(
+            classified,
+            ContextError::SetRoleFailed { ref role, .. } if role == "cloudsqlsuperuser"
+        ));
+    }
+
+    #[test]
+    fn classify_pool_connect_error_passes_through_unrelated_errors() {
+        let err = sqlx::Error::PoolTimedOut;
+        let classified = classify_pool_connect_error(Some("any_role"), err);
+        assert!(matches!(classified, ContextError::DatabaseConnect { .. }));
+    }
+
+    #[test]
+    fn classify_pool_connect_error_without_set_role_is_database_connect() {
+        // Even a Protocol error with our marker shouldn't be classified as
+        // SetRoleFailed when no role was configured for this pool.
+        let raw = wrap_set_role_failure("ghost", sqlx::Error::Protocol("oops".to_string()));
+        let classified = classify_pool_connect_error(None, raw);
+        assert!(matches!(classified, ContextError::DatabaseConnect { .. }));
     }
 
     #[test]

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -329,8 +329,9 @@ impl ConnectionSpec {
                         .map(|s| format!("secret={}\0{}", s.name, s.key))
                 })
                 .unwrap_or_default();
+            let role_part = params.set_role.as_deref().unwrap_or("");
             format!(
-                "{namespace}/{}\0user={user_part}\0pass={pass_part}\0auth={auth_part}\0ssl={ssl_part}",
+                "{namespace}/{}\0user={user_part}\0pass={pass_part}\0auth={auth_part}\0ssl={ssl_part}\0role={role_part}",
                 self.identity_key()
             )
         } else {
@@ -426,6 +427,17 @@ pub struct ConnectionParams {
     /// SSL mode from a Secret key.
     #[serde(default)]
     pub ssl_mode_secret: Option<SecretKeySelector>,
+
+    /// Run `SET ROLE "<value>"` once on every pooled connection. Useful when
+    /// the operator authenticates as a low-privilege identity (e.g. a Cloud
+    /// SQL IAM user) that has been granted membership in a privileged role
+    /// like `cloudsqlsuperuser` — PostgreSQL does not inherit role
+    /// *attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so
+    /// `SET ROLE` is required for the connection to act with the parent
+    /// role's attributes. The value must be a simple PostgreSQL identifier
+    /// (`^[A-Za-z_][A-Za-z0-9_$-]*$`).
+    #[serde(default)]
+    pub set_role: Option<String>,
 }
 
 /// Provider-backed authentication for `connection.params`.
@@ -694,6 +706,27 @@ pub enum ConnectionValidationError {
 
     #[error("connection.params: password/passwordSecret are mutually exclusive with auth")]
     AuthWithPassword,
+
+    #[error(
+        "connection.params.setRole: \"{value}\" is not a valid PostgreSQL role identifier (must match ^[A-Za-z_][A-Za-z0-9_$-]*$)"
+    )]
+    InvalidRoleName { value: String },
+}
+
+/// Returns true if `s` is a simple PostgreSQL role identifier matching
+/// `^[A-Za-z_][A-Za-z0-9_$-]*$`.
+///
+/// `SET ROLE` does not accept bind parameters, so any value reaching the
+/// connection-pool hook is interpolated into the SQL string. Restricting
+/// identifiers at admission time is defence in depth on top of the
+/// double-quoting in the `after_connect` callback.
+pub(crate) fn is_valid_set_role_identifier(s: &str) -> bool {
+    let mut bytes = s.bytes();
+    match bytes.next() {
+        Some(b) if b.is_ascii_alphabetic() || b == b'_' => {}
+        _ => return false,
+    }
+    bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b == b'-')
 }
 
 /// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules:
@@ -1276,6 +1309,21 @@ impl PostgresPolicySpec {
                     return Err(ConnectionValidationError::InvalidSslMode {
                         value: value.clone(),
                     });
+                }
+
+                // Validate setRole identifier. `SET ROLE` does not accept bind
+                // params, so the identifier is restricted at admission time.
+                if let Some(value) = &params.set_role {
+                    if value.trim().is_empty() {
+                        return Err(ConnectionValidationError::EmptyLiteral {
+                            field: "setRole".to_string(),
+                        });
+                    }
+                    if !is_valid_set_role_identifier(value) {
+                        return Err(ConnectionValidationError::InvalidRoleName {
+                            value: value.clone(),
+                        });
+                    }
                 }
 
                 Ok(())
@@ -1865,6 +1913,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         };
         let user_b = ConnectionSpec {
@@ -1884,6 +1933,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         };
 
@@ -1921,6 +1971,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         };
         let secret_conn = ConnectionSpec {
@@ -1943,6 +1994,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         };
 
@@ -1972,6 +2024,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         };
         let conn_with_ssl = ConnectionSpec {
@@ -1991,6 +2044,7 @@ mod tests {
                 auth: None,
                 ssl_mode: Some("require".into()),
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         };
 
@@ -2020,6 +2074,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
 
@@ -2049,6 +2104,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
 
@@ -2113,6 +2169,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         }
     }
@@ -2152,6 +2209,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
         assert!(matches!(
@@ -2189,9 +2247,108 @@ mod tests {
                 auth: None,
                 ssl_mode: Some("invalid-mode".into()),
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
         assert!(spec.validate_connection_spec().is_err());
+    }
+
+    fn params_with_set_role(set_role: Option<String>) -> ConnectionParams {
+        ConnectionParams {
+            host: Some("host".into()),
+            host_secret: None,
+            port: None,
+            port_secret: None,
+            dbname: Some("db".into()),
+            dbname_secret: None,
+            username: Some("user".into()),
+            username_secret: None,
+            password: Some("pass".into()),
+            password_secret: None,
+            auth: None,
+            ssl_mode: None,
+            ssl_mode_secret: None,
+            set_role,
+        }
+    }
+
+    #[test]
+    fn validate_connection_accepts_valid_set_role() {
+        for role in [
+            "cloudsqlsuperuser",
+            "_underscore_start",
+            "role-with-dash",
+            "role_with$dollar",
+            "Mixed_Case_Role",
+            "r2d2",
+        ] {
+            let spec = spec_with_connection(ConnectionSpec {
+                secret_ref: None,
+                secret_key: None,
+                params: Some(params_with_set_role(Some(role.into()))),
+            });
+            assert!(
+                spec.validate_connection_spec().is_ok(),
+                "expected {role} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_connection_rejects_invalid_set_role() {
+        for role in [
+            "1leading_digit",
+            "has space",
+            "has\"quote",
+            "has;semicolon",
+            "has'singlequote",
+            "ünicode",
+        ] {
+            let spec = spec_with_connection(ConnectionSpec {
+                secret_ref: None,
+                secret_key: None,
+                params: Some(params_with_set_role(Some(role.into()))),
+            });
+            let err = spec
+                .validate_connection_spec()
+                .expect_err(&format!("expected {role} to be rejected"));
+            assert!(
+                matches!(err, ConnectionValidationError::InvalidRoleName { ref value } if value == role),
+                "unexpected error for {role}: {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_connection_rejects_empty_set_role() {
+        let spec = spec_with_connection(ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(params_with_set_role(Some("   ".into()))),
+        });
+        assert!(matches!(
+            spec.validate_connection_spec(),
+            Err(ConnectionValidationError::EmptyLiteral { ref field }) if field == "setRole"
+        ));
+    }
+
+    #[test]
+    fn cache_key_includes_set_role() {
+        let conn_no_role = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(params_with_set_role(None)),
+        };
+        let conn_with_role = ConnectionSpec {
+            secret_ref: None,
+            secret_key: None,
+            params: Some(params_with_set_role(Some("cloudsqlsuperuser".into()))),
+        };
+        assert_ne!(
+            conn_no_role.cache_key("ns"),
+            conn_with_role.cache_key("ns"),
+            "cache key should differ when setRole is present"
+        );
     }
 
     #[test]
@@ -2216,6 +2373,7 @@ mod tests {
                 }),
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
 
@@ -2245,6 +2403,7 @@ mod tests {
                 }),
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
 
@@ -2276,6 +2435,7 @@ mod tests {
                 }),
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
 
@@ -2313,6 +2473,7 @@ mod tests {
                     auth: None,
                     ssl_mode: Some((*mode).into()),
                     ssl_mode_secret: None,
+                    set_role: None,
                 }),
             });
             assert!(
@@ -2344,6 +2505,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
         assert!(spec.validate_connection_spec().is_err());
@@ -2371,6 +2533,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
         assert!(matches!(
@@ -2398,6 +2561,7 @@ mod tests {
                 auth: None,
                 ssl_mode: None,
                 ssl_mode_secret: None,
+                set_role: None,
             }),
         });
         assert!(matches!(

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -437,6 +437,7 @@ pub struct ConnectionParams {
     /// role's attributes. The value must be a simple PostgreSQL identifier
     /// (`^[A-Za-z_][A-Za-z0-9_$-]*$`).
     #[serde(default)]
+    #[schemars(regex(pattern = r"^[A-Za-z_][A-Za-z0-9_$-]*$"))]
     pub set_role: Option<String>,
 }
 

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -434,10 +434,16 @@ pub struct ConnectionParams {
     /// like `cloudsqlsuperuser` — PostgreSQL does not inherit role
     /// *attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so
     /// `SET ROLE` is required for the connection to act with the parent
-    /// role's attributes. The value must be a simple PostgreSQL identifier
-    /// (`^[A-Za-z_][A-Za-z0-9_$-]*$`).
+    /// role's attributes.
+    ///
+    /// Must be a simple PostgreSQL identifier matching
+    /// `^[A-Za-z_][A-Za-z0-9_$-]*$`. The pattern intentionally excludes `@`
+    /// and `.` — `setRole` is for switching to a privileged *group* role
+    /// (e.g. `cloudsqlsuperuser`), not an IAM-style principal like
+    /// `pgroles-operator@project.iam`, which has no extra attributes to
+    /// inherit via `SET ROLE`.
     #[serde(default)]
-    #[schemars(regex(pattern = r"^[A-Za-z_][A-Za-z0-9_$-]*$"))]
+    #[schemars(regex(pattern = SET_ROLE_PATTERN))]
     pub set_role: Option<String>,
 }
 
@@ -709,13 +715,28 @@ pub enum ConnectionValidationError {
     AuthWithPassword,
 
     #[error(
-        "connection.params.setRole: \"{value}\" is not a valid PostgreSQL role identifier (must match ^[A-Za-z_][A-Za-z0-9_$-]*$)"
+        "connection.params.setRole: \"{value}\" is not a valid PostgreSQL role identifier (must match {pattern})",
+        pattern = SET_ROLE_PATTERN,
     )]
     InvalidRoleName { value: String },
 }
 
+/// Regex pattern restricting `connection.params.setRole` values.
+///
+/// Single source of truth: used by the `#[schemars(...)]` attribute on the
+/// field (emitted into the CRD's OpenAPI schema), referenced by the
+/// `InvalidRoleName` error message, and pinned by `is_valid_set_role_identifier`
+/// via unit tests.
+///
+/// Intentionally rejects `@` and `.`, so IAM-email-style identifiers
+/// (e.g. `pgroles-operator@project.iam`) cannot be a `setRole` target.
+/// `SET ROLE` is meant for switching to a privileged *group* role like
+/// `cloudsqlsuperuser`; IAM principals don't carry role attributes worth
+/// switching to.
+pub(crate) const SET_ROLE_PATTERN: &str = "^[A-Za-z_][A-Za-z0-9_$-]*$";
+
 /// Returns true if `s` is a simple PostgreSQL role identifier matching
-/// `^[A-Za-z_][A-Za-z0-9_$-]*$`.
+/// [`SET_ROLE_PATTERN`].
 ///
 /// `SET ROLE` does not accept bind parameters, so any value reaching the
 /// connection-pool hook is interpolated into the SQL string. Restricting

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -384,6 +384,9 @@ fn retry_class_for_reconcile_error(error: &ReconcileError) -> RetryClass {
             }
             ContextError::GcpAuthHttp { .. } => RetryClass::Transient,
             ContextError::DatabaseConnect { .. } => RetryClass::Transient,
+            // `SET ROLE "<role>"` failing on a freshly-connected session is
+            // a permission/config issue, not a transient connectivity blip.
+            ContextError::SetRoleFailed { .. } => RetryClass::Slow,
             ContextError::EmptyResolvedValue { .. }
             | ContextError::InvalidResolvedSslMode { .. } => RetryClass::Slow,
         },
@@ -2099,6 +2102,7 @@ impl ReconcileError {
                 | ContextError::GcpAuthRejected { .. }
                 | ContextError::GcpAuthInvalidResponse { .. } => "GcpAuthFailed",
                 ContextError::DatabaseConnect { .. } => "DatabaseConnectionFailed",
+                ContextError::SetRoleFailed { .. } => "SetRoleFailed",
                 ContextError::EmptyResolvedValue { .. } => "InvalidConnectionParams",
                 ContextError::InvalidResolvedSslMode { .. } => "InvalidConnectionParams",
             },
@@ -3371,6 +3375,17 @@ mod tests {
             },
         )));
         assert_eq!(retry_class(&error), RetryClass::Transient);
+    }
+
+    #[test]
+    fn retry_classifies_set_role_failed_as_slow() {
+        let error = finalizer::Error::ApplyFailed(ReconcileError::Context(Box::new(
+            crate::context::ContextError::SetRoleFailed {
+                role: "cloudsqlsuperuser".to_string(),
+                source: sqlx::Error::Protocol("permission denied".to_string()),
+            },
+        )));
+        assert_eq!(retry_class(&error), RetryClass::Slow);
     }
 
     #[test]

--- a/crates/pgroles-operator/tests/set_role_integration.rs
+++ b/crates/pgroles-operator/tests/set_role_integration.rs
@@ -1,0 +1,169 @@
+//! Integration test for `connection.params.setRole`.
+//!
+//! Run with a live PostgreSQL:
+//!
+//! ```text
+//! DATABASE_URL=postgres://postgres:testpassword@localhost:5432/pgroles_test \
+//!     cargo test -p pgroles-operator --test set_role_integration -- --ignored
+//! ```
+//!
+//! The test creates a low-privilege login role and a privileged role that
+//! holds `CREATEROLE`, grants the privileged role to the low-privilege role,
+//! and then exercises a `CREATE ROLE` statement that is **only permitted
+//! when `SET ROLE` is applied**. Two pools are constructed:
+//!
+//! 1. **without** the `after_connect` hook — `CREATE ROLE` must fail with
+//!    `permission denied`.
+//! 2. **with** the hook (using the operator's `build_set_role_stmt` helper) —
+//!    the same statement must succeed.
+//!
+//! Together these two assertions prove that the privileged operation only
+//! works when the `SET ROLE` plumbing is in effect.
+
+use pgroles_operator::context::build_set_role_stmt;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions};
+use sqlx::{ConnectOptions, Executor, Row};
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for live DB tests")
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_nanos()
+}
+
+async fn superuser_pool() -> PgPool {
+    PgPool::connect(&database_url())
+        .await
+        .expect("failed to connect to live test database as superuser")
+}
+
+/// Build connect options for the low-privilege role by overriding username
+/// and password on the base `DATABASE_URL`.
+fn low_priv_options(low_user: &str, low_password: &str) -> PgConnectOptions {
+    PgConnectOptions::from_str(&database_url())
+        .expect("DATABASE_URL must parse as Postgres connect options")
+        .username(low_user)
+        .password(low_password)
+        // Quiet the per-statement INFO logs that sqlx emits at debug.
+        .log_statements(tracing::log::LevelFilter::Off)
+}
+
+#[tokio::test]
+#[ignore]
+async fn set_role_grants_create_role_privilege_to_low_priv_user() {
+    let suffix = unique_suffix();
+    let low_user = format!("pgr_setrole_low_{suffix}");
+    let high_role = format!("pgr_setrole_high_{suffix}");
+    let target_role = format!("pgr_setrole_target_{suffix}");
+    let low_password = "low_priv_password";
+
+    let admin = superuser_pool().await;
+
+    // Setup: create a low-privilege LOGIN role and a privileged role with
+    // CREATEROLE, then grant the privileged role to the low-privilege one.
+    // NOINHERIT on the low role ensures attribute privileges of `high_role`
+    // are never available unless `SET ROLE` is explicitly invoked.
+    let setup_sql = format!(
+        r#"
+        DROP ROLE IF EXISTS "{target_role}";
+        DROP ROLE IF EXISTS "{low_user}";
+        DROP ROLE IF EXISTS "{high_role}";
+        CREATE ROLE "{high_role}" CREATEROLE NOINHERIT;
+        CREATE ROLE "{low_user}" LOGIN NOINHERIT PASSWORD '{low_password}';
+        GRANT "{high_role}" TO "{low_user}";
+        "#
+    );
+    admin
+        .execute(setup_sql.as_str())
+        .await
+        .expect("failed to set up test roles");
+
+    // Pool 1 — no SET ROLE hook. `CREATE ROLE` must fail.
+    let plain_pool = PgPoolOptions::new()
+        .max_connections(2)
+        .acquire_timeout(Duration::from_secs(10))
+        .connect_with(low_priv_options(&low_user, low_password))
+        .await
+        .expect("low-priv pool without SET ROLE should still be able to connect");
+
+    let create_without_set_role = plain_pool
+        .execute(format!(r#"CREATE ROLE "{target_role}""#).as_str())
+        .await;
+    assert!(
+        create_without_set_role.is_err(),
+        "CREATE ROLE must fail when SET ROLE is NOT applied (got: {:?})",
+        create_without_set_role,
+    );
+    if let Err(err) = &create_without_set_role {
+        let msg = err.to_string();
+        assert!(
+            msg.contains("permission denied"),
+            "expected permission denied error, got: {msg}",
+        );
+    }
+    drop(plain_pool);
+
+    // Pool 2 — same low-priv connection, but with the operator's
+    // `after_connect` hook running `SET ROLE "<high_role>"`. The same
+    // `CREATE ROLE` statement must now succeed.
+    let high_role_for_hook = high_role.clone();
+    let set_role_pool = PgPoolOptions::new()
+        .max_connections(2)
+        .acquire_timeout(Duration::from_secs(10))
+        .after_connect(move |conn, _meta| {
+            let stmt = build_set_role_stmt(&high_role_for_hook);
+            Box::pin(async move {
+                sqlx::Executor::execute(&mut *conn, stmt.as_str()).await?;
+                Ok(())
+            })
+        })
+        .connect_with(low_priv_options(&low_user, low_password))
+        .await
+        .expect("low-priv pool with SET ROLE hook should connect");
+
+    // Sanity: confirm the hook actually flipped the effective role.
+    let effective: String = sqlx::query("SELECT current_user::text AS u")
+        .fetch_one(&set_role_pool)
+        .await
+        .expect("should be able to read current_user")
+        .get("u");
+    assert_eq!(
+        effective, high_role,
+        "after_connect hook must make current_user = high_role"
+    );
+
+    set_role_pool
+        .execute(format!(r#"CREATE ROLE "{target_role}""#).as_str())
+        .await
+        .expect("CREATE ROLE must succeed once SET ROLE is applied");
+
+    // Confirm the role really exists.
+    let exists: bool = sqlx::query("SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1)")
+        .bind(&target_role)
+        .fetch_one(&admin)
+        .await
+        .expect("should be able to query pg_roles")
+        .get(0);
+    assert!(exists, "target role should have been created");
+
+    drop(set_role_pool);
+
+    // Cleanup.
+    let cleanup_sql = format!(
+        r#"
+        DROP ROLE IF EXISTS "{target_role}";
+        DROP ROLE IF EXISTS "{low_user}";
+        DROP ROLE IF EXISTS "{high_role}";
+        "#
+    );
+    admin
+        .execute(cleanup_sql.as_str())
+        .await
+        .expect("failed to clean up test roles");
+}

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -211,6 +211,11 @@
                             ],
                             "type": "object"
                           },
+                          "setRole": {
+                            "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes. The value must be a simple PostgreSQL identifier\n(`^[A-Za-z_][A-Za-z0-9_$-]*$`).",
+                            "nullable": true,
+                            "type": "string"
+                          },
                           "sslMode": {
                             "description": "SSL mode as a literal value.",
                             "nullable": true,

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -214,6 +214,7 @@
                           "setRole": {
                             "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes. The value must be a simple PostgreSQL identifier\n(`^[A-Za-z_][A-Za-z0-9_$-]*$`).",
                             "nullable": true,
+                            "pattern": "^[A-Za-z_][A-Za-z0-9_$-]*$",
                             "type": "string"
                           },
                           "sslMode": {

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -212,7 +212,7 @@
                             "type": "object"
                           },
                           "setRole": {
-                            "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes. The value must be a simple PostgreSQL identifier\n(`^[A-Za-z_][A-Za-z0-9_$-]*$`).",
+                            "description": "Run `SET ROLE \"<value>\"` once on every pooled connection. Useful when\nthe operator authenticates as a low-privilege identity (e.g. a Cloud\nSQL IAM user) that has been granted membership in a privileged role\nlike `cloudsqlsuperuser` — PostgreSQL does not inherit role\n*attributes* (`CREATEROLE`, `CREATEDB`, …) through `GRANT … TO …`, so\n`SET ROLE` is required for the connection to act with the parent\nrole's attributes.\n\nMust be a simple PostgreSQL identifier matching\n`^[A-Za-z_][A-Za-z0-9_$-]*$`. The pattern intentionally excludes `@`\nand `.` — `setRole` is for switching to a privileged *group* role\n(e.g. `cloudsqlsuperuser`), not an IAM-style principal like\n`pgroles-operator@project.iam`, which has no extra attributes to\ninherit via `SET ROLE`.",
                             "nullable": true,
                             "pattern": "^[A-Za-z_][A-Za-z0-9_$-]*$",
                             "type": "string"

--- a/k8s/samples/params-connection-policy.yaml
+++ b/k8s/samples/params-connection-policy.yaml
@@ -17,6 +17,11 @@ spec:
         name: zalando-creds
         key: password
       sslMode: require
+      # setRole: cloudsqlsuperuser
+      #   Run `SET ROLE "<value>"` on every pooled connection. Use when
+      #   the operator authenticates as a low-privilege identity that has
+      #   been granted membership in a privileged role (e.g. Cloud SQL
+      #   IAM user + cloudsqlsuperuser).
   interval: "5m"
   default_owner: postgres
 


### PR DESCRIPTION
## Summary

Adds an optional `setRole` field on `PostgresPolicy.spec.connection.params`. When set, the operator runs `SET ROLE "<value>"` once per pooled sqlx connection via `PoolOptions::after_connect`, so the session's `current_user` becomes the named role and that role's *attributes* (e.g. `CREATEROLE`) apply to every statement on the pool.

Use case from #119: the operator authenticates as a low-privilege identity (Cloud SQL IAM, Workload Identity Federation, etc.) that has been granted membership in a privileged parent role like `cloudsqlsuperuser`. PostgreSQL role membership does **not** inherit role attributes through `GRANT … TO …`, only object privileges — so even an `INHERIT` member still hits `permission denied to create role`. `SET ROLE` is the standard workaround.

Closes #119.

## What's in the diff

- **CRD** (`crates/pgroles-operator/src/crd.rs`):
  - New `ConnectionParams.set_role: Option<String>`.
  - `ConnectionValidationError::InvalidRoleName` plus an `is_valid_set_role_identifier` check that enforces `^[A-Za-z_][A-Za-z0-9_$-]*$` at admission. `SET ROLE` doesn't accept bind params, so admission-time restriction is the primary defence.
  - `ConnectionSpec::cache_key` extended to include `set_role` so a config change invalidates the cached pool.
- **Pool wiring** (`crates/pgroles-operator/src/context.rs`):
  - New `build_set_role_stmt` helper that double-quotes the identifier and doubles any embedded `"` (defence in depth on top of CRD validation — kept in a pure function so it's unit-testable).
  - `ResolvedConnectionUrl` carries the resolved `set_role`.
  - `get_or_create_pool` now chains `.after_connect(...)` that executes `build_set_role_stmt(&role)` on every new connection — including pool re-establishment, since sqlx replays the hook.
- **CRDs regenerated** — `charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml` and `k8s/crd.yaml` are in sync (`scripts/check-crd-drift.sh` passes).

## Tests

- **6 new unit tests** covering accept/reject for the identifier regex, empty-literal rejection, cache-key inclusion, and the SQL-quoting helper (including the embedded-quote doubling).
- **New live-DB integration test** at `crates/pgroles-operator/tests/set_role_integration.rs`. It's `#[ignore]`d so CI's `integration-test` job picks it up via `cargo test --workspace -- --include-ignored` against the Postgres service on PG 16/17/18. The test:
  1. Creates a NOINHERIT login role and a CREATEROLE parent role, grants the parent to the login role.
  2. Builds a pool **without** the `after_connect` hook and asserts `CREATE ROLE` fails with `permission denied`.
  3. Builds a second pool **with** the hook (using the real `build_set_role_stmt`), asserts `current_user` is now the parent role, and asserts the same `CREATE ROLE` succeeds.
  4. Cleans up.

  The two-sided assertion is deliberate: the privileged operation *only* works when the SET ROLE plumbing is in effect, so the test would also catch a regression where the hook is silently dropped.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (non-ignored) — 255 operator unit tests + workspace green
- [x] `scripts/check-crd-drift.sh` — clean
- [ ] CI integration-test job (PG 16/17/18) runs `set_role_integration::set_role_grants_create_role_privilege_to_low_priv_user`

## Out of scope

- No `setRoleSecret` Secret-reference variant — a role name is typically static config, not a credential. Easy to add later.
- No `session:` wrapper in the CRD (as sketched in #119) — the field lives directly on `connection.params` for consistency with the existing field shape.
- URL-mode connections (`connection.secretRef`) don't carry a `set_role` today; the field is params-mode only.

https://claude.ai/code/session_01GeV3bnqE38pwEhi8oY2AsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeV3bnqE38pwEhi8oY2AsN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional setRole parameter to connection configuration (validated as a PostgreSQL identifier).
  * Connection pools will run SET ROLE for the configured role on each new connection.
  * Connections using different setRole values are kept separate to avoid cross-role caching.

* **Documentation**
  * Sample configuration now documents how to apply setRole on pooled connections.

* **Tests**
  * Integration and unit tests added to cover setRole behavior and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->