### PR TITLE
docs: add pgroles agent skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       - name: CRD drift check
         run: scripts/check-crd-drift.sh
 
+      - uses: astral-sh/setup-uv@v9.0.0
+
       - name: Validate Agent Skills
         run: |
           test -f skills/pgroles-policy/SKILL.md
@@ -54,7 +56,7 @@ jobs:
             > /tmp/pgroles-agent-skills
           test -s /tmp/pgroles-agent-skills
           while IFS= read -r -d '' skill_file; do
-            pipx run --spec skills-ref==0.1.1 \
+            uvx --from skills-ref==0.1.1 \
               agentskills validate "$(dirname "$skill_file")"
           done < /tmp/pgroles-agent-skills
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,20 @@ jobs:
       - name: CRD drift check
         run: scripts/check-crd-drift.sh
 
+      - name: Validate Agent Skills
+        run: |
+          test -f skills/pgroles-policy/SKILL.md
+          test -f skills/pgroles-operator/SKILL.md
+          test "$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq \
+            "$(find skills -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l)"
+          find skills -mindepth 2 -maxdepth 2 -name SKILL.md -print0 \
+            > /tmp/pgroles-agent-skills
+          test -s /tmp/pgroles-agent-skills
+          while IFS= read -r -d '' skill_file; do
+            pipx run --spec skills-ref==0.1.1 \
+              agentskills validate "$(dirname "$skill_file")"
+          done < /tmp/pgroles-agent-skills
+
   # ---------------------------------------------------------------------------
   # Job 2: Unit tests
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,6 +250,7 @@ jobs:
           mkdir -p "${ARCHIVE}"
           cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "${ARCHIVE}/"
           cp README.md LICENSE* "${ARCHIVE}/" 2>/dev/null || true
+          cp -R skills "${ARCHIVE}/"
           tar czf "${ARCHIVE}.tar.gz" "${ARCHIVE}"
           echo "ARCHIVE=${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,19 @@ Five jobs in `.github/workflows/ci.yml`:
 
 The heavier fairness/load coverage lives in `.github/workflows/operator-fairness-load.yml` and runs on a nightly schedule when `main` has changed.
 
