### PR TITLE
test: live-DB coverage for role config inspection and convergence

### DIFF
--- a/crates/pgroles-inspect/src/roles.rs
+++ b/crates/pgroles-inspect/src/roles.rs
@@ -248,6 +248,122 @@ mod tests {
     }
 
     #[test]
+    fn parse_rolconfig_entry_splits_on_first_equals() {
+        // GUC values may themselves contain '=' — only the first one is the
+        // parameter/value separator.
+        assert_eq!(
+            parse_rolconfig_entry("search_path=a=b"),
+            Some(("search_path".to_string(), "a=b".to_string()))
+        );
+        assert_eq!(parse_rolconfig_entry("no_separator"), None);
+    }
+
+    #[test]
+    fn parse_rolconfig_entry_unescapes_doubled_quotes() {
+        assert_eq!(
+            parse_rolconfig_entry(r#"app.motd="say ""hi"", ok""#),
+            Some(("app.motd".to_string(), r#"say "hi", ok"#.to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_rolconfig_entry_lowercases_parameter_names() {
+        assert_eq!(
+            parse_rolconfig_entry("Role=combined"),
+            Some(("role".to_string(), "combined".to_string()))
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn fetch_roles_reads_role_config_defaults() {
+        let login = unique_name("config_login");
+        let group = unique_name("config_group");
+        let _cleanup = TestDbCleanup::new(format!(
+            r#"
+            DROP ROLE IF EXISTS "{login}";
+            DROP ROLE IF EXISTS "{group}";
+            "#
+        ));
+
+        // search_path is set from a single string literal — PostgreSQL stores
+        // it double-quoted in rolconfig (`search_path="app, public"`), which
+        // exercises the quote-stripping normalization.
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{login}";
+            DROP ROLE IF EXISTS "{group}";
+            CREATE ROLE "{group}" NOLOGIN;
+            CREATE ROLE "{login}" LOGIN;
+            GRANT "{group}" TO "{login}";
+            ALTER ROLE "{login}" SET "role" = '{group}';
+            ALTER ROLE "{login}" SET "search_path" = 'app, public';
+            ALTER ROLE "{login}" SET "app.tenant" = 'acme';
+            "#
+        ));
+
+        let roles = with_runtime(async {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            fetch_roles(&pool, Some(&[login.as_str()]))
+                .await
+                .expect("failed to fetch scoped roles")
+        });
+
+        assert_eq!(roles.len(), 1);
+        let config = &roles[0].to_role_state().config;
+        assert_eq!(config.get("role").map(String::as_str), Some(group.as_str()));
+        assert_eq!(
+            config.get("search_path").map(String::as_str),
+            Some("app, public")
+        );
+        assert_eq!(config.get("app.tenant").map(String::as_str), Some("acme"));
+    }
+
+    #[test]
+    #[ignore]
+    fn fetch_roles_ignores_per_database_config() {
+        let login = unique_name("config_dbscoped");
+        let _cleanup = TestDbCleanup::new(format!(r#"DROP ROLE IF EXISTS "{login}";"#));
+
+        execute_sql(&format!(
+            r#"
+            DROP ROLE IF EXISTS "{login}";
+            CREATE ROLE "{login}" LOGIN;
+            "#
+        ));
+
+        let roles = with_runtime(async {
+            use sqlx::Executor;
+
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect to live test database");
+            let (dbname,): (String,) = sqlx::query_as("SELECT current_database()")
+                .fetch_one(&pool)
+                .await
+                .expect("failed to read current database name");
+            pool.execute(
+                format!(r#"ALTER ROLE "{login}" IN DATABASE "{dbname}" SET "work_mem" = '64MB';"#)
+                    .as_str(),
+            )
+            .await
+            .expect("failed to set per-database config");
+
+            fetch_roles(&pool, Some(&[login.as_str()]))
+                .await
+                .expect("failed to fetch scoped roles")
+        });
+
+        assert_eq!(roles.len(), 1);
+        assert!(
+            roles[0].to_role_state().config.is_empty(),
+            "per-database settings must not appear as managed cluster-wide config"
+        );
+    }
+
+    #[test]
     #[ignore]
     fn fetch_roles_scopes_to_managed_names() {
         let managed = unique_name("managed_role");

--- a/crates/pgroles-inspect/tests/config_roundtrip.rs
+++ b/crates/pgroles-inspect/tests/config_roundtrip.rs
@@ -1,0 +1,162 @@
+//! Live round-trip test for role configuration defaults.
+//!
+//! Exercises the full pipeline against a real PostgreSQL server:
+//! manifest → expand → diff → SQL → execute → inspect → diff again.
+//! This is the coverage that catches version- or quoting-dependent drift
+//! in how `pg_roles.rolconfig` stores values (e.g. list-typed settings set
+//! from a single literal come back double-quoted), which unit tests with
+//! hand-written rolconfig fixtures cannot see.
+//!
+//! Requires DATABASE_URL; run with `cargo test -- --include-ignored`.
+
+use sqlx::{Executor, PgPool};
+
+use pgroles_core::diff::diff;
+use pgroles_core::manifest::{expand_manifest, parse_manifest};
+use pgroles_core::model::RoleGraph;
+use pgroles_core::sql::render_statements;
+use pgroles_inspect::{InspectConfig, inspect};
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for live DB tests")
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos()
+}
+
+fn with_runtime<T>(future: impl std::future::Future<Output = T>) -> T {
+    tokio::runtime::Runtime::new()
+        .expect("failed to create tokio runtime")
+        .block_on(future)
+}
+
+async fn execute_all(pool: &PgPool, statements: &[String]) {
+    for statement in statements {
+        pool.execute(statement.as_str())
+            .await
+            .unwrap_or_else(|error| panic!("failed to execute `{statement}`: {error}"));
+    }
+}
+
+struct RoleCleanup {
+    roles: Vec<String>,
+}
+
+impl Drop for RoleCleanup {
+    fn drop(&mut self) {
+        let roles = self.roles.clone();
+        with_runtime(async move {
+            let pool = PgPool::connect(&database_url())
+                .await
+                .expect("failed to connect for cleanup");
+            for role in roles {
+                let _ = pool
+                    .execute(format!(r#"DROP ROLE IF EXISTS "{role}";"#).as_str())
+                    .await;
+            }
+        });
+    }
+}
+
+#[test]
+#[ignore]
+fn role_config_converges_and_detects_drift() {
+    let suffix = unique_suffix();
+    let blue = format!("cfg_blue_{suffix}");
+    let green = format!("cfg_green_{suffix}");
+    let combined = format!("cfg_combined_{suffix}");
+    let _cleanup = RoleCleanup {
+        roles: vec![blue.clone(), green.clone(), combined.clone()],
+    };
+
+    // The issue-132 blue/green pattern, plus a list-valued setting written
+    // in the form PostgreSQL re-quotes on storage.
+    let yaml = format!(
+        r#"
+roles:
+  - name: {combined}
+  - name: {blue}
+    login: true
+    config:
+      role: {combined}
+      search_path: "app, public"
+  - name: {green}
+    login: true
+    config:
+      role: {combined}
+
+memberships:
+  - role: {combined}
+    members:
+      - name: {blue}
+      - name: {green}
+"#
+    );
+
+    let manifest = parse_manifest(&yaml).expect("manifest should parse");
+    let expanded = expand_manifest(&manifest).expect("manifest should expand");
+    let desired = RoleGraph::from_expanded(&expanded, None).expect("graph should build");
+    let config = InspectConfig::from_expanded(&expanded, false);
+
+    with_runtime(async {
+        let pool = PgPool::connect(&database_url())
+            .await
+            .expect("failed to connect to live test database");
+
+        // Fresh state: plan creates everything, including config alters.
+        let current = inspect(&pool, &config).await.expect("inspect failed");
+        let changes = diff(&current, &desired);
+        assert!(!changes.is_empty(), "fresh plan should not be empty");
+        let statements: Vec<String> = changes.iter().flat_map(render_statements).collect();
+        execute_all(&pool, &statements).await;
+
+        // Converged: a re-inspect must produce an empty plan. This is the
+        // no-flapping property — if rolconfig normalization ever disagrees
+        // with what we applied, this assertion catches it.
+        let current = inspect(&pool, &config).await.expect("inspect failed");
+        let changes = diff(&current, &desired);
+        assert!(
+            changes.is_empty(),
+            "expected converged state, got: {changes:?}"
+        );
+
+        // Drift both ways: green loses its setting, blue gains a stray one.
+        execute_all(
+            &pool,
+            &[
+                format!(r#"ALTER ROLE "{green}" RESET "role";"#),
+                format!(r#"ALTER ROLE "{blue}" SET "statement_timeout" = '10s';"#),
+            ],
+        )
+        .await;
+
+        let current = inspect(&pool, &config).await.expect("inspect failed");
+        let changes = diff(&current, &desired);
+        let statements: Vec<String> = changes.iter().flat_map(render_statements).collect();
+        assert!(
+            statements
+                .iter()
+                .any(|s| s == &format!(r#"ALTER ROLE "{green}" SET "role" = '{combined}';"#)),
+            "expected drift plan to restore green's role setting, got: {statements:?}"
+        );
+        assert!(
+            statements
+                .iter()
+                .any(|s| s == &format!(r#"ALTER ROLE "{blue}" RESET "statement_timeout";"#)),
+            "expected drift plan to reset blue's stray setting, got: {statements:?}"
+        );
+
+        // Applying the drift plan converges again.
+        execute_all(&pool, &statements).await;
+        let current = inspect(&pool, &config).await.expect("inspect failed");
+        let changes = diff(&current, &desired);
+        assert!(
+            changes.is_empty(),
+            "expected re-converged state, got: {changes:?}"
+        );
+    });
+}


### PR DESCRIPTION
Stacked on #134 — adds the live-database coverage the role config feature was missing. Once #134 merges this should retarget to `main`.

## What

The config feature's unit tests cover the parse → diff → render pipeline well, but nothing exercised a real PostgreSQL server. The storage format of `pg_roles.rolconfig` is exactly the kind of boundary that unit tests with hand-written fixtures can't protect (e.g. list-typed values set from a single literal come back double-quoted, and that normalization must agree with what pgroles applies — or every plan flaps forever).

New `#[ignore]` tests, which CI runs against the PostgreSQL 16/17/18 matrix via `--include-ignored`:

- **`fetch_roles_reads_role_config_defaults`** — sets `role`, a list-valued `search_path` (from a single literal, exercising the quote-stripping normalization), and a dot-qualified custom GUC (`app.tenant`) on a live server, then asserts the inspected `RoleState.config`.
- **`fetch_roles_ignores_per_database_config`** — `ALTER ROLE ... IN DATABASE ... SET` settings must not surface as managed cluster-wide config (they are documented as out of scope).
- **`role_config_converges_and_detects_drift`** (new `config_roundtrip.rs` integration test) — full pipeline round-trip of the issue-132 blue/green manifest: fresh apply, then re-inspect must produce an **empty plan** (the no-flapping property), then drift injected in both directions (a lost setting and a stray one) is detected, corrected, and re-converges to empty.

Plus fast unit tests for `parse_rolconfig_entry` edges: values containing `=` (split only on the first), doubled-quote unescaping, and parameter-name lowercasing.

## Testing

Full workspace with `--include-ignored` passes against PostgreSQL 16 (702 tests); clippy clean. The new live tests use unique role names with drop-guards, matching the existing live-test conventions in `pgroles-inspect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TwqLzRSJR8WHpLvvVqkCg

---
_Generated by [Claude Code](https://claude.ai/code/session_019TwqLzRSJR8WHpLvvVqkCg)_