### PR TITLE
ci: bump remaining Node 20 actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: Configure Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -54,7 +54,7 @@ jobs:
         run: touch out/.nojekyll
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/out
 
@@ -69,4 +69,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/operator-fairness-load.yml
+++ b/.github/workflows/operator-fairness-load.yml
@@ -25,7 +25,7 @@ jobs:
       should_run: ${{ steps.decide.outputs.should_run }}
       reason: ${{ steps.decide.outputs.reason }}
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: decide
         with:
           script: |


### PR DESCRIPTION
GitHub forces Node.js 20 actions to run on Node 24 starting **June 16th, 2026** and removes Node 20 from runners in September 2026. Most of this repo is already on node24 majors; this bumps the stragglers:

| Workflow | Action | From | To | Notes |
|---|---|---|---|---|
| docs-pages.yml | `actions/setup-node` | v4 | v6 | `node-version: 20` is the docs build toolchain, unrelated to the action runtime |
| docs-pages.yml | `actions/configure-pages` | v5 | v6 | node24 only |
| docs-pages.yml | `actions/deploy-pages` | v4 | v5 | node24 only |
| docs-pages.yml | `actions/upload-pages-artifact` | v3 | v5 | composite, but v3 internally runs `upload-artifact@v4` (node20); v5 pins v7 |
| operator-fairness-load.yml | `actions/github-script` | v7 | v9 | script only uses injected `github`/`context`/`core` — unaffected by v9's ESM break of `require('@actions/github')` |

Left as-is: `release.yml`'s `upload-artifact@v6`/`download-artifact@v7` (already node24-default), docker/* (all node24 at current pins), `attest@v4`/`softprops/action-gh-release@v3` (node24), `cosign-installer` (composite), `Swatinem/rust-cache@v2` (floating major resolves to node24), and the local `setup-e2e` composite (uses `docker/setup-buildx-action@v4`, node24).

Same sweep as thepartly/reflectapi#172.