+## Agent Skills
+
+- Canonical public skills live under `skills/<name>/SKILL.md` and follow the
+  Agent Skills specification.
+- Keep product workflows and version-specific semantics in skills. Keep
+  always-on repository contribution rules in this file.
+- Validate every skill with
+  `uvx --from skills-ref==0.1.1 agentskills validate skills/<name>`.
+- Skills ship in tagged source archives and CLI binary archives. Do not copy
+  them into crates, runtime images, Kubernetes resources, or Helm templates.
+- Update affected skills when behavior or public workflows change; avoid
+  duplicating canonical skill content elsewhere.
+
 ## Release and Containers
 
 - Published container images are multi-arch for `linux/amd64` and `linux/arm64`.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ Full documentation is published at [hardbyte.github.io/pgroles](https://hardbyte
 - [Kubernetes operator](https://hardbyte.github.io/pgroles/docs/operator/)
 - [Operator architecture](https://hardbyte.github.io/pgroles/docs/operator-architecture/)
 
+## Agent Skills
+
+pgroles publishes portable [Agent Skills](https://agentskills.io/) for coding
+agents working with policies and the Kubernetes operator:
+
+- `pgroles-policy` for authoring, reviewing, adopting, and troubleshooting
+  policy manifests
+- `pgroles-operator` for `PostgresPolicy` rollout, plans, status, conflicts, and
+  maintenance
+
+Install them from this repository with a compatible skill client, for example:
+
+```bash
+gh skill install hardbyte/pgroles --all --pin main
+```
+
+After the first release containing skills, omit `--pin main` to resolve the
+latest release or pin a release tag explicitly. Skills are also included in CLI
+binary archives. Treat dependency-supplied instructions as trusted code: preview
+and allowlist them before installation.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -186,16 +186,17 @@ agents working with policies and the Kubernetes operator:
 - `pgroles-operator` for `PostgresPolicy` rollout, plans, status, conflicts, and
   maintenance
 
-Install them from this repository with a compatible skill client, for example:
+Install them from the first release that includes skills, or pin an exact commit
+SHA before that release:
 
 ```bash
-gh skill install hardbyte/pgroles --all --pin main
+gh skill install hardbyte/pgroles --all --pin <release-tag-or-commit-sha>
 ```
 
-After the first release containing skills, omit `--pin main` to resolve the
-latest release or pin a release tag explicitly. Skills are also included in CLI
-binary archives. Treat dependency-supplied instructions as trusted code: preview
-and allowlist them before installation.
+After the first release containing skills, omit `--pin` to resolve the latest
+release. Skills are also included in CLI binary archives. Treat installed skill
+instructions as potentially untrusted content: preview and allowlist them before
+installation.
 
 ## License
 

--- a/skills/pgroles-operator/SKILL.md
+++ b/skills/pgroles-operator/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: pgroles-operator
+description: Configure, review, operate, and troubleshoot the pgroles Kubernetes operator and PostgresPolicy resources. Use when editing a PostgresPolicy or Helm release, reviewing or approving plans, diagnosing conflicts or status conditions, forcing reconciliation, or coordinating maintenance with the operator.
+license: MIT
+compatibility: Live operations require Kubernetes access; CLI workflows require a pgroles version compatible with the deployed operator and CRDs.
+---
+
+# Pgroles Operator
+
+Use the deployed chart and CRD as the schema authority. Do not copy fields from
+newer upstream documentation into an older cluster.
+
+Load the `pgroles-policy` skill as well when changing roles, profiles, grants,
+memberships, ownership, default privileges, or retirements.
+
+Install or upgrade with the Helm instructions for the target release. Always
+inspect chart values and rendered resources before applying an upgrade:
+
+```bash
+helm show values oci://ghcr.io/hardbyte/charts/pgroles-operator \
+  --version <version>
+helm template pgroles-operator \
+  oci://ghcr.io/hardbyte/charts/pgroles-operator \
+  --version <version> --namespace pgroles-system --include-crds \
+  --values values.yaml > pgroles-operator-rendered.yaml
+```
+
+Helm does not upgrade objects shipped in a chart's `crds/` directory. Apply the
+version-matched CRDs explicitly before upgrading the controller:
+
+```bash
+set -euo pipefail
+helm show crds oci://ghcr.io/hardbyte/charts/pgroles-operator \
+  --version <version> > pgroles-operator-crds.yaml
+test -s pgroles-operator-crds.yaml
+kubectl apply --server-side -f pgroles-operator-crds.yaml
+helm upgrade --install pgroles-operator \
+  oci://ghcr.io/hardbyte/charts/pgroles-operator \
+  --version <version> --namespace pgroles-system --create-namespace \
+  --values values.yaml
+```
+
+Review the rendered CRD and workload diff before applying it. The API is
+`v1alpha1` and has no conversion webhook; check release notes for compatibility
+and rollback implications.
+
+## Execution And Reconciliation
+
+Two independent controls determine behavior:
+
+- `spec.mode: plan` computes and publishes a filtered plan without executing
+  PostgreSQL SQL.
+- `spec.mode: apply` may execute the filtered plan, subject to `spec.approval`.
+- `spec.reconciliation_mode` selects `additive`, `adopt`, or `authoritative`
+  filtering. See the policy skill before changing it.
+
+Treat `plan` to `apply`, approval changes, and stronger reconciliation modes as
+operational database migrations. Review generated SQL and replacement access
+before enabling execution.
+
+## Policy Scope And Conflicts
+
+Prefer one policy per database. Multiple policies may share a database only when
+their ownership claims are disjoint.
+
+Claims conservatively include declared and profile-expanded roles, grant and
+default-privilege grantees, both sides of memberships, and declared or referenced
+schemas. Sharing a referenced schema conflicts even if policies intend to manage
+different objects inside it.
+
+Conflict detection compares policies with the same operator database identity.
+That identity comes from namespace-qualified connection references or structured
+connection inputs, not from resolving every connection to a PostgreSQL endpoint.
+Use the same canonical connection reference for policies intended to share a
+database. Different Secrets can point to the same database without being
+recognized as the same identity.
+
+Plan-only policies retain claims. A suspended policy returns before checking
+peers, but an active peer can still detect overlap with its claims.
+
+## Rollout Workflow
+
+1. Verify the target chart version, CRDs, connection Secret, executor privileges,
+   and provider/IaC prerequisites.
+2. Render the actual Kubernetes overlay or Helm release.
+3. Start in `mode: plan` for brownfield or high-impact changes.
+4. Inspect the `PostgresPolicyPlan`, SQL, change summary, revocations, role
+   retirements, and transitive memberships.
+5. Move to `mode: apply` with the smallest safe reconciliation mode and approval
+   policy.
+6. Wait for apply-mode convergence, then test positive and negative operations
+   as the actual service identities.
+7. Remove temporary grants or old credentials only after the replacement access
+   and workload rollout are verified.
+
+Argo CD `Synced`, resource creation, or a `Ready=True` condition alone does not
+prove database convergence.
+
+## Status Interpretation
+
+`Ready=True` records a completed successful controller outcome. It may remain
+while another reconcile starts or contends for a lock, and it can mean
+`Planned` rather than applied.
+
+`Drifted=True` means the latest successfully computed, reconciliation-mode-
+filtered plan has pending changes. The condition may be absent during
+reconciliation, suspension, conflict, or failure; absence is not in-sync proof.
+
+For convergence within the selected reconciliation mode, require all of:
+
+- `spec.mode: apply`
+- `status.observed_generation == metadata.generation`
+- `Ready=True` with reason `Reconciled`
+- `Drifted=False`
+- no current plan in `Pending`, `Approved`, or `Applying`
+
+An `Applied` plan may remain referenced. Only authoritative mode represents full
+convergence within pgroles' managed inspection scope; additive mode can leave
+existing attributes and undeclared access untouched.
+
+## Force Reconciliation
+
+Prefer the version-matched CLI and specify the namespace:
+
+```bash
+pgroles reconcile postgrespolicy/<name> -n <namespace> --wait --timeout 2m
+kubectl -n <namespace> get postgrespolicy <name> -o yaml
+```
+
+`--wait` acknowledges that the request reached a successful planning or
+reconciliation outcome through `status.lastHandledReconcileAt`. It does not
+guarantee SQL was applied. Requests blocked by suspension, conflict, contention,
+or failure may remain unacknowledged.
+
+## Plans And Approval
+
+Before approving a plan:
+
+- confirm it targets the current policy generation and database state
+- inspect SQL and the change summary, not only the total count
+- verify external identities and referenced schemas exist
+- inspect revocations, membership removals, ownership changes, and retirements
+- reject or allow supersession rather than approving a stale plan
+
+Approve or reject the current plan explicitly:
+
+```bash
+kubectl -n <namespace> annotate pgplan <plan-name> \
+  pgroles.io/approved=true --overwrite
+kubectl -n <namespace> annotate pgplan <plan-name> \
+  pgroles.io/rejected=true --overwrite
+```
+
+After approval, wait for `Applied` and then verify the parent policy's convergence
+conditions. A plan object supports review and recent history, but is not
+independent proof of current database state and may be removed by terminal-plan
+retention.
+
+## Suspension And Maintenance
+
+`spec.suspend: true` prevents new work after a reconcile observes the suspended
+spec. It does not cancel SQL already executing. The in-flight apply transaction
+continues to commit or roll back.
+
+`Paused=True` shows that a reconcile observed suspension. It is not a general
+cross-replica drain barrier because suspension is handled before pgroles acquires
+the per-database advisory lock. For destructive database maintenance, coordinate
+an explicit operator writer drain appropriate to the deployment, such as safely
+scaling the operator to zero and waiting for pod termination. Account for the
+cluster-wide impact before doing so.
+
+Resume reconciliation before removing recovery or maintenance-blocking state,
+then force reconciliation and verify recovery.
+
+## Troubleshooting Order
+
+1. Confirm Kubernetes context, namespace, chart version, CRD, and policy
+   generation.
+2. Read all conditions, `last_error`, current plan, and recent Events.
+3. Inspect operator logs without exposing Secrets or database URLs.
+4. Confirm the connection identity and referenced Secrets exist.
+5. Check policy ownership conflicts and overlapping role/schema claims.
+6. Verify the executor's PostgreSQL ownership, grant options, role administration,
+   and managed-provider limitations.
+7. Recompute the plan only after resolving prerequisites; do not repeatedly
+   approve unchanged failing SQL.
+
+Policy deletion means stop managing. The operator intentionally leaves roles and
+grants in the database.

--- a/skills/pgroles-policy/SKILL.md
+++ b/skills/pgroles-policy/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: pgroles-policy
+description: Author, review, migrate, and troubleshoot pgroles YAML policies for PostgreSQL roles, profiles, grants, memberships, schema ownership, default privileges, external identities, and role retirement. Use when changing a pgroles manifest, adopting an existing database, or investigating an unexpected SQL plan.
+license: MIT
+compatibility: Requires a pgroles CLI compatible with the manifest version; database diff and apply workflows require PostgreSQL access.
+---
+
+# Pgroles Policy
+
+Use the pgroles version installed by the project. Read its matching documentation
+or checked-out source before using fields introduced in newer releases.
+
+## Choose The Source Of Truth
+
+Use pgroles for steady-state roles, memberships, grants, schema ownership, and
+default privileges. Keep provider identities and cloud login plumbing in the
+cloud/IaC system. Use migrations for ordered object changes that desired-state
+reconciliation cannot infer, such as reassigning existing object ownership or
+creating `SECURITY DEFINER` functions.
+
+Do not manage the same role attribute, membership, or grant in two systems after
+the migration window ends.
+
+## Authoring Workflow
+
+1. Identify the database, PostgreSQL version, executor identity, and installed
+   pgroles version.
+2. Inspect nearby manifests and the actual database. For brownfield adoption,
+   start with `pgroles generate`; use `--suggest-profiles` only after reviewing
+   that the refactoring preserves the exact expanded state.
+3. Define reusable profiles by access shape, then bind them to schemas. Profiles
+   create concrete roles using the schema's `role_pattern`, which defaults to
+   `{schema}-{profile}`.
+4. Declare managed roles and memberships explicitly. Use `external: true` for a
+   role whose lifecycle belongs to a provider or another system.
+5. Model current and future objects separately: ordinary grants cover existing
+   objects; default privileges cover only future objects created by the named
+   owner.
+6. Validate, inspect the expanded graph, and review the SQL diff before apply.
+
+Useful commands:
+
+```bash
+pgroles validate -f pgroles.yaml
+pgroles graph desired -f pgroles.yaml
+pgroles diff -f pgroles.yaml --database-url "$DATABASE_URL"
+```
+
+Never print database URLs, passwords, or rendered Secrets in logs.
+
+## Reconciliation Modes
+
+The CLI `--mode` and operator `spec.reconciliation_mode` select which computed
+changes remain in the plan:
+
+- `additive`: creates and additions only. It filters revokes, membership
+  removals, existing schema-owner transfers, existing-role rewrites, and role
+  retirement. It also omits role comments. Configured password updates are a
+  deliberate exception.
+- `adopt`: authoritative convergence except role drops and their retirement
+  steps. Revokes and membership removals still occur.
+- `authoritative`: retains every change computed within pgroles' managed
+  inspection scope.
+
+Authoritative mode is scoped. It does not inventory and delete every role or
+schema in PostgreSQL. Inspection follows managed roles, referenced schemas,
+managed grantees, and explicitly retired roles.
+
+For a brownfield database, use this progression:
+
+1. generate and review the current state
+2. diff in `additive` mode
+3. apply additive changes and test effective privileges
+4. review an `adopt` or `authoritative` diff, especially every revocation
+5. switch modes only when the manifest covers the intended managed state
+
+An additive no-op does not prove that existing role attributes or undeclared
+access match the manifest.
+
+## External Roles
+
+`external: true` is a lifecycle filter, not provisioning or validation. pgroles
+will not create, alter, drop, password-manage, or manage memberships granted
+from that role. It may still grant privileges to it, use it as a schema/default
+privilege owner, or add it as a member of a managed group.
+
+The external role must already exist whenever retained SQL references it. Ensure
+the provider or IaC rollout completes before pgroles apply. Treat PostgreSQL
+predefined roles as external; do not attempt to manage system-role lifecycle.
+
+## Ownership And ACLs
+
+Schema ownership is modeled specially: pgroles converges the declared owner and
+ensures that owner has effective `CREATE` and `USAGE` on the schema.
+
+Table, sequence, function, and type ownership is not modeled. pgroles reconciles
+visible direct ACL entries for managed grantees. If an object owner's explicit
+ACL becomes visible, authoritative reconciliation can revoke privileges not
+declared for that managed role. Declare the ordinary object privileges an owner
+must retain when applications use that role for DML.
+
+Ownership rights such as altering or dropping an object, and the owner's
+implicit grant options, remain PostgreSQL behavior outside the object ACL model.
+
+Default privileges are per creating role, schema, and object type. A default
+owner declaration does not retroactively grant existing objects and does not
+cover objects created by another role.
+
+## Privilege Review
+
+Review effective and transitive privileges, not role names alone.
+
+- Sequence `USAGE` permits `nextval`; grant `SELECT` alone when advancement is
+  not required.
+- `REFERENCES` is needed by the role that creates a foreign key, not by runtime
+  writers solely for referential-integrity enforcement.
+- Treat `TRIGGER`, `UPDATE`, `DELETE`, `TRUNCATE`, routine `EXECUTE`, and
+  schema-wide wildcards as security-sensitive.
+- Owner, definer, and other group roles may carry much broader inherited access
+  than the new membership suggests.
+- PUBLIC and column-level grants are outside desired-state reconciliation. Read
+  inspection warnings and review them separately.
+
+## Safe Removal
+
+Removing a role from `roles:` is not sufficient evidence that dropping it is
+safe. Use an explicit retirement so pgroles can inspect dependencies and express
+the intended cleanup. Review active-session termination, ownership reassignment,
+`DROP OWNED`, and the final role drop before applying authoritative mode.
+
+Deleting a Kubernetes `PostgresPolicy` stops management; it does not undo the
+database state.
+
+## Validation
+
+Before completing a change:
+
+1. run `pgroles validate`
+2. render bundles before reviewing their effective policy
+3. inspect `pgroles graph` and the complete SQL diff
+4. confirm external roles and referenced undeclared schemas already exist
+5. verify the executor has ownership, grant options, and role administration
+6. apply first in a non-production environment when possible
+7. run positive and negative SQL checks as the actual login roles
+8. run a second diff and require no changes within the selected mode
+
+Read the matching-version documentation for manifest syntax, staged adoption,
+executor privileges, managed-provider limitations, and tooling details.


### PR DESCRIPTION
## Summary

- add portable Agent Skills for policy authoring and Kubernetes operator workflows
- validate every published skill against the Agent Skills specification in CI
- include canonical skills in CLI release archives and document installation
- document version-aware policy semantics, CRD upgrades, plans, status, conflicts, and maintenance safety

## Validation

- `uvx --from skills-ref==0.1.1 agentskills validate skills/pgroles-policy`
- `uvx --from skills-ref==0.1.1 agentskills validate skills/pgroles-operator`
- `gh skill publish --dry-run .`
- release archive smoke test confirmed both skill directories are packaged
- `git diff --check`

`cargo fmt --all --check` and the CRD drift script are blocked locally because the configured `~/.local/bin/sccache` is an incompatible executable on this machine. This PR changes no Rust or CRD files; CI will run the repository checks without that local wrapper issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable Agent Skills for authoring pgroles policies and operating the Kubernetes operator.
  * Included Agent Skills in packaged releases.
  * Added installation guidance for the published skills.

* **Documentation**
  * Documented policy workflows, reconciliation modes, validation, troubleshooting, and safe changes.
  * Added operator guidance for deployment, reconciliation, status interpretation, and maintenance.

* **Tests**
  * Added CI validation to verify required Agent Skills and their documentation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->