### PR TITLE
fix: identify a policy's plans by owner UID, not by a truncated label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,24 @@ jobs:
                 "(position='$STACK_POSITION' size='$STACK_SIZE'); refusing to gate on it"
               exit 1
             fi
-            if [ "$STACK_POSITION" -lt 1 ] || [ "$STACK_POSITION" -gt "$STACK_SIZE" ]; then
+            # Validate before comparing. `[ non-numeric -lt 1 ]` writes
+            # "integer expression expected" to stderr and evaluates *false*,
+            # which does not trip `bash -e` inside an `if` condition — so an
+            # unchecked comparison would let the step continue and skip the
+            # expensive suite, the exact failure this guard exists to prevent.
+            for value in "$STACK_POSITION" "$STACK_SIZE"; do
+              case "$value" in
+                ''|*[!0-9]*)
+                  echo "::error::stack metadata is not a non-negative integer" \
+                    "(position='$STACK_POSITION' size='$STACK_SIZE');" \
+                    "refusing to gate on it"
+                  exit 1
+                  ;;
+              esac
+            done
+            # 10# forces decimal, so a zero-padded value is never read as octal.
+            if [ "$((10#$STACK_POSITION))" -lt 1 ] \
+              || [ "$((10#$STACK_POSITION))" -gt "$((10#$STACK_SIZE))" ]; then
               echo "::error::stack position $STACK_POSITION outside the documented" \
                 "1..$STACK_SIZE range; the top-of-stack test in this workflow is no" \
                 "longer valid and must be revisited"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,26 @@ jobs:
           STACK_POSITION: ${{ github.event.pull_request.stack.position }}
           STACK_SIZE: ${{ github.event.pull_request.stack.size }}
         run: |
+          # Stacked pull requests are in public preview, so assert the metadata
+          # semantics this gate depends on: `position` is documented as 1-based
+          # with 1 at the bottom, and the top entry is `position == size`. If
+          # that ever changes, `position == size` would silently be false for the
+          # real top entry and the whole stack could merge without the expensive
+          # suite ever running. Fail loudly instead of skipping wrongly.
+          if [ -n "$STACK_POSITION" ] || [ -n "$STACK_SIZE" ]; then
+            if [ -z "$STACK_POSITION" ] || [ -z "$STACK_SIZE" ]; then
+              echo "::error::stack metadata is partially populated" \
+                "(position='$STACK_POSITION' size='$STACK_SIZE'); refusing to gate on it"
+              exit 1
+            fi
+            if [ "$STACK_POSITION" -lt 1 ] || [ "$STACK_POSITION" -gt "$STACK_SIZE" ]; then
+              echo "::error::stack position $STACK_POSITION outside the documented" \
+                "1..$STACK_SIZE range; the top-of-stack test in this workflow is no" \
+                "longer valid and must be revisited"
+              exit 1
+            fi
+          fi
+
           echo "run_heavy=$IS_TOP_OR_UNSTACKED" >> "$GITHUB_OUTPUT"
           if [ "$IS_TOP_OR_UNSTACKED" = "true" ]; then
             echo "Running the full suite (not a non-top stack entry)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,7 +875,100 @@ jobs:
           pg_query "DROP SCHEMA IF EXISTS schema_alpha CASCADE; DROP SCHEMA IF EXISTS schema_beta CASCADE;"
 
           # ================================================================
