### PR TITLE
Prepare v0.7.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.7] - 2026-05-18
+
+### Added
+
+- **The operator can now `SET ROLE` to a privileged parent role on every pooled connection.** Set `connection.params.setRole: <role>` on a `PostgresPolicy` and the operator's sqlx pool runs `SET ROLE "<role>"` once via `after_connect`, so the session's `current_user` becomes that role and its attributes (`CREATEROLE`, `CREATEDB`, …) apply to every subsequent statement. This unblocks the "operator authenticates as a low-privilege identity (e.g. Cloud SQL IAM user via Workload Identity) that has been granted membership in `cloudsqlsuperuser`" pattern, where PostgreSQL's role membership semantics otherwise refuse role-attribute inheritance. The role identifier is validated at admission time against `^[A-Za-z_][A-Za-z0-9_$-]*$` via the CRD's OpenAPI `pattern`, and `SET ROLE` failures surface as a distinct `SetRoleFailed` status reason instead of being conflated with database connection failures. (#119, #120)
+
 ## [0.7.6] - 2026-05-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-cli"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-core"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "base64",
  "hmac 0.13.0",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-inspect"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "pgroles-core",
  "sqlx",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-operator"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 authors = ["Brian Thorne <brian@thorne.link>"]
 license = "MIT"
@@ -55,8 +55,8 @@ k8s-openapi = { version = "0.27.1", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Internal crates
-pgroles-core = { path = "crates/pgroles-core", version = "0.7.6" }
-pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.6" }
+pgroles-core = { path = "crates/pgroles-core", version = "0.7.7" }
+pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.7" }
 
 [profile.release]
 strip = "symbols"

--- a/charts/pgroles-operator/Chart.yaml
+++ b/charts/pgroles-operator/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Define roles, memberships, grants, and default privileges in YAML
   and let the operator converge your database to the desired state.
 type: application
-version: 0.7.6
-appVersion: "0.7.6"
+version: 0.7.7
+appVersion: "0.7.7"
 icon: https://raw.githubusercontent.com/hardbyte/pgroles/main/docs/public/logo.svg
 sources:
   - https://github.com/hardbyte/pgroles
@@ -16,8 +16,8 @@ maintainers:
     url: https://hardbyte.nz
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: 'Wildcard EXECUTE grants now converge on schemas that contain PostgreSQL procedures by rendering schema-wide function grants as ALL ROUTINES and specific function targets as ROUTINE.'
+    - kind: added
+      description: 'PostgresPolicy connection.params now accepts an optional setRole field. When set, the operator runs `SET ROLE "<value>"` on every pooled connection, enabling least-privilege identities (e.g. Cloud SQL IAM) that have been granted membership in a privileged role like cloudsqlsuperuser to act with that role''s attributes for DDL.'
   artifacthub.io/category: database
   artifacthub.io/operator: "true"
   artifacthub.io/prerelease: "false"


### PR DESCRIPTION
Bumps the pgroles workspace and Helm metadata from 0.7.6 → 0.7.7 and documents the `connection.params.setRole` field added in #120.

- `Cargo.toml`: workspace `version` + `pgroles-core`/`pgroles-inspect` path-dep versions
- `Cargo.lock`: regenerated by `cargo check --workspace`
- `charts/pgroles-operator/Chart.yaml`: `version`, `appVersion`, and a fresh `artifacthub.io/changes` entry
- `CHANGELOG.md`: new `[0.7.7]` Added entry

No code changes — purely release metadata. The 0.7.7 release is patch-level because the addition is opt-in and backward-compatible: existing `PostgresPolicy` resources without `connection.params.setRole` behave identically to 0.7.6.

Tagging `v0.7.7` against `main` once this merges will trigger `release.yml`.

https://claude.ai/code/session_01GeV3bnqE38pwEhi8oY2AsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GeV3bnqE38pwEhi8oY2AsN)_