### PR TITLE
Add external role marker for provider-managed roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Externally managed roles can now be marked `external: true`.** External roles may still be referenced in grants, schema ownership, default privileges, and as members of managed roles, but pgroles will not create, alter, drop, password-manage, or manage memberships granted from those roles. This avoids breaking Cloud SQL IAM users and groups whose `LOGIN` attribute and provider memberships are owned outside pgroles. (#123)
+
 ## [0.7.7] - 2026-05-18
 
 ### Added

--- a/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+++ b/charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
@@ -705,6 +705,11 @@
                           "nullable": true,
                           "type": "boolean"
                         },
+                        "external": {
+                          "default": false,
+                          "description": "Treat this role as externally managed. The operator may reference it in\ngrants, ownership, and memberships, but will not create, alter, drop,\npassword-manage, or manage memberships granted from this role.",
+                          "type": "boolean"
+                        },
                         "inherit": {
                           "nullable": true,
                           "type": "boolean"

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -16,7 +16,7 @@ use pgroles_cli::{
     inject_password_changes, planned_role_drops, read_manifest_file, resolve_passwords,
     validate_bundle_file, validate_manifest,
 };
-use pgroles_core::diff::{ReconciliationMode, filter_changes};
+use pgroles_core::diff::{ReconciliationMode, filter_changes, filter_external_role_changes};
 use pgroles_core::ownership::validate_changes_against_managed_surface;
 use pgroles_core::visual::{self, VisualManagedScope, VisualSource};
 use pgroles_inspect::{InspectConfig, inspect_drop_role_safety};
@@ -423,15 +423,18 @@ async fn cmd_diff(
         let resolved_passwords = resolve_passwords(&validated.composed.expanded)
             .context("failed to resolve role passwords")?;
         info!(%mode, "reconciliation mode");
-        let changes = inject_password_changes(
-            filter_changes(
-                apply_role_retirements(
-                    compute_plan(&current, &validated.composed.desired),
-                    &validated.composed.manifest.retirements,
+        let changes = filter_external_role_changes(
+            inject_password_changes(
+                filter_changes(
+                    apply_role_retirements(
+                        compute_plan(&current, &validated.composed.desired),
+                        &validated.composed.manifest.retirements,
+                    ),
+                    mode,
                 ),
-                mode,
+                &resolved_passwords,
             ),
-            &resolved_passwords,
+            &validated.composed.expanded.roles,
         );
         validate_changes_against_managed_surface(
             &changes,
@@ -485,15 +488,18 @@ async fn cmd_diff(
     let resolved_passwords =
         resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
     info!(%mode, "reconciliation mode");
-    let changes = inject_password_changes(
-        filter_changes(
-            apply_role_retirements(
-                compute_plan(&current, &validated.desired),
-                &validated.manifest.retirements,
+    let changes = filter_external_role_changes(
+        inject_password_changes(
+            filter_changes(
+                apply_role_retirements(
+                    compute_plan(&current, &validated.desired),
+                    &validated.manifest.retirements,
+                ),
+                mode,
             ),
-            mode,
+            &resolved_passwords,
         ),
-        &resolved_passwords,
+        &validated.expanded.roles,
     );
     let drop_safety = inspect_drop_safety(&pool, &changes, &validated.manifest.retirements).await?;
     let summary = PlanSummary::from_changes(&changes);
@@ -555,15 +561,18 @@ async fn cmd_apply(
         let resolved_passwords = resolve_passwords(&validated.composed.expanded)
             .context("failed to resolve role passwords")?;
         info!(%mode, "reconciliation mode");
-        let changes = inject_password_changes(
-            filter_changes(
-                apply_role_retirements(
-                    compute_plan(&current, &validated.composed.desired),
-                    &validated.composed.manifest.retirements,
+        let changes = filter_external_role_changes(
+            inject_password_changes(
+                filter_changes(
+                    apply_role_retirements(
+                        compute_plan(&current, &validated.composed.desired),
+                        &validated.composed.manifest.retirements,
+                    ),
+                    mode,
                 ),
-                mode,
+                &resolved_passwords,
             ),
-            &resolved_passwords,
+            &validated.composed.expanded.roles,
         );
         validate_changes_against_managed_surface(
             &changes,
@@ -641,15 +650,18 @@ async fn cmd_apply(
     let resolved_passwords =
         resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
     info!(%mode, "reconciliation mode");
-    let changes = inject_password_changes(
-        filter_changes(
-            apply_role_retirements(
-                compute_plan(&current, &validated.desired),
-                &validated.manifest.retirements,
+    let changes = filter_external_role_changes(
+        inject_password_changes(
+            filter_changes(
+                apply_role_retirements(
+                    compute_plan(&current, &validated.desired),
+                    &validated.manifest.retirements,
+                ),
+                mode,
             ),
-            mode,
+            &resolved_passwords,
         ),
-        &resolved_passwords,
+        &validated.expanded.roles,
     );
 
     // Validate changes against privilege level.

--- a/crates/pgroles-cli/src/main.rs
+++ b/crates/pgroles-cli/src/main.rs
@@ -420,22 +420,20 @@ async fn cmd_diff(
         let pool = connect_db(database_url).await?;
         let inspect_config = inspect_config_for_bundle(&validated);
         let current = inspect_current_for_plan_with_config(&pool, &inspect_config).await?;
-        let resolved_passwords = resolve_passwords(&validated.composed.expanded)
-            .context("failed to resolve role passwords")?;
         info!(%mode, "reconciliation mode");
         let changes = filter_external_role_changes(
-            inject_password_changes(
-                filter_changes(
-                    apply_role_retirements(
-                        compute_plan(&current, &validated.composed.desired),
-                        &validated.composed.manifest.retirements,
-                    ),
-                    mode,
+            filter_changes(
+                apply_role_retirements(
+                    compute_plan(&current, &validated.composed.desired),
+                    &validated.composed.manifest.retirements,
                 ),
-                &resolved_passwords,
+                mode,
             ),
             &validated.composed.expanded.roles,
         );
+        let resolved_passwords = resolve_passwords(&validated.composed.expanded)
+            .context("failed to resolve role passwords")?;
+        let changes = inject_password_changes(changes, &resolved_passwords);
         validate_changes_against_managed_surface(
             &changes,
             &validated.composed.managed_change_surface,
@@ -485,22 +483,20 @@ async fn cmd_diff(
     let pool = connect_db(database_url).await?;
     let current = inspect_current_for_plan(&pool, &validated).await?;
 
-    let resolved_passwords =
-        resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
     info!(%mode, "reconciliation mode");
     let changes = filter_external_role_changes(
-        inject_password_changes(
-            filter_changes(
-                apply_role_retirements(
-                    compute_plan(&current, &validated.desired),
-                    &validated.manifest.retirements,
-                ),
-                mode,
+        filter_changes(
+            apply_role_retirements(
+                compute_plan(&current, &validated.desired),
+                &validated.manifest.retirements,
             ),
-            &resolved_passwords,
+            mode,
         ),
         &validated.expanded.roles,
     );
+    let resolved_passwords =
+        resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
+    let changes = inject_password_changes(changes, &resolved_passwords);
     let drop_safety = inspect_drop_safety(&pool, &changes, &validated.manifest.retirements).await?;
     let summary = PlanSummary::from_changes(&changes);
 
@@ -558,22 +554,20 @@ async fn cmd_apply(
 
         let current = inspect_current_for_plan_with_config(&pool, &inspect_config).await?;
 
-        let resolved_passwords = resolve_passwords(&validated.composed.expanded)
-            .context("failed to resolve role passwords")?;
         info!(%mode, "reconciliation mode");
         let changes = filter_external_role_changes(
-            inject_password_changes(
-                filter_changes(
-                    apply_role_retirements(
-                        compute_plan(&current, &validated.composed.desired),
-                        &validated.composed.manifest.retirements,
-                    ),
-                    mode,
+            filter_changes(
+                apply_role_retirements(
+                    compute_plan(&current, &validated.composed.desired),
+                    &validated.composed.manifest.retirements,
                 ),
-                &resolved_passwords,
+                mode,
             ),
             &validated.composed.expanded.roles,
         );
+        let resolved_passwords = resolve_passwords(&validated.composed.expanded)
+            .context("failed to resolve role passwords")?;
+        let changes = inject_password_changes(changes, &resolved_passwords);
         validate_changes_against_managed_surface(
             &changes,
             &validated.composed.managed_change_surface,
@@ -647,22 +641,20 @@ async fn cmd_apply(
 
     let current = inspect_current_for_plan(&pool, &validated).await?;
 
-    let resolved_passwords =
-        resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
     info!(%mode, "reconciliation mode");
     let changes = filter_external_role_changes(
-        inject_password_changes(
-            filter_changes(
-                apply_role_retirements(
-                    compute_plan(&current, &validated.desired),
-                    &validated.manifest.retirements,
-                ),
-                mode,
+        filter_changes(
+            apply_role_retirements(
+                compute_plan(&current, &validated.desired),
+                &validated.manifest.retirements,
             ),
-            &resolved_passwords,
+            mode,
         ),
         &validated.expanded.roles,
     );
+    let resolved_passwords =
+        resolve_passwords(&validated.expanded).context("failed to resolve role passwords")?;
+    let changes = inject_password_changes(changes, &resolved_passwords);
 
     // Validate changes against privilege level.
     let priv_warnings =

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::manifest::{ObjectType, Privilege, RoleRetirement};
+use crate::manifest::{ObjectType, Privilege, RoleDefinition, RoleRetirement};
 use crate::model::{
     DefaultPrivKey, GrantKey, MembershipEdge, RoleAttribute, RoleGraph, RoleState,
     default_schema_owner_privileges,
@@ -202,6 +202,47 @@ pub fn filter_changes(changes: Vec<Change>, mode: ReconciliationMode) -> Vec<Cha
             .into_iter()
             .filter(|change| !is_role_drop_or_retirement(change))
             .collect(),
+    }
+}
+
+/// Remove role-lifecycle and granted-role membership changes for external roles.
+///
+/// External roles are still valid references for grants, schema ownership, and
+/// as members of managed roles. pgroles simply avoids taking ownership of the
+/// external role object itself or of memberships granted from that role.
+pub fn filter_external_role_changes(changes: Vec<Change>, roles: &[RoleDefinition]) -> Vec<Change> {
+    let external_roles: BTreeSet<&str> = roles
+        .iter()
+        .filter(|role| role.external)
+        .map(|role| role.name.as_str())
+        .collect();
+
+    if external_roles.is_empty() {
+        return changes;
+    }
+
+    changes
+        .into_iter()
+        .filter(|change| !is_external_role_change(change, &external_roles))
+        .collect()
+}
+
+fn is_external_role_change(change: &Change, external_roles: &BTreeSet<&str>) -> bool {
+    match change {
+        Change::CreateRole { name, .. }
+        | Change::AlterRole { name, .. }
+        | Change::SetComment { name, .. }
+        | Change::SetPassword { name, .. }
+        | Change::DropRole { name } => external_roles.contains(name.as_str()),
+        Change::AddMember { role, .. } | Change::RemoveMember { role, .. } => {
+            external_roles.contains(role.as_str())
+        }
+        Change::TerminateSessions { role }
+        | Change::DropOwned { role }
+        | Change::ReassignOwned {
+            from_role: role, ..
+        } => external_roles.contains(role.as_str()),
+        _ => false,
     }
 }
 
@@ -818,6 +859,24 @@ mod tests {
         }
     }
 
+    fn role_definition(name: &str, external: bool) -> RoleDefinition {
+        RoleDefinition {
+            name: name.to_string(),
+            external,
+            login: None,
+            superuser: None,
+            createdb: None,
+            createrole: None,
+            inherit: None,
+            replication: None,
+            bypassrls: None,
+            connection_limit: None,
+            comment: None,
+            password: None,
+            password_valid_until: None,
+        }
+    }
+
     #[test]
     fn diff_empty_to_empty_is_empty() {
         let changes = diff(&empty_graph(), &empty_graph());
@@ -875,6 +934,62 @@ mod tests {
             }
             other => panic!("expected AlterRole, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn external_role_filter_suppresses_lifecycle_and_granted_role_memberships() {
+        let external = "analytics-admin@example.com";
+        let mut current = empty_graph();
+        current.roles.insert(
+            external.to_string(),
+            RoleState {
+                login: true,
+                ..RoleState::default()
+            },
+        );
+        current.memberships.insert(MembershipEdge {
+            role: external.to_string(),
+            member: "cloudsqlsuperuser".to_string(),
+            inherit: true,
+            admin: false,
+        });
+
+        let mut desired = empty_graph();
+        desired
+            .roles
+            .insert(external.to_string(), RoleState::default());
+
+        let changes = diff(&current, &desired);
+        assert!(changes.iter().any(|change| {
+            matches!(
+                change,
+                Change::AlterRole { name, attributes }
+                    if name == external && attributes.contains(&RoleAttribute::Login(false))
+            )
+        }));
+        assert!(changes.iter().any(|change| {
+            matches!(
+                change,
+                Change::RemoveMember { role, member }
+                    if role == external && member == "cloudsqlsuperuser"
+            )
+        }));
+
+        let filtered = filter_external_role_changes(changes, &[role_definition(external, true)]);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn external_role_filter_keeps_external_role_as_managed_member() {
+        let external = "team@example.com";
+        let changes = vec![Change::RemoveMember {
+            role: "kv-editor".to_string(),
+            member: external.to_string(),
+        }];
+
+        let filtered =
+            filter_external_role_changes(changes.clone(), &[role_definition(external, true)]);
+        assert_eq!(filtered, changes);
     }
 
     #[test]
@@ -1748,6 +1863,7 @@ memberships:
     fn resolve_passwords_missing_env_var() {
         let roles = vec![crate::manifest::RoleDefinition {
             name: "app-svc".to_string(),
+            external: false,
             login: Some(true),
             password: Some(crate::manifest::PasswordSource {
                 from_env: "PGROLES_TEST_MISSING_VAR_9a8b7c6d".to_string(),
@@ -1781,6 +1897,7 @@ memberships:
     fn resolve_passwords_empty_env_var() {
         let roles = vec![crate::manifest::RoleDefinition {
             name: "app-svc".to_string(),
+            external: false,
             login: Some(true),
             password: Some(crate::manifest::PasswordSource {
                 from_env: "PGROLES_TEST_EMPTY_VAR_1a2b3c4d".to_string(),
@@ -1818,6 +1935,7 @@ memberships:
     fn resolve_passwords_happy_path() {
         let roles = vec![crate::manifest::RoleDefinition {
             name: "app-svc".to_string(),
+            external: false,
             login: Some(true),
             password: Some(crate::manifest::PasswordSource {
                 from_env: "PGROLES_TEST_RESOLVE_VAR_5e6f7g8h".to_string(),
@@ -1849,6 +1967,7 @@ memberships:
     fn resolve_passwords_skips_roles_without_password() {
         let roles = vec![crate::manifest::RoleDefinition {
             name: "no-password".to_string(),
+            external: false,
             login: Some(true),
             password: None,
             password_valid_until: None,

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -485,14 +485,17 @@ pub fn apply_role_retirements(changes: Vec<Change>, retirements: &[RoleRetiremen
 
 /// Resolve password sources from environment variables.
 ///
-/// Returns a map of role name → resolved password for every role that declares
-/// a `password.from_env` source. Returns an error if a referenced environment
-/// variable is not set.
+/// Returns a map of role name → resolved password for every managed role that
+/// declares a `password.from_env` source. External roles are reference-only and
+/// never participate in password management.
 pub fn resolve_passwords(
     roles: &[crate::manifest::RoleDefinition],
 ) -> Result<std::collections::BTreeMap<String, String>, PasswordResolutionError> {
     let mut resolved = std::collections::BTreeMap::new();
     for role in roles {
+        if role.external {
+            continue;
+        }
         if let Some(source) = &role.password {
             let value = std::env::var(&source.from_env).map_err(|_| {
                 PasswordResolutionError::MissingEnvVar {
@@ -1961,6 +1964,33 @@ memberships:
         let resolved = result.expect("should succeed");
         assert_eq!(resolved.len(), 1);
         assert_eq!(resolved["app-svc"], "my_secret_pw");
+    }
+
+    #[test]
+    fn resolve_passwords_skips_external_roles() {
+        let roles = vec![crate::manifest::RoleDefinition {
+            name: "external-svc".to_string(),
+            external: true,
+            login: Some(true),
+            password: Some(crate::manifest::PasswordSource {
+                from_env: "PGROLES_TEST_EXTERNAL_MISSING_VAR_2b4d6f8h".to_string(),
+            }),
+            password_valid_until: None,
+            superuser: None,
+            createdb: None,
+            createrole: None,
+            inherit: None,
+            replication: None,
+            bypassrls: None,
+            connection_limit: None,
+            comment: None,
+        }];
+
+        // SAFETY: test-only, unique var name avoids conflicts with parallel tests.
+        unsafe { std::env::remove_var("PGROLES_TEST_EXTERNAL_MISSING_VAR_2b4d6f8h") };
+
+        let resolved = resolve_passwords(&roles).expect("external role passwords are ignored");
+        assert!(resolved.is_empty());
     }
 
     #[test]

--- a/crates/pgroles-core/src/export.rs
+++ b/crates/pgroles-core/src/export.rs
@@ -26,6 +26,7 @@ pub fn role_graph_to_manifest(graph: &RoleGraph) -> PolicyManifest {
             let defaults = crate::model::RoleState::default();
             RoleDefinition {
                 name: name.clone(),
+                external: false,
                 login: if state.login != defaults.login {
                     Some(state.login)
                 } else {

--- a/crates/pgroles-core/src/manifest.rs
+++ b/crates/pgroles-core/src/manifest.rs
@@ -290,10 +290,20 @@ pub(crate) fn default_role_pattern() -> String {
     "{schema}-{profile}".to_string()
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// A concrete role definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleDefinition {
     pub name: String,
+
+    /// Treat this role as managed by another system. pgroles may reference it
+    /// in grants, ownership, and memberships, but will not create, alter, drop,
+    /// password-manage, or manage memberships granted from this role.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub external: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub login: Option<bool>,
@@ -546,6 +556,7 @@ pub fn expand_manifest(manifest: &PolicyManifest) -> Result<ExpandedManifest, Ma
             // Create role definition
             roles.push(RoleDefinition {
                 name: role_name.clone(),
+                external: false,
                 login: profile.login,
                 superuser: None,
                 createdb: None,

--- a/crates/pgroles-core/src/model.rs
+++ b/crates/pgroles-core/src/model.rs
@@ -391,6 +391,7 @@ mod tests {
     fn role_state_from_definition_applies_overrides() {
         let definition = RoleDefinition {
             name: "test".to_string(),
+            external: false,
             login: Some(true),
             superuser: None,
             createdb: Some(true),

--- a/crates/pgroles-core/tests/suggest_property.rs
+++ b/crates/pgroles-core/tests/suggest_property.rs
@@ -166,6 +166,7 @@ fn random_manifest(rng: &mut Rng) -> PolicyManifest {
             }
             roles.push(RoleDefinition {
                 name: role_name.clone(),
+                external: false,
                 login: if kind.login { Some(true) } else { None },
                 superuser: None,
                 createdb: None,

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -564,6 +564,11 @@ pub struct DefaultPrivilegeGrantSpec {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RoleSpec {
     pub name: String,
+    /// Treat this role as externally managed. The operator may reference it in
+    /// grants, ownership, and memberships, but will not create, alter, drop,
+    /// password-manage, or manage memberships granted from this role.
+    #[serde(default)]
+    pub external: bool,
     #[serde(default)]
     pub login: Option<bool>,
     #[serde(default)]
@@ -1429,6 +1434,7 @@ impl PostgresPolicySpec {
             .iter()
             .map(|r| RoleDefinition {
                 name: r.name.clone(),
+                external: r.external,
                 login: r.login,
                 superuser: r.superuser,
                 createdb: r.createdb,
@@ -1708,6 +1714,7 @@ mod tests {
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "analytics".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -1853,6 +1860,7 @@ mod tests {
             }],
             roles: vec![RoleSpec {
                 name: "app-service".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -2720,6 +2728,7 @@ params:
         let mut spec = spec_with_connection(params_mode_connection());
         spec.roles = vec![RoleSpec {
             name: "app".into(),
+            external: false,
             login: Some(true),
             password: Some(PasswordSpec {
                 secret_ref: Some(SecretReference {
@@ -3283,6 +3292,7 @@ retirements:
             roles: vec![
                 RoleSpec {
                     name: "role-a".to_string(),
+                    external: false,
                     login: Some(true),
                     password: Some(PasswordSpec {
                         secret_ref: Some(SecretReference {
@@ -3303,6 +3313,7 @@ retirements:
                 },
                 RoleSpec {
                     name: "role-b".to_string(),
+                    external: false,
                     login: Some(true),
                     password: Some(PasswordSpec {
                         secret_ref: Some(SecretReference {
@@ -3323,6 +3334,7 @@ retirements:
                 },
                 RoleSpec {
                     name: "role-c".to_string(),
+                    external: false,
                     login: None,
                     password: None,
                     password_valid_until: None,
@@ -3378,6 +3390,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: Some(false),
                 superuser: None,
                 createdb: None,
@@ -3428,6 +3441,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: None, // omitted, not explicitly false
                 superuser: None,
                 createdb: None,
@@ -3478,6 +3492,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -3532,6 +3547,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -3584,6 +3600,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -3637,6 +3654,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -3689,6 +3707,7 @@ retirements:
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "app-user".to_string(),
+                external: false,
                 login: Some(true),
                 superuser: None,
                 createdb: None,

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -1714,7 +1714,7 @@ mod tests {
             schemas: vec![],
             roles: vec![RoleSpec {
                 name: "analytics".to_string(),
-                external: false,
+                external: true,
                 login: Some(true),
                 superuser: None,
                 createdb: None,
@@ -1743,6 +1743,7 @@ mod tests {
         assert_eq!(manifest.default_owner, Some("app_owner".to_string()));
         assert_eq!(manifest.roles.len(), 1);
         assert_eq!(manifest.roles[0].name, "analytics");
+        assert!(manifest.roles[0].external);
         assert_eq!(manifest.roles[0].login, Some(true));
         assert_eq!(manifest.roles[0].comment, Some("test role".to_string()));
         assert_eq!(manifest.retirements.len(), 1);

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -931,6 +931,7 @@ async fn apply_under_lock(
     if !password_changes.is_empty() {
         changes = pgroles_core::diff::inject_password_changes(changes, &password_changes);
     }
+    changes = pgroles_core::diff::filter_external_role_changes(changes, &expanded.roles);
     let dropped_roles: Vec<String> = changes
         .iter()
         .filter_map(|change| match change {
@@ -2291,6 +2292,7 @@ mod tests {
                 schemas: Vec::new(),
                 roles: vec![RoleSpec {
                     name: role_name.to_string(),
+                    external: false,
                     login: Some(true),
                     superuser: None,
                     createdb: None,
@@ -2366,6 +2368,7 @@ mod tests {
                 roles: vec![
                     RoleSpec {
                         name: "app".to_string(),
+                        external: false,
                         login: Some(true),
                         superuser: None,
                         createdb: None,
@@ -2386,6 +2389,7 @@ mod tests {
                     },
                     RoleSpec {
                         name: "reporter".to_string(),
+                        external: false,
                         login: Some(true),
                         superuser: None,
                         createdb: None,

--- a/crates/pgroles-operator/src/reconciler.rs
+++ b/crates/pgroles-operator/src/reconciler.rs
@@ -924,6 +924,7 @@ async fn apply_under_lock(
         ),
         reconciliation_mode,
     );
+    changes = pgroles_core::diff::filter_external_role_changes(changes, &expanded.roles);
 
     let resolved_passwords = resolve_passwords_from_secrets(ctx, resource, namespace).await?;
     let (password_changes, applied_password_source_versions) =
@@ -931,7 +932,6 @@ async fn apply_under_lock(
     if !password_changes.is_empty() {
         changes = pgroles_core::diff::inject_password_changes(changes, &password_changes);
     }
-    changes = pgroles_core::diff::filter_external_role_changes(changes, &expanded.roles);
     let dropped_roles: Vec<String> = changes
         .iter()
         .filter_map(|change| match change {
@@ -1588,6 +1588,9 @@ async fn resolve_passwords_from_secrets(
 
     // First pass: fetch all referenced Secrets for secretRef roles.
     for role_spec in &resource.spec.roles {
+        if role_spec.external {
+            continue;
+        }
         if let Some(pw) = &role_spec.password
             && let Some(secret_ref) = &pw.secret_ref
         {
@@ -1607,6 +1610,9 @@ async fn resolve_passwords_from_secrets(
 
     // Second pass: resolve passwords from cache (secretRef) or generate.
     for role_spec in &resource.spec.roles {
+        if role_spec.external {
+            continue;
+        }
         if let Some(pw) = &role_spec.password {
             if let Some(gen_spec) = &pw.generate {
                 let password = if resource.spec.mode == PolicyMode::Plan {
@@ -1744,6 +1750,9 @@ fn resolve_passwords_from_cached_secrets(
 ) -> Result<std::collections::BTreeMap<String, ResolvedPassword>, ReconcileError> {
     let mut resolved = std::collections::BTreeMap::new();
     for role_spec in &resource.spec.roles {
+        if role_spec.external {
+            continue;
+        }
         if let Some(pw) = &role_spec.password
             && pw.secret_ref.is_some()
         {
@@ -3783,6 +3792,27 @@ mod tests {
                 .map(|password| password.cleartext.as_str()),
             Some("reporter-secret")
         );
+    }
+
+    #[test]
+    fn resolve_passwords_from_cached_secrets_skips_external_roles() {
+        let mut resource = password_role_policy();
+        resource.spec.roles[1].external = true;
+        let cache = BTreeMap::from([(
+            "role-passwords".to_string(),
+            secret_with_keys("role-passwords", &[("app", "app-secret")]),
+        )]);
+
+        let resolved =
+            resolve_passwords_from_cached_secrets(&resource, &cache).expect("should resolve");
+
+        assert_eq!(
+            resolved
+                .get("app")
+                .map(|password| password.cleartext.as_str()),
+            Some("app-secret")
+        );
+        assert!(!resolved.contains_key("reporter"));
     }
 
     #[test]

--- a/docs/src/pages/docs/google-cloud-sql.md
+++ b/docs/src/pages/docs/google-cloud-sql.md
@@ -72,8 +72,7 @@ Cloud SQL maps IAM principals to PostgreSQL roles with specific naming rules:
 ```yaml
 roles:
   - name: "my-sa@my-project.iam"
-    login: true
-    comment: "IAM-authenticated service account"
+    external: true
 ```
 
 ### IAM groups
@@ -83,8 +82,7 @@ roles:
 ```yaml
 roles:
   - name: "backend-team@example.com"
-    login: false
-    comment: "Cloud Identity group — members authenticate individually"
+    external: true
 
 grants:
   - role: "backend-team@example.com"
@@ -96,6 +94,8 @@ grants:
 ```
 
 When a group member logs in for the first time, Cloud SQL creates their individual PostgreSQL role automatically and grants them the group's privileges.
+
+Use `external: true` for Cloud SQL IAM users and groups that are created through Cloud SQL IAM APIs, Terraform `google_sql_user`, or another platform owner. That keeps pgroles from changing the role's `LOGIN` attribute or revoking provider-managed role memberships while still allowing grants and ownership references.
 
 {% callout type="note" title="Group membership propagation" %}
 Changes to Cloud Identity group membership take about 15 minutes to propagate. However, changes to the group's database privileges take effect immediately.

--- a/docs/src/pages/docs/manifest-reference.md
+++ b/docs/src/pages/docs/manifest-reference.md
@@ -136,6 +136,7 @@ roles:
 | Attribute | Type | Default | Description |
 |---|---|---|---|
 | `name` | string | *required* | Role name |
+| `external` | bool | `false` | Role lifecycle is managed outside pgroles |
 | `login` | bool | `false` | Can the role log in? |
 | `superuser` | bool | `false` | Superuser privileges |
 | `createdb` | bool | `false` | Can create databases |
@@ -151,6 +152,8 @@ roles:
 Roles with `login: true` can declare a password source. The password value is never stored in the manifest; it is resolved at apply time from an environment variable in CLI mode or from a Kubernetes Secret in operator mode.
 
 Only `login: true` roles may have a password. Declaring a password on a non-login role is a validation error.
+
+Use `external: true` for roles whose lifecycle is owned by another system, such as Cloud SQL IAM users or groups created by Terraform or the cloud provider API. pgroles may still reference external roles in grants, schema ownership, default privileges, and as members of managed roles, but it will not create, alter, drop, password-manage, or manage memberships granted from the external role.
 
 {% callout type="note" title="Passwords and drift detection" %}
 Because PostgreSQL does not expose password hashes for comparison, password changes always appear in the plan. The `diff --exit-code` flag treats password-only changes as non-structural; they do not trigger exit code 2.

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -705,6 +705,11 @@
                           "nullable": true,
                           "type": "boolean"
                         },
+                        "external": {
+                          "default": false,
+                          "description": "Treat this role as externally managed. The operator may reference it in\ngrants, ownership, and memberships, but will not create, alter, drop,\npassword-manage, or manage memberships granted from this role.",
+                          "type": "boolean"
+                        },
                         "inherit": {
                           "nullable": true,
                           "type": "boolean"


### PR DESCRIPTION
## Summary
- add `roles[].external: true` to mark provider-owned roles as referenceable but not lifecycle-managed
- filter lifecycle, password, drop/retirement, and memberships granted from external roles in CLI and operator planning
- document the Cloud SQL IAM pattern and regenerate the PostgresPolicy CRD

Fixes #123.

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p pgroles-core external_role_filter -- --nocapture`
- `cargo test -p pgroles-cli --bin pgroles`
- `cargo test -p pgroles-operator --lib`
- `scripts/check-crd-drift.sh`
- `cargo test -p pgroles-core --lib`
- `cargo test -p pgroles-cli --test cli`
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

## Reproduction
- reproduced the issue with a generic Cloud SQL IAM-style role declared under `roles:` in authoritative mode, which planned `ALTER ROLE ... NOLOGIN` and a provider-membership revoke
- confirmed adding `external: true` suppresses those destructive role-management changes while preserving reference use in grants and ownership

## Notes
- changed docs and regression tests use generic examples only; no environment-specific names are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for marking roles as externally managed via `external: true`. Such roles may be referenced for grants, ownership, and default privileges, but pgroles and the operator will not create/alter/drop them or manage their passwords or outbound membership grants.

* **Documentation**
  * Updated manifest reference and Google Cloud SQL guide with examples and guidance for using `external: true`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/pgroles/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->