-          # Group G: Operator restart with pending plan
+          # Group G: UID isolation for colliding policy labels
+          # ================================================================
+
+          echo "--- Test: Colliding policy labels stay UID-isolated ---"
+          collision_prefix="zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+          collision_a="${collision_prefix}.one"
+          collision_b="${collision_prefix}.two"
+
+          # Both names are valid DNS subdomains, but LabelValue::sanitize
+          # truncates both to the same 63-byte server-side prefilter.
+          test "${#collision_prefix}" -eq 63
+          kubectl apply -f - <<EOF
+          apiVersion: pgroles.io/v1alpha1
+          kind: PostgresPolicy
+          metadata:
+            name: ${collision_a}
+            namespace: default
+          spec:
+            connection:
+              secretRef:
+                name: postgres-credentials
+            interval: "30s"
+            mode: apply
+            approval: manual
+            roles:
+              - name: collision_uid_user_one
+                login: true
+          ---
+          apiVersion: pgroles.io/v1alpha1
+          kind: PostgresPolicy
+          metadata:
+            name: ${collision_b}
+            namespace: default
+          spec:
+            connection:
+              secretRef:
+                name: postgres-credentials
+            interval: "30s"
+            mode: apply
+            approval: manual
+            roles:
+              - name: collision_uid_user_two
+                login: true
+          EOF
+
+          wait_for_ready_status_reason "$collision_a" True Planned
+          plan_a=$(wait_for_current_plan_ref "$collision_a")
+          wait_for_ready_status_reason "$collision_b" True Planned
+          plan_b=$(wait_for_current_plan_ref "$collision_b")
+          test "$plan_a" != "$plan_b" \
+            || { echo "::error::colliding policies selected the same plan"; exit 1; }
+
+          label_a="$(kubectl get pgplan "$plan_a" -o jsonpath='{.metadata.labels.pgroles\.io/policy}')"
+          label_b="$(kubectl get pgplan "$plan_b" -o jsonpath='{.metadata.labels.pgroles\.io/policy}')"
+          test "$label_a" = "$label_b" \
+            || { echo "::error::fixture does not produce a policy-label collision"; exit 1; }
+
+          uid_a="$(kubectl get pgr "$collision_a" -o jsonpath='{.metadata.uid}')"
+          uid_b="$(kubectl get pgr "$collision_b" -o jsonpath='{.metadata.uid}')"
+          owner_a="$(kubectl get pgplan "$plan_a" -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].uid}')"
+          owner_b="$(kubectl get pgplan "$plan_b" -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].uid}')"
+          test "$owner_a" = "$uid_a" && test "$owner_b" = "$uid_b" \
+            || { echo "::error::plans are not separated by policy owner UID"; exit 1; }
+
+          # B is the newer pending plan and shares A's label. Approving A proves
+          # A's actionable-plan lookup does not accidentally select B.
+          approve_plan "$plan_a"
+          wait_for_plan_phase "$plan_a" Applied
+          assert_role_exists collision_uid_user_one
+          test "$(kubectl get pgplan "$plan_b" -o jsonpath='{.status.phase}')" = "Pending" \
+            || { echo "::error::approving A mutated B's plan"; exit 1; }
+          assert_role_absent collision_uid_user_two
+
+          # Owner-reference cleanup must remove only A's plan despite the label
+          # collision. B must remain independently discoverable and actionable.
+          kubectl delete pgr "$collision_a" --wait=true
+          kubectl wait --for=delete "pgplan/${plan_a}" --timeout=30s || {
+            echo "::error::plan $plan_a should have been garbage collected"
+            exit 1
+          }
+          test "$(kubectl get pgr "$collision_b" -o jsonpath='{.status.current_plan_ref.name}')" = "$plan_b" \
+            || { echo "::error::deleting A disturbed B's current plan lookup"; exit 1; }
+          test "$(kubectl get pgplan "$plan_b" -o jsonpath='{.status.phase}')" = "Pending" \
+            || { echo "::error::deleting A removed or changed B's plan"; exit 1; }
+
+          approve_plan "$plan_b"
+          wait_for_plan_phase "$plan_b" Applied
+          assert_role_exists collision_uid_user_two
+
+          kubectl delete pgr "$collision_b" --wait=true
+          pg_query "DROP ROLE IF EXISTS collision_uid_user_one; DROP ROLE IF EXISTS collision_uid_user_two;"
+
+          # ================================================================
+          # Group H: Operator restart with pending plan
           # ================================================================
 
           echo "--- Test: Operator restart with pending plan ---"

--- a/crates/pgroles-operator/src/main.rs
+++ b/crates/pgroles-operator/src/main.rs
@@ -15,9 +15,7 @@ use kube::{Api, Client, Resource, ResourceExt};
 use tracing::info;
 
 use pgroles_operator::context::OperatorContext;
-use pgroles_operator::crd::{
-    LABEL_POLICY, PostgresPolicy, PostgresPolicyPlan, REQUESTED_RECONCILE_ANNOTATION,
-};
+use pgroles_operator::crd::{PostgresPolicy, PostgresPolicyPlan, REQUESTED_RECONCILE_ANNOTATION};
 use pgroles_operator::observability::{OperatorObservability, serve_health};
 use pgroles_operator::reconciler::{error_policy, reconcile};
 
