### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-02
+
 ### Fixed
 
 - **Policy names longer than 63 characters no longer break plan creation, plan lookup, and cleanup.** Kubernetes caps label values at 63 bytes but allows resource names up to 253, and the operator conflated the two rules. Three defects followed. A sanitized label value truncated at the cap could land on a separator and be rejected outright, so the plan ConfigMap failed to write and the policy stopped reconciling (thanks @aarons-afk for the report and original fix, #146). `generate_plan_name` cut the policy-name prefix without trimming an exposed `.` or `-`, so the appended `-plan-…` began a new DNS label with a separator and the API server refused the plan. And `is_valid_secret_name` rejected `generatePassword.secretName` values beginning with a digit, which Kubernetes permits. All three rules now come from one module (`k8s_names`) that restates them once, with property tests over a hostile alphabet — including multi-byte UTF-8, which an earlier fix attempt silently truncated mid-character.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-cli"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-core"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hmac 0.13.0",
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-inspect"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "pgroles-core",
  "sqlx",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "pgroles-operator"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.8"
+version = "0.8.0"
 edition = "2024"
 authors = ["Brian Thorne <brian@thorne.link>"]
 license = "MIT"
@@ -55,8 +55,8 @@ k8s-openapi = { version = "0.27.1", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Internal crates
-pgroles-core = { path = "crates/pgroles-core", version = "0.7.8" }
-pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.7.8" }
+pgroles-core = { path = "crates/pgroles-core", version = "0.8.0" }
+pgroles-inspect = { path = "crates/pgroles-inspect", version = "0.8.0" }
 
 [profile.release]
 strip = "symbols"

--- a/charts/pgroles-operator/Chart.yaml
+++ b/charts/pgroles-operator/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   Define roles, memberships, grants, and default privileges in YAML
   and let the operator converge your database to the desired state.
 type: application
-version: 0.7.8
-appVersion: "0.7.8"
+version: 0.8.0
+appVersion: "0.8.0"
 icon: https://raw.githubusercontent.com/hardbyte/pgroles/main/docs/public/logo.svg
 sources:
   - https://github.com/hardbyte/pgroles
@@ -16,10 +16,14 @@ maintainers:
     url: https://hardbyte.nz
 annotations:
   artifacthub.io/changes: |
+    - kind: fixed
+      description: 'Policy names longer than 63 characters no longer break plan creation, lookup, or cleanup. Kubernetes caps label values at 63 bytes but allows resource names up to 253, and the operator conflated the two rules.'
+    - kind: fixed
+      description: 'Plans and plan-SQL ConfigMaps are matched to their policy by controller-owner UID rather than by a truncated label, so two policies sharing a 63-byte name prefix no longer cross-approve or cross-delete each other resources.'
     - kind: added
-      description: 'PostgresPolicy roles can now be marked external: true so provider-managed roles remain referenceable without pgroles creating, altering, dropping, password-managing, or pruning memberships granted from them.'
+      description: 'Roles and profiles can declare config defaults managed with ALTER ROLE ... SET, including {schema} and {profile} placeholder substitution on profiles[].config.'
     - kind: added
-      description: 'PostgresPolicy resources now support immediate reconcile requests through the reconcile.pgroles.io/requestedAt annotation; pgroles reconcile can set it and optionally wait for status.lastHandledReconcileAt.'
+      description: 'diff and apply now detect and warn about column-level grants in managed schemas, closing a silent audit hole in authoritative mode.'
   artifacthub.io/category: database
   artifacthub.io/operator: "true"
   artifacthub.io/prerelease: "false"


### PR DESCRIPTION
Prepares the 0.8.0 release.

## Version bumps

| File | Change |
|---|---|
| `Cargo.toml` | workspace `version`, and the `pgroles-core` / `pgroles-inspect` path-dependency pins |
| `Cargo.lock` | the four workspace crates |
| `charts/pgroles-operator/Chart.yaml` | `version` and `appVersion` |

## Release notes

`CHANGELOG.md`: `## [Unreleased]` becomes `## [0.8.0] - 2026-08-02`, with an empty `Unreleased` retained.

`artifacthub.io/changes` in `Chart.yaml` is refreshed — it still listed the 0.7.8 entries.

## Release contents

**Fixed**

- Policy names longer than 63 characters no longer break plan creation, lookup, or cleanup (#146, #152).
- Plans and plan-SQL ConfigMaps are matched by controller-owner UID rather than a truncated label (#152).
- Schema owner transfers no longer strip the incoming owner's privileges (#140).

**Added**

- Role and profile `config` defaults, managed with `ALTER ROLE ... SET` (#132).
- Column-level grant detection in `diff` and `apply`.
- Executor-privileges and limitations documentation pages.

**Dependencies**

- OpenTelemetry 0.31 → 0.32, plus `cmov`, `quinn-proto`, `next` and `js-yaml` (#154).

## Upgrade note

Deleting a policy with `--cascade=orphan` strips the owner references that plan re-adoption and garbage collection now depend on. Orphaned plans and plan-SQL ConfigMaps persist until deleted by hand. See [limitations](https://hardbyte.github.io/pgroles/docs/limitations/).

## Verification

`cargo build --workspace`, `cargo fmt --check`, `clippy --all-targets -D warnings`, and `check-crd-drift.sh` pass at the new version, rebased onto `ea46390`.