### PR TITLE
refactor: single source of truth for Kubernetes identifier rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,11 @@ cargo test -p pgroles-core --lib diff::tests::diff_creates_new_roles -- --exact
 # CRD drift check (CI enforces both committed CRD copies match crdgen output)
 scripts/check-crd-drift.sh
 
-# Regenerate CRD after modifying crd.rs
-cargo run --bin crdgen > k8s/crd.yaml
-cp k8s/crd.yaml charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml
+# Regenerate CRDs after modifying crd.rs (writes both CRDs; the four committed
+# copies must match, which is what check-crd-drift.sh compares)
+cargo run --bin crdgen -- --output-dir charts/pgroles-operator/crds/
+cp charts/pgroles-operator/crds/postgrespolicies.pgroles.io.yaml k8s/crd.yaml
+cp charts/pgroles-operator/crds/postgrespolicyplans.pgroles.io.yaml k8s/postgrespolicyplan-crd.yaml
 ```
 
 ### Local PostgreSQL for integration tests
@@ -60,7 +62,7 @@ diff(current, desired) → Vec<Change> → sql::render_all_with_context() → SQ
 - **pgroles-core** — Pure library, no IO. Manifest parsing, profile expansion, diff engine, SQL rendering, manifest export. All collections use `BTreeMap`/`BTreeSet` for deterministic output.
 - **pgroles-inspect** — Async database introspection via `sqlx`/`pg_catalog`. Version detection, cloud provider detection (RDS, Cloud SQL, AlloyDB, Azure), drop-role safety preflight.
 - **pgroles-cli** — Binary crate. Thin orchestration over core + inspect. Subcommands: `validate`, `diff`/`plan`, `apply`, `inspect`, `generate`.
-- **pgroles-operator** — Kubernetes operator. Reconciles `PostgresPolicy` CRDs (`pgroles.io/v1alpha1`). Has a `crdgen` binary for generating `k8s/crd.yaml`.
+- **pgroles-operator** — Kubernetes operator. Reconciles `PostgresPolicy` CRDs (`pgroles.io/v1alpha1`). Has a `crdgen` binary for generating the CRD YAML.
   - Kubernetes identifiers: every name and label value derived from user input goes through `k8s_names`. Do not hand-roll truncation or character filtering elsewhere — a cut that lands on a separator yields a value the API server rejects, which surfaces as a policy that silently stops reconciling. Invariants are enforced by property tests in `tests/identifier_properties.rs`.
   - Health endpoints: `/livez`, `/readyz`
   - Reconciliation modes: `apply`, `plan`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ diff(current, desired) → Vec<Change> → sql::render_all_with_context() → SQ
 - **pgroles-inspect** — Async database introspection via `sqlx`/`pg_catalog`. Version detection, cloud provider detection (RDS, Cloud SQL, AlloyDB, Azure), drop-role safety preflight.
 - **pgroles-cli** — Binary crate. Thin orchestration over core + inspect. Subcommands: `validate`, `diff`/`plan`, `apply`, `inspect`, `generate`.
 - **pgroles-operator** — Kubernetes operator. Reconciles `PostgresPolicy` CRDs (`pgroles.io/v1alpha1`). Has a `crdgen` binary for generating `k8s/crd.yaml`.
+  - Kubernetes identifiers: every name and label value derived from user input goes through `k8s_names`. Do not hand-roll truncation or character filtering elsewhere — a cut that lands on a separator yields a value the API server rejects, which surfaces as a policy that silently stops reconciling. Invariants are enforced by property tests in `tests/identifier_properties.rs`.
   - Health endpoints: `/livez`, `/readyz`
   - Reconciliation modes: `apply`, `plan`
   - Metrics/telemetry: prefer OTLP export via OpenTelemetry Collector; do not add a built-in Prometheus scrape endpoint by default unless the change explicitly requires it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2055,7 @@ dependencies = [
  "percent-encoding",
  "pgroles-core",
  "pgroles-inspect",
+ "proptest",
  "rand 0.10.1",
  "reqwest",
  "schemars",
@@ -2202,6 +2218,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2258,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2375,6 +2416,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2598,6 +2648,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3488,6 +3550,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/pgroles-operator/Cargo.toml
+++ b/crates/pgroles-operator/Cargo.toml
@@ -50,3 +50,6 @@ path = "src/main.rs"
 [[bin]]
 name = "crdgen"
 path = "src/bin/crdgen.rs"
+
+[dev-dependencies]
+proptest = "1.11.0"

--- a/crates/pgroles-operator/src/crd.rs
+++ b/crates/pgroles-operator/src/crd.rs
@@ -772,24 +772,12 @@ pub(crate) fn is_valid_set_role_identifier(s: &str) -> bool {
     bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'$' || b == b'-')
 }
 
-/// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules:
-/// lowercase alpha start, alphanumeric end, body allows lowercase alpha,
-/// digits, `-`, and `.`.
+/// Validate a Kubernetes Secret name per RFC 1123 DNS subdomain rules.
+///
+/// Delegates to [`crate::k8s_names::is_valid_resource_name`] so Secret names
+/// are held to the same rules as every other resource name the operator builds.
 fn is_valid_secret_name(name: &str) -> bool {
-    if name.is_empty() || name.len() > crate::password::MAX_SECRET_NAME_LENGTH {
-        return false;
-    }
-    let bytes = name.as_bytes();
-    // RFC 1123: must start with a lowercase letter.
-    if !bytes[0].is_ascii_lowercase() {
-        return false;
-    }
-    if !bytes[bytes.len() - 1].is_ascii_lowercase() && !bytes[bytes.len() - 1].is_ascii_digit() {
-        return false;
-    }
-    bytes
-        .iter()
-        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || *b == b'-' || *b == b'.')
+    crate::k8s_names::is_valid_resource_name(name)
 }
 
 fn is_valid_secret_key(key: &str) -> bool {

--- a/crates/pgroles-operator/src/k8s_names.rs
+++ b/crates/pgroles-operator/src/k8s_names.rs
@@ -1,0 +1,297 @@
+//! Construction and validation of Kubernetes identifiers.
+//!
+//! The API server rejects objects whose names or label values break the rules
+//! in the [object names reference][names]. Client-side builders that truncate a
+//! long input are the usual source of invalid values: the cut can land on a
+//! separator and leave a value that no longer starts and ends with an
+//! alphanumeric, and the resulting rejection surfaces as a policy that stops
+//! reconciling rather than as an obvious bug.
+//!
+//! Every identifier the operator derives from user input goes through this
+//! module so those rules live in exactly one place. Two shapes matter:
+//!
+//! - **Label values** ([`LabelValue`]) — at most 63 characters of
+//!   alphanumerics, `.`, `-`, and `_`, starting and ending alphanumeric. The
+//!   empty string is also valid.
+//! - **Resource names** ([`ResourceName`]) — RFC 1123 DNS subdomains: at most
+//!   253 characters of dot-separated labels, each label lowercase
+//!   alphanumerics and `-`, starting and ending alphanumeric.
+//!
+//! [names]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+
+use std::fmt;
+
+/// Maximum length of a Kubernetes label value.
+pub const MAX_LABEL_VALUE_LENGTH: usize = 63;
+
+/// Maximum length of a Kubernetes resource name (RFC 1123 DNS subdomain).
+pub const MAX_RESOURCE_NAME_LENGTH: usize = 253;
+
+/// An identifier that does not satisfy the Kubernetes rules for its position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidIdentifier {
+    /// What kind of identifier was expected (e.g. `"label value"`).
+    pub kind: &'static str,
+    /// The offending value.
+    pub value: String,
+}
+
+impl fmt::Display for InvalidIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid Kubernetes {}: {:?}", self.kind, self.value)
+    }
+}
+
+impl std::error::Error for InvalidIdentifier {}
+
+/// Is `value` a valid Kubernetes label value?
+///
+/// Label values are at most 63 characters of alphanumerics, `.`, `-`, and `_`,
+/// and must start and end with an alphanumeric. The empty string is valid.
+pub fn is_valid_label_value(value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
+    if value.len() > MAX_LABEL_VALUE_LENGTH {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    if !bytes[0].is_ascii_alphanumeric() || !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'))
+}
+
+/// Is `value` a valid RFC 1123 DNS label (one dot-free segment of a name)?
+fn is_dns1123_label(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    let bytes = value.as_bytes();
+    let is_lower_alnum = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+    if !is_lower_alnum(bytes[0]) || !is_lower_alnum(bytes[bytes.len() - 1]) {
+        return false;
+    }
+    bytes.iter().all(|b| is_lower_alnum(*b) || *b == b'-')
+}
+
+/// Is `value` a valid Kubernetes resource name (RFC 1123 DNS subdomain)?
+///
+/// Stricter than a first/last character check: every dot-separated label must
+/// itself be non-empty and start and end with a lowercase alphanumeric, so
+/// names such as `db..creds` and `db-.creds` are correctly rejected.
+pub fn is_valid_resource_name(value: &str) -> bool {
+    if value.is_empty() || value.len() > MAX_RESOURCE_NAME_LENGTH {
+        return false;
+    }
+    value.split('.').all(is_dns1123_label)
+}
+
+/// Truncate a resource-name prefix to at most `max_bytes`, then trim any `.`
+/// or `-` the cut exposed.
+///
+/// Truncation respects UTF-8 boundaries so the result is always a valid `str`.
+/// Trailing separators must go because callers append their own suffix: a
+/// prefix ending in `.` would start a new DNS label with the suffix's leading
+/// `-`, which the API server rejects. Only `.` and `-` are trimmed, so a
+/// prefix that starts with an alphanumeric can never be emptied.
+pub fn truncate_name_prefix(prefix: &str, max_bytes: usize) -> &str {
+    let cut = if prefix.len() <= max_bytes {
+        prefix.len()
+    } else {
+        // Largest char boundary at or below max_bytes.
+        (0..=max_bytes)
+            .rev()
+            .find(|idx| prefix.is_char_boundary(*idx))
+            .unwrap_or(0)
+    };
+    prefix[..cut].trim_end_matches(['.', '-'])
+}
+
+/// A validated Kubernetes label value.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LabelValue(String);
+
+impl LabelValue {
+    /// Derive a valid label value from arbitrary input.
+    ///
+    /// Characters outside the permitted set become `_`, leading separators are
+    /// dropped before the 63-character cut so they do not consume budget that
+    /// is then discarded, and any separator the cut exposes is trimmed.
+    ///
+    /// This is lossy and therefore **not injective**: distinct inputs can
+    /// produce the same label value. Do not use the result as the sole identity
+    /// for anything that drives deletion — see [`crate::plan`] for the
+    /// hash-based approach used where uniqueness matters.
+    pub fn sanitize(value: &str) -> Self {
+        let sanitized: String = value
+            .trim_start_matches(|c: char| !c.is_ascii_alphanumeric())
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .take(MAX_LABEL_VALUE_LENGTH)
+            .collect();
+        let trimmed = sanitized.trim_end_matches(|c: char| !c.is_ascii_alphanumeric());
+        Self(trimmed.to_string())
+    }
+
+    /// Accept `value` only if it is already a valid label value.
+    pub fn try_new(value: &str) -> Result<Self, InvalidIdentifier> {
+        if is_valid_label_value(value) {
+            Ok(Self(value.to_string()))
+        } else {
+            Err(InvalidIdentifier {
+                kind: "label value",
+                value: value.to_string(),
+            })
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for LabelValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<LabelValue> for String {
+    fn from(value: LabelValue) -> Self {
+        value.0
+    }
+}
+
+/// A validated Kubernetes resource name.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ResourceName(String);
+
+impl ResourceName {
+    /// Accept `value` only if it is a valid resource name.
+    pub fn try_new(value: impl Into<String>) -> Result<Self, InvalidIdentifier> {
+        let value = value.into();
+        if is_valid_resource_name(&value) {
+            Ok(Self(value))
+        } else {
+            Err(InvalidIdentifier {
+                kind: "resource name",
+                value,
+            })
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for ResourceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<ResourceName> for String {
+    fn from(value: ResourceName) -> Self {
+        value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_value_sanitize_maps_and_trims() {
+        assert_eq!(
+            LabelValue::sanitize("orders-service").as_str(),
+            "orders-service"
+        );
+        assert_eq!(
+            LabelValue::sanitize("default/db-creds/DATABASE_URL").as_str(),
+            "default_db-creds_DATABASE_URL"
+        );
+        assert_eq!(
+            LabelValue::sanitize("_params_literal_appdb_").as_str(),
+            "params_literal_appdb"
+        );
+        // Only separators collapses to the empty string, which is a valid label.
+        assert_eq!(LabelValue::sanitize("___").as_str(), "");
+    }
+
+    #[test]
+    fn label_value_sanitize_trims_leading_before_truncating() {
+        // Leading separators must not consume the 63-character budget.
+        let value = LabelValue::sanitize(&format!("__{}", "a".repeat(70)));
+        assert_eq!(value.as_str(), "a".repeat(MAX_LABEL_VALUE_LENGTH));
+    }
+
+    #[test]
+    fn label_value_sanitize_trims_separator_exposed_by_truncation() {
+        let value = LabelValue::sanitize(&format!("{}_x", "a".repeat(62)));
+        assert_eq!(value.as_str(), "a".repeat(62));
+    }
+
+    #[test]
+    fn label_value_try_new_rejects_invalid() {
+        assert!(LabelValue::try_new("orders").is_ok());
+        assert!(LabelValue::try_new("").is_ok());
+        assert!(LabelValue::try_new("_orders").is_err());
+        assert!(LabelValue::try_new("orders_").is_err());
+        assert!(LabelValue::try_new("orders/svc").is_err());
+        assert!(LabelValue::try_new(&"a".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn resource_name_rejects_malformed_labels() {
+        assert!(is_valid_resource_name("db-creds"));
+        assert!(is_valid_resource_name("9db-creds"));
+        assert!(is_valid_resource_name("team.alpha.orders"));
+
+        assert!(!is_valid_resource_name(""));
+        assert!(!is_valid_resource_name("db..creds"));
+        assert!(!is_valid_resource_name("db-.creds"));
+        assert!(!is_valid_resource_name("-db-creds"));
+        assert!(!is_valid_resource_name("db-creds-"));
+        assert!(!is_valid_resource_name("DB-creds"));
+        assert!(!is_valid_resource_name("db_creds"));
+        assert!(!is_valid_resource_name(
+            &"a".repeat(MAX_RESOURCE_NAME_LENGTH + 1)
+        ));
+    }
+
+    #[test]
+    fn truncate_name_prefix_trims_exposed_separators() {
+        assert_eq!(truncate_name_prefix("orders", 10), "orders");
+        assert_eq!(truncate_name_prefix("orders-service", 7), "orders");
+        assert_eq!(truncate_name_prefix("team.alpha", 5), "team");
+        // Interior separators are preserved.
+        assert_eq!(truncate_name_prefix("team.alpha", 10), "team.alpha");
+    }
+
+    #[test]
+    fn truncate_name_prefix_respects_utf8_boundaries() {
+        // `é` is two bytes: an odd budget must not split it.
+        let input = "é".repeat(5);
+        let truncated = truncate_name_prefix(&input, 5);
+        assert_eq!(truncated, "é".repeat(2));
+        assert!(truncated.len() <= 5);
+    }
+}

--- a/crates/pgroles-operator/src/k8s_names.rs
+++ b/crates/pgroles-operator/src/k8s_names.rs
@@ -110,6 +110,38 @@ pub fn truncate_name_prefix(prefix: &str, max_bytes: usize) -> &str {
     prefix[..cut].trim_end_matches(['.', '-'])
 }
 
+/// Derive a single RFC 1123 DNS label from arbitrary input, for use as one
+/// segment of a composed resource name.
+///
+/// Input is lowercased; every run of characters outside `[a-z0-9]` collapses to
+/// a single `-`; leading and trailing `-` are dropped. `fallback` is returned if
+/// nothing survives, so the result is always a usable segment.
+///
+/// Like [`LabelValue::sanitize`] this is lossy and **not injective** — callers
+/// composing several segments must not treat the result as an identity.
+pub fn sanitize_dns_label_segment(input: &str, fallback: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut last_was_dash = false;
+
+    for ch in input.chars() {
+        let normalized = ch.to_ascii_lowercase();
+        if normalized.is_ascii_lowercase() || normalized.is_ascii_digit() {
+            result.push(normalized);
+            last_was_dash = false;
+        } else if !last_was_dash && !result.is_empty() {
+            result.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    let trimmed = result.trim_matches('-');
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 /// A validated Kubernetes label value.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LabelValue(String);

--- a/crates/pgroles-operator/src/lib.rs
+++ b/crates/pgroles-operator/src/lib.rs
@@ -7,6 +7,7 @@ pub mod advisory;
 pub mod context;
 pub mod crd;
 pub mod events;
+pub mod k8s_names;
 pub mod observability;
 pub mod password;
 pub mod plan;

--- a/crates/pgroles-operator/src/password.rs
+++ b/crates/pgroles-operator/src/password.rs
@@ -61,43 +61,14 @@ pub fn generated_secret_key(spec: &GeneratePasswordSpec) -> String {
 }
 
 fn default_generated_secret_name(policy_name: &str, role_name: &str) -> String {
-    let policy = sanitize_secret_name_segment(policy_name, "policy");
-    let role = sanitize_secret_name_segment(role_name, "role");
+    let policy = crate::k8s_names::sanitize_dns_label_segment(policy_name, "policy");
+    let role = crate::k8s_names::sanitize_dns_label_segment(role_name, "role");
     let name = format!("{policy}-pgr-{role}");
     let truncated = crate::k8s_names::truncate_name_prefix(&name, MAX_SECRET_NAME_LENGTH);
     if truncated.is_empty() {
         "pgroles-generated-password".to_string()
     } else {
         truncated.to_string()
-    }
-}
-
-fn sanitize_secret_name_segment(input: &str, fallback: &str) -> String {
-    let mut result = String::new();
-    let mut last_was_dash = false;
-
-    for ch in input.chars() {
-        let normalized = ch.to_ascii_lowercase();
-        if normalized.is_ascii_lowercase() || normalized.is_ascii_digit() {
-            result.push(normalized);
-            last_was_dash = false;
-        } else if !last_was_dash {
-            result.push('-');
-            last_was_dash = true;
-        }
-    }
-
-    while matches!(result.as_bytes().first(), Some(b'-')) {
-        result.remove(0);
-    }
-    while matches!(result.as_bytes().last(), Some(b'-')) {
-        result.pop();
-    }
-
-    if result.is_empty() {
-        fallback.to_string()
-    } else {
-        result
     }
 }
 

--- a/crates/pgroles-operator/src/password.rs
+++ b/crates/pgroles-operator/src/password.rs
@@ -19,8 +19,9 @@ pub const MIN_PASSWORD_LENGTH: u32 = 16;
 /// Maximum allowed password length.
 pub const MAX_PASSWORD_LENGTH: u32 = 128;
 
-/// Maximum length for a Kubernetes Secret name.
-pub const MAX_SECRET_NAME_LENGTH: usize = 253;
+/// Maximum length for a Kubernetes Secret name. A Secret name is an RFC 1123
+/// DNS subdomain like any other resource name.
+pub const MAX_SECRET_NAME_LENGTH: usize = crate::k8s_names::MAX_RESOURCE_NAME_LENGTH;
 
 /// Fixed key used to store the SCRAM verifier in generated Secrets.
 pub const GENERATED_VERIFIER_KEY: &str = "verifier";
@@ -62,19 +63,12 @@ pub fn generated_secret_key(spec: &GeneratePasswordSpec) -> String {
 fn default_generated_secret_name(policy_name: &str, role_name: &str) -> String {
     let policy = sanitize_secret_name_segment(policy_name, "policy");
     let role = sanitize_secret_name_segment(role_name, "role");
-    let mut name = format!("{policy}-pgr-{role}");
-    if name.len() <= MAX_SECRET_NAME_LENGTH {
-        return name;
-    }
-
-    name.truncate(MAX_SECRET_NAME_LENGTH);
-    while matches!(name.as_bytes().last(), Some(b'-')) {
-        name.pop();
-    }
-    if name.is_empty() {
+    let name = format!("{policy}-pgr-{role}");
+    let truncated = crate::k8s_names::truncate_name_prefix(&name, MAX_SECRET_NAME_LENGTH);
+    if truncated.is_empty() {
         "pgroles-generated-password".to_string()
     } else {
-        name
+        truncated.to_string()
     }
 }
 

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -14,6 +14,7 @@ use k8s_openapi::ByteString;
 use k8s_openapi::api::core::v1::ConfigMap;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
+use kube::core::labels::{Expression, Selector};
 use kube::{Client, Resource, ResourceExt};
 use sha2::{Digest, Sha256};
 use tracing::info;
@@ -24,6 +25,7 @@ use crate::crd::{
     PolicyPlanRef, PostgresPolicy, PostgresPolicyPlan, PostgresPolicyPlanSpec,
     PostgresPolicyPlanStatus, SqlCompression, SqlRef,
 };
+use crate::k8s_names::{LabelValue, truncate_name_prefix};
 use crate::reconciler::ReconcileError;
 
 /// Result of plan creation — distinguishes genuinely new plans from
@@ -211,9 +213,9 @@ pub async fn create_or_update_plan(
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
 
     // 4. List existing plans for this policy.
-    let label_selector = format!("{LABEL_POLICY}={}", sanitize_label_value(&policy_name));
+    let selector = policy_selector(&policy_name);
     let existing_plans = plans_api
-        .list(&ListParams::default().labels(&label_selector))
+        .list(&ListParams::default().labels_from(&selector))
         .await?;
 
     // 5. Check for duplicate pending plan with same hash.
@@ -820,9 +822,9 @@ pub async fn cleanup_old_plans(
     let max_plans = max_plans.unwrap_or(DEFAULT_MAX_PLANS);
 
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
-    let label_selector = format!("{LABEL_POLICY}={}", sanitize_label_value(&policy_name));
+    let selector = policy_selector(&policy_name);
     let existing_plans = plans_api
-        .list(&ListParams::default().labels(&label_selector))
+        .list(&ListParams::default().labels_from(&selector))
         .await?;
     let now_ts = now_epoch_secs();
 
@@ -914,9 +916,9 @@ async fn cleanup_orphan_sql_configmaps(
     now_ts: i64,
 ) -> Result<(), ReconcileError> {
     let configmaps_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
-    let label_selector = format!("{LABEL_POLICY}={}", sanitize_label_value(policy_name));
+    let selector = policy_selector(policy_name);
     let configmaps = configmaps_api
-        .list(&ListParams::default().labels(&label_selector))
+        .list(&ListParams::default().labels_from(&selector))
         .await?;
     let known_plan_labels: BTreeSet<String> = existing_plans
         .iter()
@@ -1077,17 +1079,12 @@ fn generate_plan_name(policy_name: &str, sql_hash: &str) -> String {
     let suffix = &sql_hash[..12.min(sql_hash.len())];
     // Kubernetes names must be <= 253 chars and DNS-compatible.
     // Reserve 4 chars for the potential "-sql" ConfigMap suffix.
-    let max_name_len = 253 - 4; // 249
+    let max_name_len = crate::k8s_names::MAX_RESOURCE_NAME_LENGTH - 4; // 249
     let max_prefix_len = max_name_len - "-plan-".len() - timestamp.len() - "-".len() - suffix.len();
-    let prefix = if policy_name.len() > max_prefix_len {
-        policy_name
-            .char_indices()
-            .take_while(|(idx, ch)| idx + ch.len_utf8() <= max_prefix_len)
-            .map(|(_, ch)| ch)
-            .collect::<String>()
-    } else {
-        policy_name.to_string()
-    };
+    // Truncation can land on a `.` or `-`; appending `-plan-...` after a
+    // trailing `.` would start a new DNS label with `-`, which the API server
+    // rejects, so `truncate_name_prefix` trims the separators the cut exposes.
+    let prefix = truncate_name_prefix(policy_name, max_prefix_len);
     format!("{prefix}-plan-{timestamp}-{suffix}")
 }
 
@@ -1108,20 +1105,16 @@ fn format_timestamp_compact() -> String {
 
 /// Sanitize a string for use as a Kubernetes label value.
 ///
-/// Label values must be <= 63 chars and match `[a-z0-9A-Z._-]*`.
+/// See [`crate::k8s_names::LabelValue::sanitize`] for the rules. This is the
+/// single builder for every label value the operator writes, and is also used
+/// to build the selectors that read them back, so writes and lookups agree.
 fn sanitize_label_value(value: &str) -> String {
-    let sanitized: String = value
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .take(63)
-        .collect();
-    sanitized
+    LabelValue::sanitize(value).into_string()
+}
+
+/// Label selector matching every object owned by `policy_name`.
+fn policy_selector(policy_name: &str) -> Selector {
+    Expression::Equal(LABEL_POLICY.to_string(), sanitize_label_value(policy_name)).into()
 }
 
 /// Current time as Unix epoch seconds (for dedup window checks).
@@ -1258,9 +1251,9 @@ pub async fn get_current_actionable_plan(
     let policy_name = policy.name_any();
 
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
-    let label_selector = format!("{LABEL_POLICY}={}", sanitize_label_value(&policy_name));
+    let selector = policy_selector(&policy_name);
     let existing_plans = plans_api
-        .list(&ListParams::default().labels(&label_selector))
+        .list(&ListParams::default().labels_from(&selector))
         .await?;
 
     // Find the most recent actionable plan (Pending or Approved, by creation time).
@@ -1293,9 +1286,9 @@ pub async fn get_plan_by_phase(
     let policy_name = policy.name_any();
 
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
-    let label_selector = format!("{LABEL_POLICY}={}", sanitize_label_value(&policy_name));
+    let selector = policy_selector(&policy_name);
     let existing_plans = plans_api
-        .list(&ListParams::default().labels(&label_selector))
+        .list(&ListParams::default().labels_from(&selector))
         .await?;
 
     let mut matching_plans: Vec<PostgresPolicyPlan> = existing_plans

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -1566,6 +1566,59 @@ mod tests {
         assert!(name.ends_with("-abcdef012345"));
     }
 
+    /// The plan-SQL ConfigMap derives its name by appending `-sql` to the plan
+    /// name and carries three label values, all from user-controlled input.
+    /// `generate_plan_name` reserves exactly 4 bytes for that suffix, so a
+    /// boundary-length policy name is where the reservation would be wrong.
+    ///
+    /// Covered here rather than end-to-end because the plan SQL only spills to a
+    /// ConfigMap above `MAX_INLINE_SQL_BYTES`; forcing that in a cluster would
+    /// mean generating 16 KiB of SQL to re-verify string composition.
+    #[test]
+    fn plan_sql_configmap_identifiers_are_valid_at_the_name_limit() {
+        use crate::k8s_names::{is_valid_label_value, is_valid_resource_name};
+
+        let hash = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+        // A hostile database identity: NUL separators and `=` from identity_key.
+        let identity = format!(
+            "prod/params\0literal={}\0literal=appdb\05432",
+            "h".repeat(80)
+        );
+
+        for policy_name in [
+            "orders".to_string(),
+            "a.very-long-policy.name-with-dots.and-dashes.at-the-limit.xxxxx".to_string(),
+            format!("{}.{}", "a".repeat(214), "b".repeat(38)),
+            "a".repeat(253),
+        ] {
+            let plan_name = generate_plan_name(&policy_name, hash);
+            let configmap_name = format!("{plan_name}-sql");
+
+            assert!(
+                is_valid_resource_name(&configmap_name),
+                "invalid ConfigMap name for policy {policy_name:?}: {configmap_name}"
+            );
+            assert!(
+                configmap_name.len() <= crate::k8s_names::MAX_RESOURCE_NAME_LENGTH,
+                "ConfigMap name over the limit: {} bytes",
+                configmap_name.len()
+            );
+            // Round-trips back to the plan name the labels are keyed on.
+            assert_eq!(configmap_plan_name(&configmap_name), plan_name);
+
+            for label in [
+                sanitize_label_value(&policy_name),
+                sanitize_label_value(&identity),
+                plan_label_value(&plan_name),
+            ] {
+                assert!(
+                    is_valid_label_value(&label),
+                    "invalid label value {label:?} for policy {policy_name:?}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn plan_label_value_is_stable_and_label_safe_for_long_names() {
         let plan_name = "very-long-policy-name-".repeat(20);

--- a/crates/pgroles-operator/tests/identifier_properties.proptest-regressions
+++ b/crates/pgroles-operator/tests/identifier_properties.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7e4503c85ec782d8bfcbe1105d724e082da8773a9e6eb051f8cfb65dad872976 # shrinks to input = "_"
+cc d8486bcf91650a4c48df13ab67649c0f17bff20e9b7da2ace516e8360141753d # shrinks to input = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_\0a/日.aé.=-¥=-9=a.Z\u{202e}?a éé Z-", max_bytes = 171
+cc 4da697ee7ace49ddd08aa38f136d7ebf26aca7dba3a88475ab977812a1c2290f # shrinks to name = "0.0a"

--- a/crates/pgroles-operator/tests/identifier_properties.rs
+++ b/crates/pgroles-operator/tests/identifier_properties.rs
@@ -13,10 +13,12 @@
 
 use proptest::prelude::*;
 
+use pgroles_operator::crd::GeneratePasswordSpec;
 use pgroles_operator::k8s_names::{
     LabelValue, MAX_LABEL_VALUE_LENGTH, MAX_RESOURCE_NAME_LENGTH, is_valid_label_value,
     is_valid_resource_name, sanitize_dns_label_segment, truncate_name_prefix,
 };
+use pgroles_operator::password::generated_secret_name;
 
 /// The label-value rule as the API server states it:
 /// `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?` and at most 63 bytes.
@@ -184,29 +186,39 @@ proptest! {
         prop_assert!(!segment.contains('.'));
     }
 
-    /// The real composition in `default_generated_secret_name`: two sanitised
-    /// segments joined by `-pgr-` and truncated to the resource-name limit must
-    /// always be a name the API server accepts.
+    /// Every name `generated_secret_name` produces must be one the API server
+    /// accepts as a Secret name.
+    ///
+    /// This drives the real builder rather than re-composing `{policy}-pgr-{role}`
+    /// here: a reconstruction would keep passing if production changed its
+    /// separator, segment order, or length budget.
     #[test]
-    fn composed_generated_secret_names_are_valid(
+    fn generated_secret_names_are_valid_resource_names(
         policy in hostile_input(),
         role in hostile_input(),
     ) {
-        let policy_segment = sanitize_dns_label_segment(&policy, "policy");
-        let role_segment = sanitize_dns_label_segment(&role, "role");
-        let composed = format!("{policy_segment}-pgr-{role_segment}");
-        let truncated = truncate_name_prefix(&composed, MAX_RESOURCE_NAME_LENGTH);
+        // `secret_name: None` is what exercises the derived-name path; a
+        // user-supplied override is validated separately by `is_valid_secret_name`.
+        let spec = GeneratePasswordSpec {
+            length: None,
+            secret_name: None,
+            secret_key: None,
+        };
+        let name = generated_secret_name(&policy, &role, &spec);
 
-        prop_assert!(!truncated.is_empty());
+        prop_assert!(!name.is_empty());
         prop_assert!(
-            is_resource_name_per_apiserver(truncated),
-            "composed secret name {:?} is invalid",
-            truncated
+            is_resource_name_per_apiserver(&name),
+            "generated_secret_name({:?}, {:?}) produced {:?}",
+            policy,
+            role,
+            name
         );
         prop_assert_eq!(
-            is_valid_resource_name(truncated),
-            is_resource_name_per_apiserver(truncated)
+            is_valid_resource_name(&name),
+            is_resource_name_per_apiserver(&name)
         );
+        prop_assert!(name.len() <= MAX_RESOURCE_NAME_LENGTH);
     }
 
     /// The module's resource-name validator must agree with the restated rule

--- a/crates/pgroles-operator/tests/identifier_properties.rs
+++ b/crates/pgroles-operator/tests/identifier_properties.rs
@@ -1,0 +1,180 @@
+//! Property tests for every Kubernetes identifier the operator derives from
+//! user input.
+//!
+//! The invariant is the one the API server enforces: whatever goes in, what
+//! comes out is a *valid* identifier for its position. These are the rules
+//! restated independently of the implementation, so a builder that regresses
+//! fails here rather than in a cluster.
+//!
+//! Table tests pin the specific cases that broke in the past; these cover the
+//! space around them. Both label values and resource names have been broken by
+//! truncation landing on a separator, which is easy to miss by example and
+//! immediate to catch by property.
+
+use proptest::prelude::*;
+
+use pgroles_operator::k8s_names::{
+    LabelValue, MAX_LABEL_VALUE_LENGTH, MAX_RESOURCE_NAME_LENGTH, is_valid_label_value,
+    is_valid_resource_name, truncate_name_prefix,
+};
+
+/// The label-value rule as the API server states it:
+/// `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?` and at most 63 bytes.
+fn is_label_value_per_apiserver(value: &str) -> bool {
+    if value.is_empty() {
+        return true;
+    }
+    if value.len() > MAX_LABEL_VALUE_LENGTH {
+        return false;
+    }
+    let first = value.chars().next().expect("non-empty");
+    let last = value.chars().next_back().expect("non-empty");
+    first.is_ascii_alphanumeric()
+        && last.is_ascii_alphanumeric()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+}
+
+/// The RFC 1123 DNS subdomain rule, restated: dot-separated labels, each
+/// non-empty, lowercase alphanumeric or `-`, starting and ending alphanumeric.
+fn is_resource_name_per_apiserver(value: &str) -> bool {
+    if value.is_empty() || value.len() > MAX_RESOURCE_NAME_LENGTH {
+        return false;
+    }
+    value.split('.').all(|label| {
+        !label.is_empty()
+            && label
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            && label.chars().next().is_some_and(|c| c != '-')
+            && label.chars().next_back().is_some_and(|c| c != '-')
+    })
+}
+
+/// Inputs that stress the separator and boundary logic: the alphabet is biased
+/// towards the characters that actually break things, plus multi-byte UTF-8.
+fn hostile_input() -> impl Strategy<Value = String> {
+    proptest::collection::vec(
+        prop_oneof![
+            Just('a'),
+            Just('9'),
+            Just('Z'),
+            Just('_'),
+            Just('.'),
+            Just('-'),
+            Just('/'),
+            Just('='),
+            Just('\0'),
+            Just(' '),
+            Just('é'),
+            Just('日'),
+            any::<char>(),
+        ],
+        0..200usize,
+    )
+    .prop_map(|chars| chars.into_iter().collect())
+}
+
+proptest! {
+    /// `LabelValue::sanitize` must accept anything and always produce a value
+    /// the API server accepts.
+    #[test]
+    fn sanitized_label_values_are_always_valid(input in hostile_input()) {
+        let value = LabelValue::sanitize(&input);
+        let s = value.as_str();
+
+        prop_assert!(
+            is_label_value_per_apiserver(s),
+            "sanitize({input:?}) produced invalid label value {s:?}"
+        );
+        // Cross-check the module's own validator against the restated rule.
+        prop_assert_eq!(is_valid_label_value(s), is_label_value_per_apiserver(s));
+        // The byte length is what Kubernetes counts, not the character count.
+        prop_assert!(s.len() <= MAX_LABEL_VALUE_LENGTH);
+    }
+
+    /// Sanitizing is idempotent: feeding a sanitized value back through must
+    /// not change it. Selectors are built by sanitizing, so a non-idempotent
+    /// builder would make lookups disagree with writes.
+    #[test]
+    fn sanitizing_a_label_value_is_idempotent(input in hostile_input()) {
+        let once = LabelValue::sanitize(&input);
+        let twice = LabelValue::sanitize(once.as_str());
+        prop_assert_eq!(once, twice);
+    }
+
+    /// Any already-valid label value must survive sanitizing untouched.
+    #[test]
+    fn valid_label_values_are_unchanged(
+        value in "[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?"
+    ) {
+        prop_assume!(is_label_value_per_apiserver(&value));
+        let sanitized = LabelValue::sanitize(&value);
+        prop_assert_eq!(sanitized.as_str(), value.as_str());
+        prop_assert!(LabelValue::try_new(&value).is_ok());
+    }
+
+    /// `truncate_name_prefix` must respect the budget, never split a character,
+    /// and never leave a trailing separator for a caller's suffix to collide
+    /// with.
+    #[test]
+    fn truncated_name_prefixes_are_suffixable(
+        input in hostile_input(),
+        max_bytes in 0..300usize,
+    ) {
+        let prefix = truncate_name_prefix(&input, max_bytes);
+
+        prop_assert!(prefix.len() <= max_bytes);
+        prop_assert!(!prefix.ends_with('.'), "trailing dot in {prefix:?}");
+        prop_assert!(!prefix.ends_with('-'), "trailing dash in {prefix:?}");
+        // The result is a prefix of the input (no characters invented).
+        prop_assert!(input.starts_with(prefix));
+    }
+
+    /// The real composition: a legal policy name in, a legal resource name out.
+    /// This is the shape that was broken — a `.` landing on the cut made the
+    /// appended `-plan-...` start a new DNS label with `-`.
+    ///
+    /// Every cut position is checked rather than a random one. A randomly
+    /// chosen budget almost never lands on a separator, so the dangerous case
+    /// would be sampled too rarely to catch a regression.
+    #[test]
+    fn suffixed_truncated_names_are_valid_resource_names(
+        name in "[a-z0-9]([a-z0-9.-]{0,60}[a-z0-9])?",
+    ) {
+        prop_assume!(is_resource_name_per_apiserver(&name));
+
+        for max_prefix in 1..=name.len() {
+            let prefix = truncate_name_prefix(&name, max_prefix);
+            if prefix.is_empty() {
+                continue;
+            }
+
+            let composed = format!("{prefix}-plan-20260731-212739-abcdef012345");
+            prop_assert!(
+                is_resource_name_per_apiserver(&composed),
+                "composing {:?} at budget {} gave invalid name {:?}",
+                name,
+                max_prefix,
+                composed
+            );
+            prop_assert_eq!(
+                is_valid_resource_name(&composed),
+                is_resource_name_per_apiserver(&composed)
+            );
+        }
+    }
+
+    /// The module's resource-name validator must agree with the restated rule
+    /// on arbitrary input, including inputs that are not remotely valid.
+    #[test]
+    fn resource_name_validator_matches_apiserver_rule(input in hostile_input()) {
+        prop_assert_eq!(
+            is_valid_resource_name(&input),
+            is_resource_name_per_apiserver(&input),
+            "disagreement on {:?}",
+            input
+        );
+    }
+}

--- a/crates/pgroles-operator/tests/identifier_properties.rs
+++ b/crates/pgroles-operator/tests/identifier_properties.rs
@@ -15,7 +15,7 @@ use proptest::prelude::*;
 
 use pgroles_operator::k8s_names::{
     LabelValue, MAX_LABEL_VALUE_LENGTH, MAX_RESOURCE_NAME_LENGTH, is_valid_label_value,
-    is_valid_resource_name, truncate_name_prefix,
+    is_valid_resource_name, sanitize_dns_label_segment, truncate_name_prefix,
 };
 
 /// The label-value rule as the API server states it:
@@ -164,6 +164,49 @@ proptest! {
                 is_resource_name_per_apiserver(&composed)
             );
         }
+    }
+
+    /// A sanitised segment must always be a usable DNS label on its own: the
+    /// fallback guarantees it is never empty, so a composed name can never grow
+    /// an empty label.
+    #[test]
+    fn sanitized_segments_are_valid_dns_labels(input in hostile_input()) {
+        let segment = sanitize_dns_label_segment(&input, "fallback");
+
+        prop_assert!(!segment.is_empty());
+        prop_assert!(
+            is_resource_name_per_apiserver(&segment),
+            "segment {:?} from {:?} is not a valid DNS label",
+            segment,
+            input
+        );
+        // A single label contains no dots, so it stays one label when composed.
+        prop_assert!(!segment.contains('.'));
+    }
+
+    /// The real composition in `default_generated_secret_name`: two sanitised
+    /// segments joined by `-pgr-` and truncated to the resource-name limit must
+    /// always be a name the API server accepts.
+    #[test]
+    fn composed_generated_secret_names_are_valid(
+        policy in hostile_input(),
+        role in hostile_input(),
+    ) {
+        let policy_segment = sanitize_dns_label_segment(&policy, "policy");
+        let role_segment = sanitize_dns_label_segment(&role, "role");
+        let composed = format!("{policy_segment}-pgr-{role_segment}");
+        let truncated = truncate_name_prefix(&composed, MAX_RESOURCE_NAME_LENGTH);
+
+        prop_assert!(!truncated.is_empty());
+        prop_assert!(
+            is_resource_name_per_apiserver(truncated),
+            "composed secret name {:?} is invalid",
+            truncated
+        );
+        prop_assert_eq!(
+            is_valid_resource_name(truncated),
+            is_resource_name_per_apiserver(truncated)
+        );
     }
 
     /// The module's resource-name validator must agree with the restated rule


### PR DESCRIPTION
**Stack 1 of 3** — base `main`. Follow-ups build on this branch.

Prompted by #146: the label-value truncation bug there is one instance of a wider class. Reviewing it turned up two more live bugs and five independent builders for Kubernetes identifiers, each with its own rules.

## The class

| Builder | Status before |
|---|---|
| `sanitize_label_value` (`plan.rs`) | the bug from #146 |
| `plan_label_value` (`plan.rs`) | fine (hash-based) |
| `generate_plan_name` (`plan.rs`) | **broken** |
| `default_generated_secret_name` (`password.rs`) | correct — already popped a trailing `-` |
| `is_valid_secret_name` (`crd.rs`) | **too strict** |

`password.rs` already contained the trailing-separator fix that `plan.rs` was missing. The knowledge existed in the repo and wasn't shared — which is the argument for consolidating rather than patching each site.

## Bugs fixed

**`generate_plan_name`.** Cuts the policy name at 215 chars, then appends `-plan-{ts}-{hash}` without trimming. A legal 253-char name with a `.` on the cut yields `…a.-plan-…`, whose segment after the dot starts with `-`. Not a valid DNS-1123 subdomain, so the API server rejects the plan and the policy stops reconciling. Same failure mode as #146, different function.

**`is_valid_secret_name`.** Required a lowercase *letter* first, but RFC 1123 permits a leading digit, so a legal Secret named `9db-creds` was rejected. Now validated per DNS label, which also correctly rejects `db..creds` — previously accepted here and then rejected by the API server.

## Approach

New `k8s_names` module owns both shapes — label values and RFC 1123 resource names — with the upstream rules as the documented spec. Every call site delegates to it. Label selectors move from `format!("{LABEL_POLICY}={}", …)` to `kube`'s typed `Selector`/`Expression` with `ListParams::labels_from`.

`LabelValue::sanitize` is documented as lossy and explicitly **not** injective, with a pointer to the hash-based `plan_label_value` for cases where uniqueness matters.

## Tests

Both bugs share a shape that's easy to miss by example and immediate to catch by property: an input long enough to truncate, with a separator landing exactly on the cut. `tests/identifier_properties.rs` restates the rules independently of the implementation and asserts every builder satisfies them for arbitrary input, over an alphabet biased toward what actually breaks things (NUL, `=`, `/`, separators, multi-byte UTF-8).

I verified the tests have teeth by reverting each fix — they fail with minimal counterexamples `"_"` and `"0.0a"`, both checked into the regressions file.

One coverage note worth flagging: the composition property walks **every** cut position per generated name rather than sampling a random budget. With a random budget it passed against the pre-fix code, because a random cut almost never lands on a separator. The exhaustive version fails as it should.

## Verification

`cargo fmt --check`, `clippy -D warnings`, full workspace tests, and `check-crd-drift.sh` all pass. No CRD change in this PR.

https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4


---
_Generated by [Claude Code](https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Kubernetes resource names and labels, including length limits, valid characters, separators, and UTF-8 input.
  * Updated generated Secret and plan names to remain valid when names are long or contain unsupported characters.
  * Improved label-based lookups using consistently sanitized values.

* **Documentation**
  * Clarified Kubernetes resource naming requirements and CRD regeneration guidance.

* **Tests**
  * Added extensive property-based coverage for malformed, Unicode, control-character, and oversized identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->