### PR TITLE
fix: single-pass convergence for schema owner transfer with stale owner grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schema owner transfers no longer strip the incoming owner's privileges when a stale explicit grant exists.** `ALTER SCHEMA ... OWNER TO z` merges z's pre-existing explicit ACL entry into the new owner entry, so a same-plan `REVOKE` against that stale grant removed the *new owner's* USAGE — leaving the owner unable to resolve its own schema until the next reconcile. The diff engine now suppresses schema revokes whose grantee is that schema's incoming owner in the same plan; the state converges in a single pass. Proven by the live property suite, which previously had to exclude this shape. (#140)
+
 ### Added
 
 - **Profiles can now declare `config` defaults for the roles they generate, with `{schema}`/`{profile}` placeholder substitution in values.** The same role-level `ALTER ROLE ... SET` config introduced below is now available on `profiles[].config`, so a per-schema `search_path` default (`config: { search_path: "{schema}" }`) can be declared once and expanded across every `schema x profile` binding instead of repeated per generated role. Placeholders substitute only in values — keys stay literal PostgreSQL parameter names, and the `config.role` membership cross-check applies to generated roles the same as hand-written ones. `pgroles generate --suggest-profiles` never clusters a `config`-carrying role into a profile, keeping it flat instead, since collapsing config maps modulo placeholder substitution risks silently changing what gets applied.

--- a/crates/pgroles-core/src/diff.rs
+++ b/crates/pgroles-core/src/diff.rs
@@ -403,6 +403,33 @@ pub fn diff(current: &RoleGraph, desired: &RoleGraph) -> Vec<Change> {
 
     diff_memberships(current, desired, &mut add_members, &mut remove_members);
 
+    // A schema-owner transfer absorbs the incoming owner's pre-existing
+    // explicit ACL entry into the new owner entry (`ALTER SCHEMA ... OWNER TO
+    // z` merges `z=U/old` into `z=UC/z`). A revoke planned against that stale
+    // explicit grant would therefore strip the NEW OWNER's privilege — the
+    // single-pass convergence bug in issue #140. Suppress schema revokes whose
+    // grantee is the schema's incoming owner in this same plan; the follow-up
+    // inspection folds the owner's privileges into `SchemaState`, so the
+    // suppressed revoke's target no longer exists as an explicit grant.
+    let incoming_owners: BTreeSet<(&str, &str)> = schema_changes
+        .iter()
+        .filter_map(|change| match change {
+            Change::AlterSchemaOwner { name, owner } => Some((name.as_str(), owner.as_str())),
+            _ => None,
+        })
+        .collect();
+    if !incoming_owners.is_empty() {
+        revokes.retain(|change| match change {
+            Change::Revoke {
+                role,
+                object_type: ObjectType::Schema,
+                name: Some(schema_name),
+                ..
+            } => !incoming_owners.contains(&(schema_name.as_str(), role.as_str())),
+            _ => true,
+        });
+    }
+
     // ----- Assemble in dependency order -----
     let mut changes = Vec::new();
     changes.extend(creates);
@@ -970,6 +997,79 @@ mod tests {
             }
             other => panic!("expected AlterRole, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn owner_transfer_suppresses_revoke_of_incoming_owners_stale_grant() {
+        // Issue #140: a stale explicit schema grant to the role that becomes
+        // the schema's owner in the same plan must NOT be revoked — the
+        // transfer absorbs the grantee's ACL entry into the owner entry, so
+        // the revoke would strip the NEW OWNER's privilege.
+        let mut current = empty_graph();
+        for role in ["w", "z", "bystander"] {
+            current.roles.insert(role.to_string(), RoleState::default());
+        }
+        current.schemas.insert(
+            "s".to_string(),
+            SchemaState {
+                owner: Some("w".to_string()),
+                owner_privileges: default_schema_owner_privileges("w"),
+            },
+        );
+        for grantee in ["z", "bystander"] {
+            current.grants.insert(
+                GrantKey {
+                    role: grantee.to_string(),
+                    object_type: ObjectType::Schema,
+                    schema: None,
+                    name: Some("s".to_string()),
+                },
+                GrantState {
+                    privileges: [Privilege::Usage].into_iter().collect(),
+                },
+            );
+        }
+
+        let mut desired = empty_graph();
+        for role in ["w", "z", "bystander"] {
+            desired.roles.insert(role.to_string(), RoleState::default());
+        }
+        desired.schemas.insert(
+            "s".to_string(),
+            SchemaState {
+                owner: Some("z".to_string()),
+                owner_privileges: default_schema_owner_privileges("z"),
+            },
+        );
+
+        let changes = diff(&current, &desired);
+
+        assert!(
+            changes.iter().any(|c| matches!(
+                c,
+                Change::AlterSchemaOwner { name, owner } if name == "s" && owner == "z"
+            )),
+            "expected owner transfer in plan: {changes:?}"
+        );
+        // The incoming owner's stale grant is absorbed by the transfer, not
+        // revoked...
+        assert!(
+            !changes.iter().any(|c| matches!(
+                c,
+                Change::Revoke { role, object_type: ObjectType::Schema, name: Some(n), .. }
+                    if role == "z" && n == "s"
+            )),
+            "revoke against incoming owner must be suppressed: {changes:?}"
+        );
+        // ...while unrelated revokes on the same schema still happen.
+        assert!(
+            changes.iter().any(|c| matches!(
+                c,
+                Change::Revoke { role, object_type: ObjectType::Schema, name: Some(n), .. }
+                    if role == "bystander" && n == "s"
+            )),
+            "bystander's stale grant must still be revoked: {changes:?}"
+        );
     }
 
     #[test]

--- a/crates/pgroles-core/tests/diff_property.rs
+++ b/crates/pgroles-core/tests/diff_property.rs
@@ -575,6 +575,19 @@ fn apply_changes(graph: &RoleGraph, changes: &[Change]) -> RoleGraph {
                     .get_mut(name)
                     .unwrap_or_else(|| panic!("AlterSchemaOwner on absent schema {name:?}"));
                 state.owner = Some(owner.clone());
+                // PostgreSQL's ALTER SCHEMA ... OWNER TO merges any explicit
+                // ACL entry the incoming owner held into the (full) owner
+                // entry, and inspection folds owner privileges into
+                // SchemaState rather than reporting an explicit grant row —
+                // mirror both (see issue #140).
+                state.owner_privileges =
+                    [Privilege::Create, Privilege::Usage].into_iter().collect();
+                g.grants.remove(&GrantKey {
+                    role: owner.clone(),
+                    object_type: ObjectType::Schema,
+                    schema: None,
+                    name: Some(name.clone()),
+                });
             }
             Change::EnsureSchemaOwnerPrivileges {
                 name, privileges, ..

--- a/crates/pgroles-inspect/tests/diff_property_live.rs
+++ b/crates/pgroles-inspect/tests/diff_property_live.rs
@@ -696,34 +696,30 @@ fn derive_current(rng: &mut Rng, desired: &RoleGraph, names: &Names) -> RoleGrap
     c
 }
 
-/// Enforce the cross-graph boundary documented in the header: a schema-level
-/// grant whose grantee owns that schema in *either* graph cannot round-trip
-/// (inspection folds owner privileges into `SchemaState`).
+/// Enforce the per-graph round-trip boundary documented in the header: a
+/// schema-level grant whose grantee owns that schema *in the same graph*
+/// cannot round-trip, because inspection folds the owner's privileges into
+/// `SchemaState` instead of reporting an explicit grant row — a desired-side
+/// grant-to-owner would re-plan forever, and a current-side one is not a
+/// reachable inspected state.
 ///
-/// EXCLUDED-WITH-COMMENT — suspected single-pass convergence bug in the diff
-/// engine, verified against PostgreSQL 16.13 and left for the maintainer to
-/// decide (this suite must stay green):
-///   current:  schema s owner=w, owner_privileges={CREATE,USAGE};
-///             grant (z, SCHEMA s) = {USAGE}       (z is not yet the owner)
-///   desired:  schema s owner=z, owner_privileges={CREATE,USAGE}; no grants
-///   plan:     AlterSchemaOwner(s → z), then Revoke(USAGE ON s FROM z)
-/// `ALTER SCHEMA ... OWNER TO z` merges z's explicit ACL entry into the new
-/// owner entry (`{z=UC/z}`), so the plan's later REVOKE strips the *owner's*
-/// USAGE (`{z=C/z}`). EnsureSchemaOwnerPrivileges is not emitted in the same
-/// plan because it is computed from the pre-transfer owner's (complete)
-/// privileges — the state only self-heals on the NEXT reconcile. Single-pass
-/// convergence is violated. Generating this shape would fail assertion 1, so
-/// both graphs are sanitized against the union of owners.
+/// The CROSS-graph shape — a stale grant in `current` to a role that becomes
+/// the schema's owner in `desired` (issue #140) — is deliberately generatable:
+/// the diff engine now suppresses the revoke that the same-plan owner
+/// transfer would otherwise turn into a strip of the new owner's USAGE, and
+/// this suite proves that fix against real PostgreSQL.
 fn strip_owner_schema_grants(current: &mut RoleGraph, desired: &mut RoleGraph) {
-    let mut owners: BTreeSet<(String, String)> = BTreeSet::new();
-    for graph in [&*current, &*desired] {
-        for (schema, state) in &graph.schemas {
-            if let Some(owner) = &state.owner {
-                owners.insert((schema.clone(), owner.clone()));
-            }
-        }
-    }
     for graph in [current, desired] {
+        let owners: BTreeSet<(String, String)> = graph
+            .schemas
+            .iter()
+            .filter_map(|(schema, state)| {
+                state
+                    .owner
+                    .as_ref()
+                    .map(|owner| (schema.clone(), owner.clone()))
+            })
+            .collect();
         graph.grants.retain(|key, _| {
             !(key.object_type == ObjectType::Schema
                 && key
@@ -859,6 +855,19 @@ fn apply_changes(graph: &RoleGraph, changes: &[Change]) -> RoleGraph {
                     .get_mut(name)
                     .unwrap_or_else(|| panic!("AlterSchemaOwner on absent schema {name:?}"));
                 state.owner = Some(owner.clone());
+                // PostgreSQL's ALTER SCHEMA ... OWNER TO merges any explicit
+                // ACL entry the incoming owner held into the (full) owner
+                // entry, and inspection folds owner privileges into
+                // SchemaState rather than reporting an explicit grant row —
+                // mirror both (see issue #140).
+                state.owner_privileges =
+                    [Privilege::Create, Privilege::Usage].into_iter().collect();
+                g.grants.remove(&GrantKey {
+                    role: owner.clone(),
+                    object_type: ObjectType::Schema,
+                    schema: None,
+                    name: Some(name.clone()),
+                });
             }
             Change::EnsureSchemaOwnerPrivileges {
                 name, privileges, ..
@@ -1223,4 +1232,87 @@ fn live_convergence_matches_desired_and_interpreter() {
             started.elapsed()
         );
     }
+}
+
+/// Targeted live regression for issue #140: a stale explicit schema grant to
+/// the role that becomes the schema's owner in the same plan. Before the fix,
+/// the plan's `REVOKE ... FROM z` landed after `ALTER SCHEMA ... OWNER TO z`
+/// had merged z's ACL entry into the owner entry, stripping the new owner's
+/// USAGE until the next reconcile. The plan must now converge in one pass and
+/// leave the owner with USAGE on its own schema.
+#[test]
+#[ignore]
+fn issue_140_owner_transfer_with_stale_owner_grant_converges_single_pass() {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_nanos();
+    let w = format!("i140_w_{nanos}");
+    let z = format!("i140_z_{nanos}");
+    let s = format!("i140_s_{nanos}");
+
+    let mut desired = RoleGraph::default();
+    desired.roles.insert(w.clone(), RoleState::default());
+    desired.roles.insert(z.clone(), RoleState::default());
+    desired.schemas.insert(
+        s.clone(),
+        SchemaState {
+            owner: Some(z.clone()),
+            owner_privileges: default_schema_owner_privileges(&z),
+        },
+    );
+
+    let config = inspect_config(&[w.clone(), z.clone()], std::slice::from_ref(&s));
+
+    let _cleanup = SeedCleanup {
+        roles: vec![w.clone(), z.clone()],
+        schemas: vec![s.clone()],
+    };
+
+    with_runtime(async {
+        let pool = PgPool::connect(&database_url())
+            .await
+            .expect("failed to connect to live test database");
+
+        // Bootstrap the exact issue-140 current state via raw SQL.
+        for statement in [
+            format!(r#"CREATE ROLE "{w}";"#),
+            format!(r#"CREATE ROLE "{z}";"#),
+            format!(r#"CREATE SCHEMA "{s}" AUTHORIZATION "{w}";"#),
+            format!(r#"GRANT USAGE ON SCHEMA "{s}" TO "{z}";"#),
+        ] {
+            execute_sql(&pool, &statement, 140, "bootstrap").await;
+        }
+
+        let inspected = inspect(&pool, &config).await.expect("inspect failed");
+        let changes = diff(&inspected, &desired);
+        assert!(
+            changes
+                .iter()
+                .any(|c| matches!(c, Change::AlterSchemaOwner { name, owner } if *name == s && *owner == z)),
+            "plan must transfer ownership, got: {changes:?}"
+        );
+        execute_changes(&pool, &changes, 140, "converge").await;
+
+        // The new owner must still hold USAGE on its own schema — the bug
+        // stripped it here.
+        let (has_usage,): (bool,) = sqlx::query_as("SELECT has_schema_privilege($1, $2, 'USAGE')")
+            .bind(&z)
+            .bind(&s)
+            .fetch_one(&pool)
+            .await
+            .expect("failed to check schema privilege");
+        assert!(
+            has_usage,
+            "issue #140 regression: new owner lost USAGE on its own schema"
+        );
+
+        // Single-pass convergence: the re-diff must be empty.
+        let re_inspected = inspect(&pool, &config).await.expect("re-inspect failed");
+        let residual = diff(&re_inspected, &desired);
+        assert!(
+            residual.is_empty(),
+            "expected single-pass convergence, residual plan: {residual:?}"
+        );
+    });
 }


### PR DESCRIPTION
Fixes #140.

## The bug

When a plan contains both `ALTER SCHEMA s OWNER TO z` and a revoke of z's pre-existing explicit grant on `s`, PostgreSQL merges z's old ACL entry into the new owner entry during the transfer — so the revoke, planned against what looked like a stale grant, strips the **new owner's** USAGE:

```sql
CREATE ROLE w; CREATE ROLE z;
CREATE SCHEMA s AUTHORIZATION w;
GRANT USAGE ON SCHEMA s TO z;
-- pgroles plan for "s owned by z, no grants":
ALTER SCHEMA "s" OWNER TO "z";
REVOKE USAGE ON SCHEMA "s" FROM "z";
-- nspacl = {z=C/z} — the owner cannot USAGE its own schema
```

The state self-healed on the *next* reconcile, but single-pass convergence was violated and the owner's schema resolution was broken in between. Found by the live property suite in #137 (its first catch); verified interactively against PG 16.13.

## The fix

`diff()` now suppresses schema revokes whose grantee is that schema's incoming owner in the same plan. The revoke's target ceases to exist as an explicit grant the moment the transfer runs (absorbed into ownership), and inspection folds owner privileges into `SchemaState`, so the plan converges in one pass. Revokes for *other* grantees on the same schema are unaffected (unit-tested).

The interaction with `EnsureSchemaOwnerPrivileges` nets out correctly by construction: the top-up grant is computed as `{CREATE,USAGE} minus old-owner privileges`, and PostgreSQL's transfer merge is a union, so the incoming owner always lands on exactly `{CREATE, USAGE}` even when the old owner's privileges were partial.

## Proof

- Both property-test interpreters' `AlterSchemaOwner` semantics now mirror the real transfer (owner entry → `{CREATE, USAGE}`; incoming owner's explicit schema grant absorbed) — keeping the model/engine/PostgreSQL three-way differential check honest.
- The live suite's generator exclusion (`strip_owner_schema_grants`) is **narrowed from either-graph to per-graph**: the per-graph half is a genuine round-trip boundary (inspection folds owner grants), while the cross-graph #140 shape is now *generated* by the seeded corpus and proven against real PostgreSQL on every CI run across PG 16/17/18.
- A targeted live regression test bootstraps the exact issue repro, converges, and asserts `has_schema_privilege(z, s, 'USAGE')` plus an empty re-diff. **Mutation-verified**: against the unfixed engine it fails with "new owner lost USAGE on its own schema"; with the fix it passes.

## Review

Adversarial interaction trace over six risk areas (mode filters incl. adopt+transfer, external-role filtering, retirement insertion, wildcard shadow indexing, report ownership attribution, generator invariants) — all clean, with structural evidence (e.g. schema-level grants have `schema: None` so they cannot collide with wildcard indexing, which requires `schema.is_some()`).

## Testing

Full workspace with `--include-ignored`: 740 passed, 0 failed; live property suite green with the exclusion narrowed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TwqLzRSJR8WHpLvvVqkCg

---
_Generated by [Claude Code](https://claude.ai/code/session_019TwqLzRSJR8WHpLvvVqkCg)_