### PR TITLE
fix: keep label values valid after truncation

### DIFF
--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1114,15 +1114,21 @@ fn sanitize_label_value(value: &str) -> String {
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
                 c
+    let sanitized: String = value
+        .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
             } else {
                 '_'
             }
         })
         .take(63)
         .collect();
-    // Truncation may land on a separator; trim so the value starts/ends alphanumeric.
+    // Truncation may land on a separator; trim so the value ends alphanumeric.
     sanitized
-        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+        .trim_end_matches(|c: char| !c.is_ascii_alphanumeric())
         .to_string()
 }
 

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1106,9 +1106,8 @@ fn format_timestamp_compact() -> String {
     format!("{year:04}{month:02}{day:02}-{hours:02}{minutes:02}{seconds:02}")
 }
 
-/// Sanitize a string for use as a Kubernetes label value.
-///
-/// Label values must be <= 63 chars and match `[a-z0-9A-Z._-]*`.
+/// Sanitize a string for use as a Kubernetes label value: <= 63 chars,
+/// alphanumerics/`.`/`-`/`_` only, starting and ending with an alphanumeric.
 fn sanitize_label_value(value: &str) -> String {
     let sanitized: String = value
         .chars()
@@ -1121,7 +1120,10 @@ fn sanitize_label_value(value: &str) -> String {
         })
         .take(63)
         .collect();
+    // Truncation may land on a separator; trim so the value starts/ends alphanumeric.
     sanitized
+        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+        .to_string()
 }
 
 /// Current time as Unix epoch seconds (for dedup window checks).
@@ -1700,6 +1702,36 @@ mod tests {
         let long_value = "a".repeat(100);
         let sanitized = sanitize_label_value(&long_value);
         assert!(sanitized.len() <= 63);
+    }
+
+    #[test]
+    fn sanitize_label_value_is_always_a_valid_label() {
+        // (input, expected)
+        let cases: [(String, String); 5] = [
+            // already valid
+            ("orders-service".into(), "orders-service".into()),
+            // leading/trailing separators get trimmed
+            (
+                "_params_literal_appdb_".into(),
+                "params_literal_appdb".into(),
+            ),
+            // only separators -> empty (empty is a valid label)
+            ("___".into(), "".into()),
+            // exactly 63 valid chars -> no change
+            ("a".repeat(63), "a".repeat(63)),
+            // 64 chars and char 63 is a separator -> cut to 63 ends with '_' -> trimmed to 62
+            (format!("{}_x", "a".repeat(62)), "a".repeat(62)),
+        ];
+
+        for (input, expected) in &cases {
+            let got = sanitize_label_value(input);
+            assert_eq!(&got, expected, "sanitize({input:?})");
+            assert!(got.len() <= 63);
+            if !got.is_empty() {
+                assert!(got.chars().next().unwrap().is_ascii_alphanumeric());
+                assert!(got.chars().last().unwrap().is_ascii_alphanumeric());
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
### What
`sanitize_label_value` maps invalid characters to `_` and caps the result at 63 characters, but a cut that lands on a `_`, `.` or `-` leaves a value K8s rejects with err: a label value must start and end with an alphanumeric.

This happens when the sanitized string is longer than 63 chars and character 63 is a separator. The plan ConfigMap is then rejected and the policy stops reconciling:

`metadata.labels: Invalid value:
"foo_params_literal_db.internal.example.com_literal_appd_":
a valid label must be an empty string or consist of alphanumeric characters,
'-', '_' or '.', and must start and end with an alphanumeric character
(regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`

### Fix
Trim leading and trailing non-alphanumerics after truncation. `sanitize_label_value` is the single builder for every label value - used both when writing labels and in the selectors that read them back - so writes and lookups stay consistent, and only already-invalid values change. 

### Testing
- Adds a table test: unchanged, trimmed, empty, exactly-63 boundary, and truncated (char 63 a separator) cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label value sanitization by removing leading and trailing separators.
  * Ensured labels remain valid when inputs contain only separators or when truncation ends with a separator.
* **Tests**
  * Added coverage for valid labels, separator handling, empty results, length limits, and truncation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->