@@ -157,29 +155,31 @@ async fn main() -> anyhow::Result<()> {
     .filter_map(|plan| async move { plan.ok() })
     .flat_map(move |plan| {
         let policy_store = plan_policy_store.clone();
-        // Look up the parent policy name from the plan's label.
-        let plan_ns = plan.namespace();
-        let parent_policy_name = plan
+        // Map the plan back to its parent by controller-owner UID.
+        //
+        // This used to compare the plan's `pgroles.io/policy` label against
+        // `metadata.name`, but that label is truncated at the 63-character label
+        // limit while a policy name may be up to 253. For any longer name the
+        // comparison never matched, so plan status changes silently stopped
+        // waking the policy reconciler. The UID is exact at any name length.
+        let parent_policy_uid = plan
             .metadata
-            .labels
-            .as_ref()
-            .and_then(|labels| labels.get(LABEL_POLICY))
-            .cloned();
+            .owner_references
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .find(|owner| owner.controller.unwrap_or(false))
+            .map(|owner| owner.uid.clone());
 
-        let refs: Vec<ObjectRef<PostgresPolicy>> =
-            if let (Some(ns), Some(policy_name)) = (plan_ns, parent_policy_name) {
-                policy_store
-                    .state()
-                    .into_iter()
-                    .filter(|policy| {
-                        policy.namespace().as_deref() == Some(ns.as_str())
-                            && policy.name_any() == policy_name
-                    })
-                    .map(|policy| ObjectRef::from_obj(policy.as_ref()))
-                    .collect()
-            } else {
-                Vec::new()
-            };
+        let refs: Vec<ObjectRef<PostgresPolicy>> = match parent_policy_uid {
+            Some(uid) if !uid.is_empty() => policy_store
+                .state()
+                .into_iter()
+                .filter(|policy| policy.metadata.uid.as_deref() == Some(uid.as_str()))
+                .map(|policy| ObjectRef::from_obj(policy.as_ref()))
+                .collect(),
+            _ => Vec::new(),
+        };
         stream::iter(refs)
     });
 

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -356,6 +356,13 @@ pub async fn create_or_update_plan(
                 // prefix can in principle collide, and this is otherwise the one
                 // mutation site the owner-UID discipline does not cover.
                 if !is_owned_by_policy(&existing, policy) {
+                    // Our SQL ConfigMap was already created, so clean it up as
+                    // the other error arm does. The orphan reaper would collect
+                    // it eventually — it carries our UID — but leaving it is a
+                    // pointless transient orphan.
+                    if let Some(configmap_name) = sql_configmap_name.as_deref() {
+                        delete_configmap_best_effort(client, &namespace, configmap_name).await;
+                    }
                     return Err(ReconcileError::PlanSqlStorage(format!(
                         "plan {plan_name} already exists and is owned by another policy"
                     )));

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -214,9 +214,13 @@ pub async fn create_or_update_plan(
 
     // 4. List existing plans for this policy.
     let selector = policy_selector(&policy_name);
-    let existing_plans = plans_api
+    // The label narrows server-side; owner UID is the exact filter.
+    let existing_plans: Vec<PostgresPolicyPlan> = plans_api
         .list(&ListParams::default().labels_from(&selector))
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|plan| is_owned_by_policy(plan, policy))
+        .collect();
 
     // 5. Check for duplicate pending plan with same hash.
     for plan in &existing_plans {
@@ -823,9 +827,12 @@ pub async fn cleanup_old_plans(
 
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
     let selector = policy_selector(&policy_name);
-    let existing_plans = plans_api
+    let existing_plans: Vec<PostgresPolicyPlan> = plans_api
         .list(&ListParams::default().labels_from(&selector))
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|plan| is_owned_by_policy(plan, policy))
+        .collect();
     let now_ts = now_epoch_secs();
 
     for plan in existing_plans
@@ -895,8 +902,9 @@ pub async fn cleanup_old_plans(
     cleanup_orphan_sql_configmaps(
         client,
         &namespace,
+        policy,
         &policy_name,
-        &existing_plans.items,
+        &existing_plans,
         now_ts,
     )
     .await?;
@@ -911,15 +919,22 @@ pub async fn cleanup_old_plans(
 async fn cleanup_orphan_sql_configmaps(
     client: &Client,
     namespace: &str,
+    policy: &PostgresPolicy,
     policy_name: &str,
     existing_plans: &[PostgresPolicyPlan],
     now_ts: i64,
 ) -> Result<(), ReconcileError> {
     let configmaps_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
     let selector = policy_selector(policy_name);
-    let configmaps = configmaps_api
+    // Filtering by owner UID here is what makes this loop safe: `existing_plans`
+    // is already restricted to this policy, so a colliding policy's ConfigMap
+    // would otherwise have an unknown plan label and be deleted as an orphan.
+    let configmaps: Vec<ConfigMap> = configmaps_api
         .list(&ListParams::default().labels_from(&selector))
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|configmap| is_owned_by_policy(configmap, policy))
+        .collect();
     let known_plan_labels: BTreeSet<String> = existing_plans
         .iter()
         .map(|plan| plan_label_value(&plan.name_any()))
@@ -1113,8 +1128,38 @@ fn sanitize_label_value(value: &str) -> String {
 }
 
 /// Label selector matching every object owned by `policy_name`.
+///
+/// This narrows server-side but is **not** an identity: the label value is
+/// truncated at 63 characters, so two policies sharing a 63-character prefix
+/// select each other's objects. Always pair it with [`is_owned_by_policy`].
 fn policy_selector(policy_name: &str) -> Selector {
     Expression::Equal(LABEL_POLICY.to_string(), sanitize_label_value(policy_name)).into()
+}
+
+/// Is `resource` owned by `policy`, by controller-owner UID?
+///
+/// The exact ownership test. The `pgroles.io/policy` label is lossy, and a
+/// truncated collision would otherwise let one policy adopt, supersede,
+/// deduplicate against, or **delete** another policy's plans and plan-SQL
+/// ConfigMaps. A UID is unique per object and per object lifetime, so this also
+/// stops a same-named replacement policy from inheriting a deleted one's
+/// objects.
+///
+/// Objects the operator did not create carry no matching owner reference and are
+/// excluded, which is the safe direction for the deletion paths.
+fn is_owned_by_policy<K: Resource>(resource: &K, policy: &PostgresPolicy) -> bool {
+    let Some(policy_uid) = policy.metadata.uid.as_deref() else {
+        // A policy with no UID cannot own anything; refuse to match rather than
+        // treat an empty UID as a wildcard.
+        return false;
+    };
+    resource
+        .meta()
+        .owner_references
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .any(|owner| owner.uid == policy_uid && owner.controller.unwrap_or(false))
 }
 
 /// Current time as Unix epoch seconds (for dedup window checks).
@@ -1252,9 +1297,12 @@ pub async fn get_current_actionable_plan(
 
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
     let selector = policy_selector(&policy_name);
-    let existing_plans = plans_api
+    let existing_plans: Vec<PostgresPolicyPlan> = plans_api
         .list(&ListParams::default().labels_from(&selector))
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|plan| is_owned_by_policy(plan, policy))
+        .collect();
 
     // Find the most recent actionable plan (Pending or Approved, by creation time).
     let mut pending_plans: Vec<PostgresPolicyPlan> = existing_plans
@@ -1287,9 +1335,12 @@ pub async fn get_plan_by_phase(
 
     let plans_api: Api<PostgresPolicyPlan> = Api::namespaced(client.clone(), &namespace);
     let selector = policy_selector(&policy_name);
-    let existing_plans = plans_api
+    let existing_plans: Vec<PostgresPolicyPlan> = plans_api
         .list(&ListParams::default().labels_from(&selector))
-        .await?;
+        .await?
+        .into_iter()
+        .filter(|plan| is_owned_by_policy(plan, policy))
+        .collect();
 
     let mut matching_plans: Vec<PostgresPolicyPlan> = existing_plans
         .into_iter()
@@ -1445,6 +1496,134 @@ mod tests {
     use base64::Engine as _;
     use flate2::read::GzDecoder;
     use std::io::Read;
+
+    /// A minimal spec — the ownership tests only care about metadata.
+    fn test_policy_spec() -> crate::crd::PostgresPolicySpec {
+        crate::crd::PostgresPolicySpec {
+            connection: crate::crd::ConnectionSpec {
+                secret_ref: Some(crate::crd::SecretReference {
+                    name: "db-credentials".to_string(),
+                }),
+                secret_key: Some("DATABASE_URL".to_string()),
+                params: None,
+            },
+            interval: "5m".to_string(),
+            suspend: false,
+            mode: crate::crd::PolicyMode::Apply,
+            reconciliation_mode: CrdReconciliationMode::default(),
+            default_owner: None,
+            profiles: Default::default(),
+            schemas: Vec::new(),
+            roles: Vec::new(),
+            grants: Vec::new(),
+            default_privileges: Vec::new(),
+            memberships: Vec::new(),
+            retirements: Vec::new(),
+            approval: None,
+        }
+    }
+
+    /// A policy with a known UID, for the ownership tests.
+    fn policy_with_uid(name: &str, uid: &str) -> PostgresPolicy {
+        let mut policy = PostgresPolicy::new(name, test_policy_spec());
+        policy.metadata.namespace = Some("default".to_string());
+        policy.metadata.uid = Some(uid.to_string());
+        policy
+    }
+
+    /// Two policies whose names share a 63-character prefix collapse to the same
+    /// `pgroles.io/policy` label, so the selector cannot tell them apart. Only
+    /// the owner UID can — and the selector result drives deletion.
+    #[test]
+    fn colliding_label_values_are_separated_by_owner_uid() {
+        let prefix = "a".repeat(63);
+        let first = policy_with_uid(&format!("{prefix}-one"), "uid-one");
+        let second = policy_with_uid(&format!("{prefix}-two"), "uid-two");
+
+        // Precondition: the labels really are indistinguishable.
+        assert_eq!(
+            sanitize_label_value(&first.name_any()),
+            sanitize_label_value(&second.name_any()),
+        );
+
+        let mut plan = test_plan("plan-1", PlanPhase::Pending, None);
+        plan.metadata.owner_references = Some(vec![build_owner_reference(&first)]);
+
+        assert!(is_owned_by_policy(&plan, &first));
+        assert!(
+            !is_owned_by_policy(&plan, &second),
+            "a colliding policy must not claim another policy's plan"
+        );
+    }
+
+    #[test]
+    fn ownership_requires_a_controller_owner_reference() {
+        let policy = policy_with_uid("orders", "uid-orders");
+
+        // No owner references at all — e.g. an object the operator did not create.
+        let plan = test_plan("plan-1", PlanPhase::Pending, None);
+        assert!(!is_owned_by_policy(&plan, &policy));
+
+        // Right UID, but not marked as the controller.
+        let mut non_controller = build_owner_reference(&policy);
+        non_controller.controller = Some(false);
+        let mut plan = test_plan("plan-2", PlanPhase::Pending, None);
+        plan.metadata.owner_references = Some(vec![non_controller]);
+        assert!(!is_owned_by_policy(&plan, &policy));
+    }
+
+    /// An empty UID must never act as a wildcard: a policy the API server has
+    /// not assigned a UID to owns nothing.
+    #[test]
+    fn policy_without_uid_owns_nothing() {
+        let mut policy = PostgresPolicy::new("orders", test_policy_spec());
+        policy.metadata.namespace = Some("default".to_string());
+        policy.metadata.uid = None;
+
+        let mut plan = test_plan("plan-1", PlanPhase::Pending, None);
+        // `build_owner_reference` defaults a missing UID to the empty string.
+        plan.metadata.owner_references = Some(vec![build_owner_reference(&policy)]);
+
+        assert!(!is_owned_by_policy(&plan, &policy));
+    }
+
+    /// A replacement policy with the same name is a different object, so it must
+    /// not inherit the deleted one's plans.
+    #[test]
+    fn recreated_policy_does_not_inherit_previous_plans() {
+        let original = policy_with_uid("orders", "uid-original");
+        let recreated = policy_with_uid("orders", "uid-recreated");
+
+        let mut plan = test_plan("plan-1", PlanPhase::Applied, None);
+        plan.metadata.owner_references = Some(vec![build_owner_reference(&original)]);
+
+        assert!(is_owned_by_policy(&plan, &original));
+        assert!(!is_owned_by_policy(&plan, &recreated));
+    }
+
+    /// The ConfigMap cleanup path filters the same way, which is what stops it
+    /// deleting a colliding policy's SQL ConfigMap as an "orphan".
+    #[test]
+    fn configmap_ownership_uses_owner_uid() {
+        let prefix = "a".repeat(63);
+        let mine = policy_with_uid(&format!("{prefix}-one"), "uid-one");
+        let theirs = policy_with_uid(&format!("{prefix}-two"), "uid-two");
+
+        let configmap = ConfigMap {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some("plan-1-sql".to_string()),
+                owner_references: Some(vec![build_owner_reference(&theirs)]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(is_owned_by_policy(&configmap, &theirs));
+        assert!(
+            !is_owned_by_policy(&configmap, &mine),
+            "cleanup must not treat another policy's ConfigMap as its own"
+        );
+    }
 
     fn test_plan(
         name: &str,

--- a/crates/pgroles-operator/src/plan.rs
+++ b/crates/pgroles-operator/src/plan.rs
@@ -350,6 +350,16 @@ pub async fn create_or_update_plan(
             Ok(plan) => (plan, true),
             Err(kube::Error::Api(api_err)) if api_err.code == 409 => {
                 let existing = plans_api.get(&plan_name).await?;
+                // The name collided, which is normally our own retry. Confirm
+                // ownership before patching anyone's status: plan names embed a
+                // 215-byte-truncated policy prefix, so two policies sharing that
+                // prefix can in principle collide, and this is otherwise the one
+                // mutation site the owner-UID discipline does not cover.
+                if !is_owned_by_policy(&existing, policy) {
+                    return Err(ReconcileError::PlanSqlStorage(format!(
+                        "plan {plan_name} already exists and is owned by another policy"
+                    )));
+                }
                 if !should_patch_existing_plan_status(&existing) {
                     return Ok(PlanCreationResult::Deduplicated(existing.name_any()));
                 }

--- a/docs/src/pages/docs/limitations.md
+++ b/docs/src/pages/docs/limitations.md
@@ -38,3 +38,12 @@ PostgreSQL does not expose password hashes for comparison, so pgroles cannot det
 ## Databases themselves
 
 pgroles grants privileges *on* a database (`CONNECT`, `CREATE`, `TEMPORARY`) but does not create, drop, or rename databases, and does not manage database ownership (`ALTER DATABASE ... OWNER TO`). Provision the database itself with your migration tooling or infrastructure-as-code before pointing a pgroles manifest at it.
+
+## Policy names are limited to 63 characters
+
+A `PostgresPolicy` name must be at most 63 characters. The operator links a policy to its plans and plan-SQL ConfigMaps through the `pgroles.io/policy` label, and Kubernetes caps label values at 63 characters, so a longer name could not be represented without truncation. The CRD rejects longer names at admission with an explanatory message.
+
+Two upgrade notes if you are adopting this on an existing installation:
+
+- **A policy created before this limit existed keeps its long name until you next write to it.** On Kubernetes 1.30 and later, [validation ratcheting](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting) allows updates that leave the offending name unchanged, so such a policy keeps reconciling normally. On Kubernetes versions before 1.30 there is no ratcheting, and *every* write is rejected — including the operator's own status updates — so the policy stops making progress with no status change to explain it. Rename affected policies (delete and recreate under a shorter name) before upgrading on those clusters. `kubectl get pgr -A -o name | awk 'length($0) > 67'` lists candidates.
+- **Deleting a policy with `--cascade=orphan` now leaks its plans.** Plans and plan-SQL ConfigMaps are matched to their policy by owner UID rather than by name, so orphaned objects are no longer re-adopted by a recreated policy of the same name. Because `--cascade=orphan` also strips the owner references that garbage collection relies on, those objects persist until deleted by hand. Prefer the default cascading delete; if you have already orphaned some, delete leftover `pgplan` objects and `*-sql` ConfigMaps explicitly.

--- a/docs/src/pages/docs/limitations.md
+++ b/docs/src/pages/docs/limitations.md
@@ -39,11 +39,6 @@ PostgreSQL does not expose password hashes for comparison, so pgroles cannot det
 
 pgroles grants privileges *on* a database (`CONNECT`, `CREATE`, `TEMPORARY`) but does not create, drop, or rename databases, and does not manage database ownership (`ALTER DATABASE ... OWNER TO`). Provision the database itself with your migration tooling or infrastructure-as-code before pointing a pgroles manifest at it.
 
-## Policy names are limited to 63 characters
+## Orphaning policies leaks plan resources
 
-A `PostgresPolicy` name must be at most 63 characters. The operator links a policy to its plans and plan-SQL ConfigMaps through the `pgroles.io/policy` label, and Kubernetes caps label values at 63 characters, so a longer name could not be represented without truncation. The CRD rejects longer names at admission with an explanatory message.
-
-Two upgrade notes if you are adopting this on an existing installation:
-
-- **A policy created before this limit existed keeps its long name until you next write to it.** On Kubernetes 1.30 and later, [validation ratcheting](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-ratcheting) allows updates that leave the offending name unchanged, so such a policy keeps reconciling normally. On Kubernetes versions before 1.30 there is no ratcheting, and *every* write is rejected — including the operator's own status updates — so the policy stops making progress with no status change to explain it. Rename affected policies (delete and recreate under a shorter name) before upgrading on those clusters. `kubectl get pgr -A -o name | awk 'length($0) > 67'` lists candidates.
-- **Deleting a policy with `--cascade=orphan` now leaks its plans.** Plans and plan-SQL ConfigMaps are matched to their policy by owner UID rather than by name, so orphaned objects are no longer re-adopted by a recreated policy of the same name. Because `--cascade=orphan` also strips the owner references that garbage collection relies on, those objects persist until deleted by hand. Prefer the default cascading delete; if you have already orphaned some, delete leftover `pgplan` objects and `*-sql` ConfigMaps explicitly.
+Deleting a policy with `--cascade=orphan` leaves its plans and plan-SQL ConfigMaps behind. These resources are matched to their policy by owner UID rather than by name, so they are not re-adopted by a recreated policy of the same name. Because orphan deletion strips the owner references that garbage collection relies on, they persist until deleted by hand. Prefer the default cascading delete; if you have already orphaned some, delete leftover `pgplan` objects and `*-sql` ConfigMaps explicitly.


### PR DESCRIPTION
**Stack 4 of 4** — base is #149. Review #147, #148 and #149 first.

Closes the collision CodeRabbit raised on #147. #148 prevents *new* lossy labels; this makes the lookups exact regardless, so a policy that predates the CEL rule is covered too.

## The bug

`pgroles.io/policy` was the only link between a policy and its plans and plan-SQL ConfigMaps, but the label truncates at 63 characters while a policy name may be 253. Two policies sharing a 63-character prefix selected each other's objects, and that selector drives **deletion** in `cleanup_old_plans` and `cleanup_orphan_sql_configmaps`, plus approval and deduplication in the three lookup paths. `LabelValue::sanitize`'s own docs in #147 warn against this exact use.

## Why UID, and why all six paths at once

Filter by controller-owner UID. The label still narrows server-side so the list stays cheap; the UID decides. Owner references are already written on both plans and ConfigMaps, so **no new label and no migration**.

The ConfigMap path is why this can't be plan-side only, and it's worth being explicit because the obvious partial fix is actively harmful: `is_orphan_sql_configmap` deletes a ConfigMap whose plan label is absent from the known set. Exact-filtering the plans while leaving the ConfigMap list truncation-matched would make a colliding policy's ConfigMap look *more* like an orphan — converting a lookup bug into a deletion bug. So I did not take the suggested `spec.policy_ref.name` post-filter as written.

UID over `spec.policyRef.name` for a second reason: it's exact per object *lifetime*. A replacement policy with the same name is a different object and must not inherit the deleted one's plans. An absent UID owns nothing rather than acting as a wildcard.

Same fix in `main.rs`, which compared the truncated label against `metadata.name` and so silently never matched above 63 characters — plan status changes could not wake the policy reconciler at all. That also retires the last use of the label as an identity.

## Tests

Five unit tests, each pinning a way this could regress: a genuine 63-character-prefix collision (asserting first that the two labels really are identical, so the test can't rot into vacuity), a missing owner reference, a non-controller owner reference, an empty UID not acting as a wildcard, a recreated same-name policy, and the ConfigMap path specifically.

## Verification

`cargo fmt --check`, `clippy -D warnings`, full workspace (274 operator unit tests), and `check-crd-drift.sh` all pass.

https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4


---
_Generated by [Claude Code](https://claude.ai/code/session_01KKdSeCxJEVcrH4MPLgwUG4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy and plan ownership tracking, preventing resources from being incorrectly adopted, deduplicated, superseded, or deleted.
  * Added validation for stacked pull request metadata, including position and size ranges.
  * Prevented name collisions between policies from affecting plan creation and reconciliation.

* **Documentation**
  * Documented the 63-character policy name limit and upgrade behavior for existing longer names.
  * Documented orphaning behavior for plans and SQL ConfigMaps when policies are deleted with cascade orphaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->